### PR TITLE
[US-10] 環境構築・Supabase セットアップ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "interview-feedback-app",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.8.0",
+        "@supabase/supabase-js": "^2.98.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -3477,6 +3479,112 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
+      "integrity": "sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
+      "integrity": "sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.98.0.tgz",
+      "integrity": "sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.98.0.tgz",
+      "integrity": "sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz",
+      "integrity": "sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.76.1"
+      }
+    },
+    "node_modules/@supabase/ssr/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.98.0.tgz",
+      "integrity": "sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
+      "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@supabase/auth-js": "2.98.0",
+        "@supabase/functions-js": "2.98.0",
+        "@supabase/postgrest-js": "2.98.0",
+        "@supabase/realtime-js": "2.98.0",
+        "@supabase/storage-js": "2.98.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3874,12 +3982,16 @@
       "version": "20.19.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -3916,6 +4028,15 @@
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -7285,6 +7406,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -11257,7 +11387,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11649,6 +11778,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.8.0",
+    "@supabase/supabase-js": "^2.98.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,9 @@
+import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "@/types/supabase";
+
+export function createClient() {
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,0 +1,31 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,28 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { Database } from "@/types/supabase";
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // Server Component からの呼び出し時は無視
+          }
+        },
+      },
+    }
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,110 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      interviews: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          audio_url: string | null;
+          duration_seconds: number | null;
+          status: "uploaded" | "transcribing" | "analyzing" | "completed" | "error";
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          title: string;
+          audio_url?: string | null;
+          duration_seconds?: number | null;
+          status?: "uploaded" | "transcribing" | "analyzing" | "completed" | "error";
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          audio_url?: string | null;
+          duration_seconds?: number | null;
+          status?: "uploaded" | "transcribing" | "analyzing" | "completed" | "error";
+          created_at?: string;
+        };
+      };
+      transcripts: {
+        Row: {
+          id: string;
+          interview_id: string;
+          speaker: "interviewer" | "interviewee";
+          content: string;
+          start_time: number;
+          end_time: number;
+        };
+        Insert: {
+          id?: string;
+          interview_id: string;
+          speaker: "interviewer" | "interviewee";
+          content: string;
+          start_time: number;
+          end_time: number;
+        };
+        Update: {
+          id?: string;
+          interview_id?: string;
+          speaker?: "interviewer" | "interviewee";
+          content?: string;
+          start_time?: number;
+          end_time?: number;
+        };
+      };
+      feedbacks: {
+        Row: {
+          id: string;
+          interview_id: string;
+          overall_score: number;
+          summary: string;
+          filler_words: Json;
+          suggestions: Json;
+          strengths: Json;
+          improvements: Json;
+        };
+        Insert: {
+          id?: string;
+          interview_id: string;
+          overall_score: number;
+          summary: string;
+          filler_words?: Json;
+          suggestions?: Json;
+          strengths?: Json;
+          improvements?: Json;
+        };
+        Update: {
+          id?: string;
+          interview_id?: string;
+          overall_score?: number;
+          summary?: string;
+          filler_words?: Json;
+          suggestions?: Json;
+          strengths?: Json;
+          improvements?: Json;
+        };
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+  };
+}

--- a/supabase/migrations/00001_initial_schema.sql
+++ b/supabase/migrations/00001_initial_schema.sql
@@ -1,0 +1,147 @@
+-- interviews テーブル
+create table public.interviews (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade not null,
+  title text not null,
+  audio_url text,
+  duration_seconds integer,
+  status text not null default 'uploaded'
+    check (status in ('uploaded', 'transcribing', 'analyzing', 'completed', 'error')),
+  created_at timestamptz not null default now()
+);
+
+-- transcripts テーブル
+create table public.transcripts (
+  id uuid primary key default gen_random_uuid(),
+  interview_id uuid references public.interviews(id) on delete cascade not null,
+  speaker text not null check (speaker in ('interviewer', 'interviewee')),
+  content text not null,
+  start_time float not null,
+  end_time float not null
+);
+
+-- feedbacks テーブル
+create table public.feedbacks (
+  id uuid primary key default gen_random_uuid(),
+  interview_id uuid references public.interviews(id) on delete cascade not null,
+  overall_score integer not null check (overall_score between 1 and 100),
+  summary text not null,
+  filler_words jsonb not null default '[]'::jsonb,
+  suggestions jsonb not null default '[]'::jsonb,
+  strengths jsonb not null default '[]'::jsonb,
+  improvements jsonb not null default '[]'::jsonb
+);
+
+-- RLS 有効化
+alter table public.interviews enable row level security;
+alter table public.transcripts enable row level security;
+alter table public.feedbacks enable row level security;
+
+-- interviews: ユーザーは自分のデータのみ CRUD 可能
+create policy "Users can select own interviews"
+  on public.interviews for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own interviews"
+  on public.interviews for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own interviews"
+  on public.interviews for update
+  using (auth.uid() = user_id);
+
+create policy "Users can delete own interviews"
+  on public.interviews for delete
+  using (auth.uid() = user_id);
+
+-- transcripts: interview の所有者のみアクセス可能
+create policy "Users can select own transcripts"
+  on public.transcripts for select
+  using (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can insert own transcripts"
+  on public.transcripts for insert
+  with check (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can update own transcripts"
+  on public.transcripts for update
+  using (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can delete own transcripts"
+  on public.transcripts for delete
+  using (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+-- feedbacks: interview の所有者のみアクセス可能
+create policy "Users can select own feedbacks"
+  on public.feedbacks for select
+  using (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can insert own feedbacks"
+  on public.feedbacks for insert
+  with check (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can update own feedbacks"
+  on public.feedbacks for update
+  using (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can delete own feedbacks"
+  on public.feedbacks for delete
+  using (
+    interview_id in (
+      select id from public.interviews where user_id = auth.uid()
+    )
+  );
+
+-- Storage: interviews バケット作成
+insert into storage.buckets (id, name, public)
+values ('interviews', 'interviews', false);
+
+-- Storage RLS: ユーザーは自分のフォルダのみアクセス可能
+create policy "Users can upload own audio"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'interviews'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+create policy "Users can read own audio"
+  on storage.objects for select
+  using (
+    bucket_id = 'interviews'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+create policy "Users can delete own audio"
+  on storage.objects for delete
+  using (
+    bucket_id = 'interviews'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );


### PR DESCRIPTION
## Summary
- Supabase クライアント設定（ブラウザ / サーバー / ミドルウェア）
- DB スキーマ SQL マイグレーション（interviews, transcripts, feedbacks テーブル）
- 全テーブルに RLS ポリシー設定（ユーザーは自分のデータのみ CRUD 可能）
- Supabase Storage に interviews バケット作成
- TypeScript 型定義（Database 型）

## Test plan
- [ ] `npm run build` 成功確認済み
- [ ] SQL を Supabase SQL Editor で実行してテーブル作成を確認
- [ ] RLS ポリシーが正しく動作することを確認

closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)