### PR TITLE
[US-3/4] ブラウザ内録音・音声アップロード

### DIFF
--- a/src/app/interview/new/page.tsx
+++ b/src/app/interview/new/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Mic, Pause, Play, Square, Upload, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useAudioRecorder } from "@/hooks/use-audio-recorder";
+import { createClient } from "@/lib/supabase/client";
+import type { Database } from "@/types/supabase";
+
+type InterviewInsert = Database["public"]["Tables"]["interviews"]["Insert"];
+
+const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = (seconds % 60).toString().padStart(2, "0");
+  return `${m}:${s}`;
+}
+
+export default function NewInterviewPage() {
+  const [title, setTitle] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const router = useRouter();
+  const { state, elapsedTime, audioBlob, error, start, pause, resume, stop } =
+    useAudioRecorder();
+
+  const handleUpload = async () => {
+    if (!audioBlob) return;
+
+    if (audioBlob.size > MAX_FILE_SIZE) {
+      setUploadError("ファイルサイズが100MBを超えています");
+      return;
+    }
+
+    setUploading(true);
+    setUploadError(null);
+
+    try {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("認証エラー");
+
+      const interviewId = crypto.randomUUID();
+      const filePath = `${user.id}/${interviewId}.webm`;
+
+      const { error: storageError } = await supabase.storage
+        .from("interviews")
+        .upload(filePath, audioBlob, { contentType: "audio/webm" });
+
+      if (storageError) throw storageError;
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from("interviews").getPublicUrl(filePath);
+
+      const insertData: InterviewInsert = {
+        id: interviewId,
+        user_id: user.id,
+        title: title || `面接 ${new Date().toLocaleDateString("ja-JP")}`,
+        audio_url: publicUrl,
+        duration_seconds: elapsedTime,
+        status: "uploaded",
+      };
+
+      const { error: dbError } = await supabase
+        .from("interviews")
+        .insert(insertData as never);
+
+      if (dbError) throw dbError;
+
+      router.push("/dashboard");
+      router.refresh();
+    } catch {
+      setUploadError("アップロードに失敗しました。もう一度お試しください。");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">新しい面接セッション</h1>
+
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="title">セッションタイトル（任意）</Label>
+          <Input
+            id="title"
+            placeholder="例: 模擬面接 - 自己紹介の練習"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">録音</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col items-center gap-6">
+            {/* 経過時間 */}
+            <div className="text-4xl font-mono tabular-nums">
+              {formatTime(elapsedTime)}
+            </div>
+
+            {/* エラー表示 */}
+            {(error || uploadError) && (
+              <div className="w-full rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {error || uploadError}
+              </div>
+            )}
+
+            {/* 録音コントロール */}
+            <div className="flex items-center gap-4">
+              {state === "idle" && (
+                <Button size="lg" onClick={start}>
+                  <Mic className="mr-2 h-5 w-5" />
+                  録音開始
+                </Button>
+              )}
+
+              {state === "recording" && (
+                <>
+                  <Button size="lg" variant="outline" onClick={pause}>
+                    <Pause className="mr-2 h-5 w-5" />
+                    一時停止
+                  </Button>
+                  <Button size="lg" variant="destructive" onClick={stop}>
+                    <Square className="mr-2 h-5 w-5" />
+                    停止
+                  </Button>
+                </>
+              )}
+
+              {state === "paused" && (
+                <>
+                  <Button size="lg" onClick={resume}>
+                    <Play className="mr-2 h-5 w-5" />
+                    再開
+                  </Button>
+                  <Button size="lg" variant="destructive" onClick={stop}>
+                    <Square className="mr-2 h-5 w-5" />
+                    停止
+                  </Button>
+                </>
+              )}
+
+              {state === "stopped" && audioBlob && (
+                <Button
+                  size="lg"
+                  onClick={handleUpload}
+                  disabled={uploading}
+                >
+                  {uploading ? (
+                    <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                  ) : (
+                    <Upload className="mr-2 h-5 w-5" />
+                  )}
+                  {uploading ? "アップロード中..." : "アップロード"}
+                </Button>
+              )}
+            </div>
+
+            {/* 録音状態インジケーター */}
+            {state === "recording" && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-red-500" />
+                録音中
+              </div>
+            )}
+            {state === "paused" && (
+              <div className="text-sm text-muted-foreground">一時停止中</div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-audio-recorder.ts
+++ b/src/hooks/use-audio-recorder.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+
+export type RecorderState = "idle" | "recording" | "paused" | "stopped";
+
+interface UseAudioRecorderReturn {
+  state: RecorderState;
+  elapsedTime: number;
+  audioBlob: Blob | null;
+  error: string | null;
+  start: () => Promise<void>;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+}
+
+export function useAudioRecorder(): UseAudioRecorderReturn {
+  const [state, setState] = useState<RecorderState>("idle");
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    clearTimer();
+    timerRef.current = setInterval(() => {
+      setElapsedTime((prev) => prev + 1);
+    }, 1000);
+  }, [clearTimer]);
+
+  const start = useCallback(async () => {
+    setError(null);
+    setAudioBlob(null);
+    setElapsedTime(0);
+    chunksRef.current = [];
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const mediaRecorder = new MediaRecorder(stream, {
+        mimeType: "audio/webm;codecs=opus",
+      });
+
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          chunksRef.current.push(e.data);
+        }
+      };
+
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        setAudioBlob(blob);
+        setState("stopped");
+        clearTimer();
+        stream.getTracks().forEach((track) => track.stop());
+      };
+
+      mediaRecorderRef.current = mediaRecorder;
+      mediaRecorder.start(1000);
+      setState("recording");
+      startTimer();
+    } catch {
+      setError("マイクにアクセスできません。ブラウザの設定を確認してください。");
+      setState("idle");
+    }
+  }, [startTimer, clearTimer]);
+
+  const pause = useCallback(() => {
+    if (mediaRecorderRef.current?.state === "recording") {
+      mediaRecorderRef.current.pause();
+      setState("paused");
+      clearTimer();
+    }
+  }, [clearTimer]);
+
+  const resume = useCallback(() => {
+    if (mediaRecorderRef.current?.state === "paused") {
+      mediaRecorderRef.current.resume();
+      setState("recording");
+      startTimer();
+    }
+  }, [startTimer]);
+
+  const stop = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state !== "inactive"
+    ) {
+      mediaRecorderRef.current.stop();
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearTimer();
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+    };
+  }, [clearTimer]);
+
+  return { state, elapsedTime, audioBlob, error, start, pause, resume, stop };
+}


### PR DESCRIPTION
## Summary
- useAudioRecorder フック（MediaRecorder API ベース、WebM/Opus 形式）
- 録音 UI（開始/一時停止/再開/停止ボタン、経過時間表示）
- Supabase Storage への音声アップロード
- interviews テーブルへのレコード作成（status: uploaded）
- 100MB ファイルサイズ制限

## Test plan
- [ ] マイクアクセス許可ダイアログが表示される
- [ ] 録音開始/一時停止/再開/停止が動作する
- [ ] 経過時間がリアルタイム表示される
- [ ] アップロード後に interviews テーブルにレコードが作成される

closes #3
closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)