### PR TITLE
feat: Issue #31 404/エラーページ

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, Home, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Application error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 px-4 py-24">
+      <div className="rounded-full bg-destructive/10 p-6">
+        <AlertTriangle className="h-16 w-16 text-destructive" />
+      </div>
+
+      <div className="text-center">
+        <h1 className="text-4xl font-bold tracking-tight">
+          エラーが発生しました
+        </h1>
+        <p className="mt-4 text-muted-foreground">
+          申し訳ございません。予期しないエラーが発生しました。
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          時間をおいて再度お試しいただくか、ホームに戻ってください。
+        </p>
+      </div>
+
+      <div className="flex gap-4">
+        <Button size="lg" onClick={reset}>
+          <RotateCcw className="mr-2 h-4 w-4" />
+          もう一度試す
+        </Button>
+        <Button size="lg" variant="outline" asChild>
+          <Link href="/">
+            <Home className="mr-2 h-4 w-4" />
+            ホームに戻る
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { FileQuestion, Home, LayoutDashboard } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 px-4 py-24">
+      <div className="rounded-full bg-muted p-6">
+        <FileQuestion className="h-16 w-16 text-muted-foreground" />
+      </div>
+
+      <div className="text-center">
+        <h1 className="text-6xl font-bold tracking-tight">404</h1>
+        <p className="mt-4 text-xl text-muted-foreground">
+          ページが見つかりません
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          お探しのページは移動または削除された可能性があります。
+        </p>
+      </div>
+
+      <div className="flex gap-4">
+        <Button size="lg" asChild>
+          <Link href="/">
+            <Home className="mr-2 h-4 w-4" />
+            ホームに戻る
+          </Link>
+        </Button>
+        <Button size="lg" variant="outline" asChild>
+          <Link href="/dashboard">
+            <LayoutDashboard className="mr-2 h-4 w-4" />
+            ダッシュボード
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #31

## 概要
カスタム404ページとエラーページを作成しました。

## 変更内容
- `src/app/not-found.tsx` - 404ページ（FileQuestionアイコン、ホーム/ダッシュボードへの導線）
- `src/app/error.tsx` - エラーページ（AlertTriangleアイコン、リトライ/ホームへの導線）

## 受け入れ基準
- [x] 404ページがブランドデザインに沿っている
- [x] ホームへ戻るボタンがある
- [x] 500エラー時のフォールバック UI がある