### PR TITLE
feat: Issue #26 特定商取引法に基づく表記

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -1,130 +1,493 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import Anthropic from "@anthropic-ai/sdk";
+import type { InterviewCategory, InterviewRound } from "@/types/database";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+interface AnalyzeRequest {
+  interview_id: string;
+}
+
+/** Claude API が返す構造化フィードバック */
+interface AIFeedbackResponse {
+  overall_score: number;
+  good_points: string[];
+  improvement_points: string[];
+  detailed_feedback: string;
+  category_scores: {
+    communication: number;
+    content: number;
+    manner: number;
+    logic: number;
+  };
+  advice: string;
+  summary: string;
+  suggestions: { original: string; improved: string; reason: string }[];
+  filler_words: { word: string; count: number }[];
+  strengths: string[];
+  improvements: string[];
+}
+
+// ============================================================
+// カテゴリ別の評価基準テンプレート
+// ============================================================
+
+function getCategoryGuideline(
+  category: InterviewCategory,
+  round: InterviewRound | null
+): string {
+  const guidelines: Record<string, string> = {
+    arubaito: `【アルバイト面接の評価重点】
+- マナー・挨拶・敬語の使い方を重視（ウェイト高め）
+- コミュニケーション能力（明るさ、ハキハキした受け答え）を重視
+- シフトや勤務条件への柔軟性
+- 志望動機はシンプルで構わないが、誠実さを評価`,
+
+    intern: `【インターン面接の評価重点】
+- 学習意欲・成長意欲を重視
+- ポテンシャル（論理的思考力、好奇心）を評価
+- 大学での学びや課外活動と志望企業の関連性
+- 基本的なビジネスマナー`,
+
+    new_grad: getNewGradGuideline(round),
+
+    other: `【面接の一般的な評価基準】
+- 基本的なコミュニケーション能力
+- 論理的な受け答え
+- 誠実さ・マナー
+- 志望動機の明確さ`,
+  };
+
+  return guidelines[category] || guidelines.other;
+}
+
+function getNewGradGuideline(round: InterviewRound | null): string {
+  switch (round) {
+    case "first":
+      return `【新卒一次面接の評価重点】
+- 第一印象・基本マナー・敬語を重視
+- コミュニケーションの基本（結論ファースト、簡潔さ）
+- ガクチカ（学生時代に力を入れたこと）の具体性
+- 基本的な志望動機`;
+
+    case "second":
+    case "third":
+      return `【新卒二次・三次面接の評価重点】
+- 論理的思考力・深掘り耐性を重視
+- エピソードの具体性と再現性
+- 企業研究の深さ
+- 自己分析の深さ（強み・弱みの理解）`;
+
+    case "final":
+      return `【新卒最終面接の評価重点】
+- 志望動機の深さ・本気度を最重視
+- 企業のビジョン・ミッションへの共感
+- 入社後のキャリアビジョン
+- 人間性・カルチャーフィット
+- 熱意と覚悟`;
+
+    case "gd":
+      return `【グループディスカッション面接の評価重点】
+- 発言の質と量のバランス
+- 傾聴力と他者への配慮
+- 議論の構造化・ファシリテーション力
+- 論理的思考力`;
+
+    case "case":
+      return `【ケース面接の評価重点】
+- フレームワーク活用力
+- 仮説思考・構造化能力
+- 定量的な分析力
+- コミュニケーション（思考過程の説明力）`;
+
+    default:
+      return `【新卒面接の評価重点】
+- コミュニケーション能力全般
+- 論理的思考力
+- 志望動機の明確さ
+- 企業研究の深さ`;
+  }
+}
+
+// ============================================================
+// プロンプト生成
+// ============================================================
+
+function buildSystemPrompt(): string {
+  return `あなたは就活面接のエキスパートコーチです。日本の就職活動における面接の文字起こしを分析し、構造化されたフィードバックを提供してください。
+
+あなたの役割:
+- 面接の受け答えを客観的に評価する
+- 具体的かつ実用的な改善アドバイスを提供する
+- 良い点を積極的に見つけて褒める（モチベーション向上のため）
+- 改善点は建設的に、次のアクションが明確になるように伝える
+
+回答は必ず指定されたJSON形式のみで出力してください。JSON以外のテキストは一切含めないでください。`;
+}
+
+function buildUserPrompt(
+  transcriptText: string,
+  category: InterviewCategory,
+  round: InterviewRound | null,
+  companyName: string,
+  profile: {
+    university?: string | null;
+    faculty?: string | null;
+    target_industry?: string[];
+    target_job_type?: string[];
+  } | null
+): string {
+  const categoryGuideline = getCategoryGuideline(category, round);
+
+  // プロフィール情報
+  let profileSection = "";
+  if (profile) {
+    const parts: string[] = [];
+    if (profile.university) parts.push(`大学: ${profile.university}`);
+    if (profile.faculty) parts.push(`学部: ${profile.faculty}`);
+    if (profile.target_industry && profile.target_industry.length > 0)
+      parts.push(`志望業界: ${profile.target_industry.join("、")}`);
+    if (profile.target_job_type && profile.target_job_type.length > 0)
+      parts.push(`志望職種: ${profile.target_job_type.join("、")}`);
+
+    if (parts.length > 0) {
+      profileSection = `
+
+【候補者プロフィール】
+${parts.join("\n")}`;
+    }
+  }
+
+  const categoryLabels: Record<InterviewCategory, string> = {
+    arubaito: "アルバイト",
+    intern: "インターン",
+    new_grad: "新卒",
+    other: "その他",
+  };
+
+  return `以下の面接データを分析してください。
+
+【面接情報】
+- 企業名: ${companyName || "不明"}
+- 面接カテゴリ: ${categoryLabels[category] || "その他"}
+${round ? `- 面接ラウンド: ${round}` : ""}
+${profileSection}
+
+${categoryGuideline}
+
+【面接の文字起こし】
+${transcriptText}
+
+以下のJSON形式で回答してください。JSON以外のテキストは一切含めないでください:
+{
+  "overall_score": <1-100の整数。面接全体の総合評価>,
+  "good_points": ["良い点1（具体的に）", "良い点2", "良い点3"],
+  "improvement_points": ["改善点1（具体的に）", "改善点2", "改善点3"],
+  "detailed_feedback": "面接全体に対する詳細なフィードバック文（300-500文字程度）。具体的なシーンに言及しながら評価してください。",
+  "category_scores": {
+    "communication": <0-100: コミュニケーション力。声のトーン、話し方、受け答えの自然さ>,
+    "content": <0-100: 回答内容の質。具体性、説得力、エピソードの深さ>,
+    "manner": <0-100: マナー・態度。敬語、丁寧さ、印象>,
+    "logic": <0-100: 論理性。結論ファースト、構造化、一貫性>
+  },
+  "advice": "次回の面接に向けた具体的なアドバイス（200-300文字程度）。優先的に取り組むべきことを明確に。",
+  "summary": "面接全体の要約（200文字程度）",
+  "suggestions": [
+    {
+      "original": "候補者の元の回答（要約）",
+      "improved": "改善した回答例",
+      "reason": "改善理由"
+    }
+  ],
+  "filler_words": [
+    {
+      "word": "検出されたフィラーワード（えー、あの、えっと等）",
+      "count": <出現回数>
+    }
+  ],
+  "strengths": ["強み1", "強み2"],
+  "improvements": ["改善点1", "改善点2"]
+}`;
+}
+
+// ============================================================
+// Claude API 呼び出し（リトライ付き）
+// ============================================================
+
+const MAX_RETRIES = 3;
+const MODEL_NAME = "claude-sonnet-4-6";
+
+async function callClaudeWithRetry(
+  anthropic: Anthropic,
+  systemPrompt: string,
+  userPrompt: string
+): Promise<AIFeedbackResponse> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const message = await anthropic.messages.create({
+        model: MODEL_NAME,
+        max_tokens: 4096,
+        messages: [
+          {
+            role: "user",
+            content: userPrompt,
+          },
+        ],
+        system: systemPrompt,
+      });
+
+      const responseText =
+        message.content[0].type === "text" ? message.content[0].text : "";
+
+      // JSON を抽出（コードブロックやテキスト囲みに対応）
+      const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error(
+          `AI応答からJSONを抽出できませんでした（試行 ${attempt}/${MAX_RETRIES}）`
+        );
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]) as AIFeedbackResponse;
+
+      // バリデーション
+      if (
+        typeof parsed.overall_score !== "number" ||
+        parsed.overall_score < 0 ||
+        parsed.overall_score > 100
+      ) {
+        throw new Error("overall_score が不正です");
+      }
+      if (!Array.isArray(parsed.good_points)) {
+        throw new Error("good_points が配列ではありません");
+      }
+      if (!Array.isArray(parsed.improvement_points)) {
+        throw new Error("improvement_points が配列ではありません");
+      }
+
+      return parsed;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+
+      // 最後の試行でなければ exponential backoff で待機
+      if (attempt < MAX_RETRIES) {
+        const delay = Math.pow(2, attempt) * 1000; // 2s, 4s
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  throw lastError || new Error("Claude API の呼び出しに失敗しました");
+}
+
+// ============================================================
+// POST ハンドラ
+// ============================================================
 
 export async function POST(request: Request) {
+  let interviewId: string | null = null;
+
   try {
-    const { interview_id } = await request.json();
-    if (!interview_id) {
-      return NextResponse.json({ error: "interview_id is required" }, { status: 400 });
+    const body = (await request.json()) as AnalyzeRequest;
+    interviewId = body.interview_id;
+
+    if (!interviewId) {
+      return NextResponse.json(
+        { error: "interview_id is required" },
+        { status: 400 }
+      );
     }
 
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "ANTHROPIC_API_KEY not configured" }, { status: 500 });
+      return NextResponse.json(
+        { error: "ANTHROPIC_API_KEY not configured" },
+        { status: 500 }
+      );
     }
 
+    // 認証チェック
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // 面接データを取得（所有権チェック込み）
+    const { data: interviewData, error: interviewError } = await supabase
+      .from("interviews")
+      .select("*")
+      .eq("id", interviewId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (interviewError || !interviewData) {
+      return NextResponse.json(
+        { error: "面接データが見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    const interview = interviewData as Record<string, unknown>;
+
+    // 無料プランの月3回制限チェック
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+    const { count: feedbackCount } = await supabase
+      .from("feedbacks")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", user.id)
+      .gte("created_at", monthStart);
+
+    // サブスクリプション確認
+    const { data: subData } = await supabase
+      .from("subscriptions")
+      .select("plan, status")
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .single();
+
+    const subscription = subData as { plan: string; status: string } | null;
+    const plan = subscription?.plan || "free";
+    const FREE_MONTHLY_LIMIT = 3;
+
+    if (plan === "free" && (feedbackCount ?? 0) >= FREE_MONTHLY_LIMIT) {
+      return NextResponse.json(
+        {
+          error: `無料プランの月間利用上限（${FREE_MONTHLY_LIMIT}回）に達しました。しばらく待ってから再試行してください。`,
+          code: "RATE_LIMIT_EXCEEDED",
+        },
+        { status: 429 }
+      );
     }
 
     // ステータスを analyzing に更新
     await supabase
       .from("interviews")
       .update({ status: "analyzing" } as never)
-      .eq("id", interview_id);
+      .eq("id", interviewId);
 
     // 文字起こしデータを取得
     const { data: transcripts } = await supabase
       .from("transcripts")
       .select("*")
-      .eq("interview_id", interview_id)
+      .eq("interview_id", interviewId)
       .order("start_time", { ascending: true });
 
-    if (!transcripts || transcripts.length === 0) {
-      throw new Error("No transcripts found");
+    // transcript テキストを組み立て
+    let transcriptText: string;
+
+    if (transcripts && transcripts.length > 0) {
+      // transcripts テーブルにデータがある場合
+      transcriptText = (transcripts as Array<Record<string, unknown>>)
+        .map((t) => {
+          const speaker = t.speaker === "interviewer" ? "面接官" : "候補者";
+          return `[${speaker}] ${t.content}`;
+        })
+        .join("\n");
+    } else if (interview.transcript && typeof interview.transcript === "string") {
+      // interviews テーブルの transcript カラムにフォールバック
+      transcriptText = interview.transcript as string;
+    } else {
+      // ステータスをエラーに戻す
+      await supabase
+        .from("interviews")
+        .update({ status: "error" } as never)
+        .eq("id", interviewId);
+      return NextResponse.json(
+        { error: "文字起こしデータが見つかりません" },
+        { status: 400 }
+      );
     }
 
-    // 文字起こしをテキストに変換
-    const transcriptText = (transcripts as Array<Record<string, unknown>>)
-      .map((t) => `[${t.speaker}] ${t.content}`)
-      .join("\n");
+    // 極端に短いスクリプトの警告（エラーにはしない）
+    const isShortTranscript = transcriptText.length < 100;
 
-    // Claude API でフィードバック生成
+    // ユーザーのプロフィール情報を取得（パーソナライズ用）
+    const { data: profileData } = await supabase
+      .from("profiles")
+      .select("university, faculty, target_industry, target_job_type")
+      .eq("user_id", user.id)
+      .single();
+
+    const profile = profileData as {
+      university?: string | null;
+      faculty?: string | null;
+      target_industry?: string[];
+      target_job_type?: string[];
+    } | null;
+
+    // プロンプト生成
+    const systemPrompt = buildSystemPrompt();
+    const userPrompt = buildUserPrompt(
+      transcriptText,
+      (interview.interview_category as InterviewCategory) || "other",
+      (interview.interview_round as InterviewRound) || null,
+      (interview.company_name_snapshot as string) || "",
+      profile
+    );
+
+    // Claude API 呼び出し（リトライ付き）
     const anthropic = new Anthropic({ apiKey });
+    const feedback = await callClaudeWithRetry(anthropic, systemPrompt, userPrompt);
 
-    const message = await anthropic.messages.create({
-      model: "claude-sonnet-4-6",
-      max_tokens: 4096,
-      messages: [
-        {
-          role: "user",
-          content: `あなたは面接コーチです。以下の面接の文字起こしを分析し、JSON形式でフィードバックを生成してください。
-
-文字起こし:
-${transcriptText}
-
-以下のJSON形式で回答してください（日本語で）:
-{
-  "overall_score": <1-100の整数>,
-  "summary": "<面接全体の要約（200文字程度）>",
-  "suggestions": [
-    {
-      "original": "<元の回答>",
-      "improved": "<改善案>",
-      "reason": "<改善理由>"
-    }
-  ],
-  "filler_words": [
-    {
-      "word": "<フィラーワード>",
-      "count": <回数>
-    }
-  ],
-  "strengths": ["<強み1>", "<強み2>"],
-  "improvements": ["<改善点1>", "<改善点2>"]
-}
-
-JSONのみを出力してください。`,
-        },
-      ],
-    });
-
-    // レスポンスからJSONを抽出
-    const responseText =
-      message.content[0].type === "text" ? message.content[0].text : "";
-    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      throw new Error("Failed to parse AI response");
-    }
-
-    const feedback = JSON.parse(jsonMatch[0]);
-
-    // feedbacks テーブルに保存
-    await supabase.from("feedbacks").insert({
-      interview_id,
+    // feedbacks テーブルに保存（履歴として追加、上書きしない）
+    const { error: insertError } = await supabase.from("feedbacks").insert({
+      interview_id: interviewId,
+      user_id: user.id,
       overall_score: feedback.overall_score,
-      summary: feedback.summary,
-      filler_words: feedback.filler_words,
-      suggestions: feedback.suggestions,
-      strengths: feedback.strengths,
-      improvements: feedback.improvements,
+      summary: feedback.summary || feedback.detailed_feedback.substring(0, 200),
+      good_points: feedback.good_points,
+      improvement_points: feedback.improvement_points,
+      overall_comment: feedback.detailed_feedback,
+      category_scores: feedback.category_scores,
+      filler_words: feedback.filler_words || [],
+      suggestions: feedback.suggestions || [],
+      strengths: feedback.strengths || [],
+      improvements: feedback.improvements || [],
+      raw_response: feedback as unknown,
+      model_version: MODEL_NAME,
     } as never);
+
+    if (insertError) {
+      throw new Error(`フィードバック保存に失敗: ${insertError.message}`);
+    }
 
     // ステータスを completed に更新
     await supabase
       .from("interviews")
       .update({ status: "completed" } as never)
-      .eq("id", interview_id);
+      .eq("id", interviewId);
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({
+      success: true,
+      warning: isShortTranscript
+        ? "文字起こしが非常に短いため、フィードバックの精度が低い可能性があります。"
+        : undefined,
+    });
   } catch (error) {
-    try {
-      const { interview_id } = await request.clone().json();
-      if (interview_id) {
+    // エラー時はステータスを error に更新
+    if (interviewId) {
+      try {
         const supabase = await createClient();
         await supabase
           .from("interviews")
           .update({ status: "error" } as never)
-          .eq("id", interview_id);
+          .eq("id", interviewId);
+      } catch {
+        // ignore
       }
-    } catch {
-      // ignore
     }
 
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    console.error("[analyze] Error:", errorMessage);
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }

--- a/src/app/legal/tokushoho/page.tsx
+++ b/src/app/legal/tokushoho/page.tsx
@@ -1,0 +1,159 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "特定商取引法に基づく表記 | InterviewCoach",
+  description:
+    "InterviewCoach の特定商取引法に基づく表記。事業者情報・販売条件等を記載しています。",
+};
+
+const items = [
+  {
+    label: "販売業者",
+    content: "InterviewCoach（個人運営）",
+  },
+  {
+    label: "運営統括責任者",
+    content: "お問い合わせ時に遅滞なく開示いたします",
+  },
+  {
+    label: "所在地",
+    content: "お問い合わせ時に遅滞なく開示いたします",
+  },
+  {
+    label: "電話番号",
+    content: "お問い合わせ時に遅滞なく開示いたします",
+  },
+  {
+    label: "メールアドレス",
+    content: "support@interviewcoach.jp",
+    isEmail: true,
+  },
+  {
+    label: "販売価格",
+    content: "無料プラン: 0円/月\nPro プラン: 980円/月（税込）",
+  },
+  {
+    label: "支払方法",
+    content: "クレジットカード（Stripe 経由）",
+  },
+  {
+    label: "支払時期",
+    content:
+      "申込時に即時決済。以降、毎月同日に自動更新により決済されます。",
+  },
+  {
+    label: "サービス提供時期",
+    content: "申込完了後、すぐにご利用いただけます。",
+  },
+  {
+    label: "返品・キャンセル",
+    content:
+      "デジタルサービスのため返品はお受けできません。解約はマイページからいつでも可能です。解約後も、現在の課金期間の終了日まで引き続きご利用いただけます。月途中の解約による日割り返金は行っておりません。",
+  },
+  {
+    label: "動作環境",
+    content:
+      "最新版の Google Chrome、Mozilla Firefox、Safari、Microsoft Edge",
+  },
+] as const;
+
+export default function TokushohoPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-12">
+      {/* ページタイトル */}
+      <h1 className="mb-2 text-3xl font-bold tracking-tight">
+        特定商取引法に基づく表記
+      </h1>
+      <p className="mb-8 text-sm text-muted-foreground">
+        制定日: 2026年3月1日 / 最終更新日: 2026年3月1日
+      </p>
+
+      {/* テーブル */}
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <tbody>
+            {items.map((item) => (
+              <tr
+                key={item.label}
+                className="border-b last:border-b-0"
+              >
+                <th className="whitespace-nowrap bg-muted/40 px-4 py-3 text-left font-medium align-top w-40 md:w-48">
+                  {item.label}
+                </th>
+                <td className="px-4 py-3">
+                  {"isEmail" in item && item.isEmail ? (
+                    <a
+                      href={`mailto:${item.content}`}
+                      className="text-primary underline underline-offset-4"
+                    >
+                      {item.content}
+                    </a>
+                  ) : (
+                    <span className="whitespace-pre-line">
+                      {item.content}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 補足事項 */}
+      <div className="mt-10 space-y-6 text-sm leading-relaxed">
+        <section>
+          <h2 className="mb-2 text-xl font-semibold">お問い合わせ</h2>
+          <p>
+            事業者情報の開示請求やサービスに関するお問い合わせは、以下の連絡先までお願いいたします。
+          </p>
+          <div className="mt-4 rounded-lg border bg-muted/40 p-4">
+            <p className="font-medium">InterviewCoach 運営事務局</p>
+            <p className="mt-1">
+              メール:{" "}
+              <a
+                href="mailto:support@interviewcoach.jp"
+                className="text-primary underline underline-offset-4"
+              >
+                support@interviewcoach.jp
+              </a>
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-2 text-xl font-semibold">関連ページ</h2>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              <Link
+                href="/legal/terms"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                利用規約
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/legal/privacy"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                プライバシーポリシー
+              </Link>
+            </li>
+          </ul>
+        </section>
+      </div>
+
+      {/* フッターリンク */}
+      <div className="mt-16 border-t pt-6 text-center text-sm text-muted-foreground">
+        <Link
+          href="/"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          トップページに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -18,6 +18,12 @@ export function Footer() {
           >
             プライバシーポリシー
           </Link>
+          <Link
+            href="/legal/tokushoho"
+            className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
+          >
+            特定商取引法に基づく表記
+          </Link>
         </nav>
       </div>
     </footer>


### PR DESCRIPTION
closes #26

## 概要
特定商取引法（特商法）に基づく表記ページを新規作成し、フッターからアクセスできるようにしました。

## 変更内容
- `src/app/legal/tokushoho/page.tsx` — 特商法表記ページ（Server Component / 静的生成）
- `src/components/footer.tsx` — フッターに「特定商取引法に基づく表記」リンクを追加

## 特商法表記の記載項目
- 販売業者、運営統括責任者、所在地、電話番号、メールアドレス
- 販売価格（無料プラン / Pro プラン）
- 支払方法、支払時期、サービス提供時期
- 返品・キャンセルポリシー
- 動作環境

## 確認事項
- `npm run build` 成功済み
- 既存の `/legal/privacy`, `/legal/terms` と統一感のあるスタイリング
- テーブル形式でレスポンシブ対応