### PR TITLE
feat: Issue #19 AIフィードバック生成

### DIFF
--- a/src/app/interview/[id]/processing/page.tsx
+++ b/src/app/interview/[id]/processing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, use } from "react";
+import { useEffect, useState, useRef, use, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import {
   CheckCircle2,
@@ -39,13 +39,13 @@ const STEPS: Step[] = [
     label: "文字起こし中...",
     status: "transcribing",
     icon: <FileText className="h-5 w-5" />,
-    estimatedTime: "約1〜3分",
+    estimatedTime: "約1~3分",
   },
   {
     label: "AI分析中...",
     status: "analyzing",
     icon: <Brain className="h-5 w-5" />,
-    estimatedTime: "約1〜2分",
+    estimatedTime: "約1~2分",
   },
   {
     label: "完了",
@@ -81,12 +81,48 @@ export default function ProcessingPage({
   const [isError, setIsError] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const analyzeCalledRef = useRef(false);
 
+  // AI分析 API を呼び出す関数
+  const triggerAnalysis = useCallback(async () => {
+    if (analyzeCalledRef.current) return;
+    analyzeCalledRef.current = true;
+    setIsAnalyzing(true);
+
+    try {
+      const res = await fetch("/api/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ interview_id: id }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        if (data.code === "RATE_LIMIT_EXCEEDED") {
+          setIsError(true);
+          setErrorMessage(data.error);
+          setIsAnalyzing(false);
+          return;
+        }
+        throw new Error(data.error || "分析に失敗しました");
+      }
+    } catch (error) {
+      console.error("[processing] analyze error:", error);
+      analyzeCalledRef.current = false;
+    }
+    setIsAnalyzing(false);
+  }, [id]);
+
+  // ステータスポーリング & 分析トリガー
   useEffect(() => {
     const supabase = createClient();
     let timeoutId: ReturnType<typeof setTimeout>;
+    let cancelled = false;
 
     async function fetchStatus() {
+      if (cancelled) return;
+
       try {
         const { data, error } = await supabase
           .from("interviews")
@@ -108,7 +144,8 @@ export default function ProcessingPage({
           return;
         }
 
-        const status = (data as Record<string, unknown>).status as InterviewStatus;
+        const status = (data as Record<string, unknown>)
+          .status as InterviewStatus;
         setCurrentStatus(status);
         setIsLoading(false);
 
@@ -121,11 +158,20 @@ export default function ProcessingPage({
         }
 
         if (status === "completed") {
-          router.push(`/interview/${id}/result`);
+          setTimeout(() => {
+            router.push(`/interview/${id}/result`);
+          }, 1000);
           return;
         }
 
-        timeoutId = setTimeout(fetchStatus, POLL_INTERVAL);
+        // uploaded 状態の場合、AI分析を自動開始
+        if (status === "uploaded" && !analyzeCalledRef.current) {
+          triggerAnalysis();
+        }
+
+        if (!cancelled) {
+          timeoutId = setTimeout(fetchStatus, POLL_INTERVAL);
+        }
       } catch {
         setIsError(true);
         setErrorMessage("通信エラーが発生しました");
@@ -136,14 +182,16 @@ export default function ProcessingPage({
     fetchStatus();
 
     return () => {
+      cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [id, router]);
+  }, [id, router, triggerAnalysis]);
 
   const handleRetry = async () => {
     setIsError(false);
     setErrorMessage(null);
     setIsLoading(true);
+    analyzeCalledRef.current = false;
 
     try {
       const supabase = createClient();
@@ -169,6 +217,10 @@ export default function ProcessingPage({
   };
 
   const currentStepIndex = getStepIndex(currentStatus);
+  // isAnalyzing を参照して lint の未使用警告を防ぐ
+  const headerTitle = isAnalyzing
+    ? "AIがフィードバックを生成しています..."
+    : "面接データを処理しています";
 
   return (
     <div className="container mx-auto max-w-2xl px-4 py-8">
@@ -177,7 +229,7 @@ export default function ProcessingPage({
       <Card>
         <CardHeader>
           <CardTitle className="text-lg text-center">
-            面接データを処理しています
+            {headerTitle}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -191,10 +243,18 @@ export default function ProcessingPage({
               <p className="text-sm text-destructive text-center">
                 {errorMessage}
               </p>
-              <Button onClick={handleRetry} variant="outline">
-                <RefreshCw className="mr-2 h-4 w-4" />
-                リトライ
-              </Button>
+              <div className="flex gap-3">
+                <Button onClick={handleRetry} variant="outline">
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  リトライ
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => router.push("/dashboard")}
+                >
+                  ダッシュボードに戻る
+                </Button>
+              </div>
             </div>
           ) : (
             <div className="space-y-0">

--- a/src/app/interview/[id]/result/page.tsx
+++ b/src/app/interview/[id]/result/page.tsx
@@ -37,10 +37,13 @@ export default async function ResultPage({
 
   const transcripts = (transcriptsData ?? []) as Transcript[];
 
+  // 最新のフィードバックを取得（履歴として複数保持されるため）
   const { data: feedbackData } = await supabase
     .from("feedbacks")
     .select("*")
     .eq("interview_id", id)
+    .order("created_at", { ascending: false })
+    .limit(1)
     .single();
 
   const feedback = feedbackData as Feedback | null;

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, CheckCircle2, AlertTriangle, Lightbulb } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import type { Database } from "@/types/supabase";
 import type { Json } from "@/types/supabase";
+import type { CategoryScores } from "@/types/database";
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Transcript = Database["public"]["Tables"]["transcripts"]["Row"];
@@ -35,6 +36,10 @@ function parseJsonArray<T>(data: Json): T[] {
   return [];
 }
 
+// ============================================================
+// スコア表示コンポーネント
+// ============================================================
+
 function ScoreDisplay({ score }: { score: number }) {
   const color =
     score >= 80
@@ -43,14 +48,95 @@ function ScoreDisplay({ score }: { score: number }) {
         ? "text-yellow-600"
         : "text-red-600";
 
+  const bgColor =
+    score >= 80
+      ? "bg-green-50 dark:bg-green-950/30"
+      : score >= 60
+        ? "bg-yellow-50 dark:bg-yellow-950/30"
+        : "bg-red-50 dark:bg-red-950/30";
+
   return (
-    <div className="flex flex-col items-center gap-2">
-      <span className={`text-6xl font-bold ${color}`}>{score}</span>
+    <div className={`flex flex-col items-center gap-3 rounded-xl p-8 ${bgColor}`}>
+      <p className="text-sm font-medium text-muted-foreground">総合スコア</p>
+      <span className={`text-7xl font-bold ${color}`}>{score}</span>
       <span className="text-sm text-muted-foreground">/ 100</span>
       <Progress value={score} className="w-48" />
     </div>
   );
 }
+
+// ============================================================
+// カテゴリ別スコア表示
+// ============================================================
+
+const CATEGORY_LABELS: Record<string, string> = {
+  communication: "コミュニケーション",
+  content: "回答内容",
+  manner: "マナー",
+  logic: "論理性",
+  specificity: "具体性",
+  enthusiasm: "熱意",
+  manners: "マナー",
+  question_handling: "質問対応",
+};
+
+function CategoryScoreBar({
+  label,
+  score,
+}: {
+  label: string;
+  score: number;
+}) {
+  const color =
+    score >= 80
+      ? "bg-green-500"
+      : score >= 60
+        ? "bg-yellow-500"
+        : "bg-red-500";
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">{label}</span>
+        <span className="text-muted-foreground">{score}点</span>
+      </div>
+      <div className="h-3 w-full rounded-full bg-muted">
+        <div
+          className={`h-3 rounded-full transition-all duration-500 ${color}`}
+          style={{ width: `${score}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CategoryScoresDisplay({
+  scores,
+}: {
+  scores: CategoryScores | null;
+}) {
+  if (!scores || Object.keys(scores).length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        カテゴリ別スコアはありません
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(scores).map(([key, value]) => {
+        if (typeof value !== "number") return null;
+        const label = CATEGORY_LABELS[key] || key;
+        return <CategoryScoreBar key={key} label={label} score={value} />;
+      })}
+    </div>
+  );
+}
+
+// ============================================================
+// メインコンポーネント
+// ============================================================
 
 export function ResultContent({
   interview,
@@ -67,6 +153,12 @@ export function ResultContent({
   const fillerWords = feedback
     ? parseJsonArray<FillerWord>(feedback.filler_words)
     : [];
+  const goodPoints = feedback
+    ? parseJsonArray<string>(feedback.good_points)
+    : [];
+  const improvementPoints = feedback
+    ? parseJsonArray<string>(feedback.improvement_points)
+    : [];
   const strengths = feedback
     ? parseJsonArray<string>(feedback.strengths)
     : [];
@@ -74,34 +166,170 @@ export function ResultContent({
     ? parseJsonArray<string>(feedback.improvements)
     : [];
 
+  // good_points が空の場合は strengths にフォールバック
+  const displayGoodPoints = goodPoints.length > 0 ? goodPoints : strengths;
+  // improvement_points が空の場合は improvements にフォールバック
+  const displayImprovementPoints =
+    improvementPoints.length > 0 ? improvementPoints : improvements;
+
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8">
       <div className="mb-6 flex items-center gap-4">
         <Button variant="ghost" size="sm" asChild>
           <Link href="/dashboard">
             <ArrowLeft className="mr-2 h-4 w-4" />
-            戻る
+            ダッシュボードに戻る
           </Link>
         </Button>
         <h1 className="text-2xl font-bold">{interview.title}</h1>
       </div>
 
-      {/* スコア */}
-      {feedback && (
+      {/* フィードバック未生成の場合 */}
+      {!feedback && (
         <Card className="mb-6">
-          <CardContent className="flex flex-col items-center py-8">
-            <ScoreDisplay score={feedback.overall_score} />
+          <CardContent className="flex flex-col items-center py-12">
+            <AlertTriangle className="mb-4 h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium text-muted-foreground">
+              フィードバックはまだ生成されていません
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              処理が完了するまでお待ちください
+            </p>
+            <Button className="mt-4" asChild>
+              <Link href={`/interview/${interview.id}/processing`}>
+                処理状況を確認する
+              </Link>
+            </Button>
           </CardContent>
         </Card>
       )}
 
+      {/* スコア & カテゴリ別スコア */}
+      {feedback && (
+        <div className="mb-6 grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardContent className="flex flex-col items-center py-6">
+              <ScoreDisplay score={feedback.overall_score} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">カテゴリ別スコア</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <CategoryScoresDisplay
+                scores={feedback.category_scores as CategoryScores}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* 良い点 & 改善点 */}
+      {feedback && (
+        <div className="mb-6 grid gap-4 sm:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-green-600">
+                <CheckCircle2 className="h-5 w-5" />
+                良い点
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {displayGoodPoints.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  データがありません
+                </p>
+              ) : (
+                <ul className="space-y-3">
+                  {displayGoodPoints.map((point, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-orange-600">
+                <AlertTriangle className="h-5 w-5" />
+                改善点
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {displayImprovementPoints.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  データがありません
+                </p>
+              ) : (
+                <ul className="space-y-3">
+                  {displayImprovementPoints.map((point, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm">
+                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-orange-500" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* 詳細フィードバック & アドバイス */}
+      {feedback && feedback.overall_comment && (
+        <div className="mb-6 space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">詳細フィードバック</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="leading-relaxed whitespace-pre-wrap">
+                {feedback.overall_comment}
+              </p>
+            </CardContent>
+          </Card>
+
+          {/* アドバイスセクション - raw_response から取得 */}
+          {feedback.raw_response &&
+            typeof feedback.raw_response === "object" &&
+            !Array.isArray(feedback.raw_response) &&
+            feedback.raw_response !== null &&
+            "advice" in feedback.raw_response &&
+            typeof (feedback.raw_response as Record<string, unknown>).advice ===
+              "string" && (
+              <Card className="border-blue-200 bg-blue-50/50 dark:border-blue-900 dark:bg-blue-950/20">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-blue-600">
+                    <Lightbulb className="h-5 w-5" />
+                    次回へのアドバイス
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="leading-relaxed whitespace-pre-wrap">
+                    {
+                      (feedback.raw_response as Record<string, unknown>)
+                        .advice as string
+                    }
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+        </div>
+      )}
+
+      {/* タブ: 要約・文字起こし・改善提案・フィラー */}
       <Tabs defaultValue="summary" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-5">
+        <TabsList className="grid w-full grid-cols-4">
           <TabsTrigger value="summary">要約</TabsTrigger>
           <TabsTrigger value="transcript">文字起こし</TabsTrigger>
           <TabsTrigger value="suggestions">改善提案</TabsTrigger>
           <TabsTrigger value="filler">フィラー</TabsTrigger>
-          <TabsTrigger value="points">評価</TabsTrigger>
         </TabsList>
 
         {/* 要約 */}
@@ -112,7 +340,9 @@ export function ResultContent({
             </CardHeader>
             <CardContent>
               {feedback ? (
-                <p className="leading-relaxed">{feedback.summary}</p>
+                <p className="leading-relaxed whitespace-pre-wrap">
+                  {feedback.summary}
+                </p>
               ) : (
                 <p className="text-muted-foreground">
                   フィードバックはまだ生成されていません
@@ -236,43 +466,17 @@ export function ResultContent({
             </CardContent>
           </Card>
         </TabsContent>
-
-        {/* 強み・改善点 */}
-        <TabsContent value="points">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-green-600">強み</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-2">
-                  {strengths.map((s, i) => (
-                    <li key={i} className="flex items-start gap-2 text-sm">
-                      <span className="mt-0.5 text-green-600">+</span>
-                      {s}
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-orange-600">改善点</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-2">
-                  {improvements.map((imp, i) => (
-                    <li key={i} className="flex items-start gap-2 text-sm">
-                      <span className="mt-0.5 text-orange-600">-</span>
-                      {imp}
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          </div>
-        </TabsContent>
       </Tabs>
+
+      {/* ダッシュボードへのリンク */}
+      <div className="mt-8 text-center">
+        <Button variant="outline" asChild>
+          <Link href="/dashboard">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            ダッシュボードに戻る
+          </Link>
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
closes #19

AIフィードバック生成機能（Claude API統合）を実装しました。プロダクトのコアバリューとなる最重要機能です。

## 変更内容

### a) AI分析 API Route (`src/app/api/analyze/route.ts`)
- 面接カテゴリ（アルバイト/インターン/新卒等）に応じた評価基準の動的調整
- 新卒面接はラウンド別（一次~最終, GD, ケース）で評価ウェイトを変更
- ユーザープロフィール（志望業界・大学等）を含めたパーソナライズドプロンプト
- 構造化JSON出力（overall_score, good_points, improvement_points, category_scores, detailed_feedback, advice等）
- Claude API 失敗時のリトライ（最大3回、exponential backoff）
- 無料プランの月3回制限チェック
- feedbacks テーブルへの履歴保存（上書きではなく追加）
- model_version の記録

### b) 処理中ページ (`src/app/interview/[id]/processing/page.tsx`)
- uploaded 状態検知時に自動で `/api/analyze` を呼び出し
- レート制限到達時のエラーメッセージ表示
- ダッシュボードに戻るボタン追加
- 完了時の遅延リダイレクト（アニメーション表示用）

### c) 結果表示ページ (`src/app/interview/[id]/result/result-content.tsx`)
- 総合スコア表示（数値 + プログレスバー + 色分け）
- カテゴリ別スコア（バー表示: communication, content, manner, logic）
- 良い点リスト（緑色チェックマーク）
- 改善点リスト（オレンジ警告マーク）
- 詳細フィードバック文表示
- 次回へのアドバイスセクション（青色カード）
- ダッシュボードに戻るリンク
- フィードバック未生成時のフォールバック UI

## テスト計画
- [ ] 面接データ登録後、processing ページで AI 分析が自動開始されることを確認
- [ ] フィードバック結果が result ページに正しく表示されることを確認
- [ ] カテゴリ別スコアがバー表示されることを確認
- [ ] 良い点・改善点がアイコン付きで色分け表示されることを確認
- [ ] エラー時のリトライが正常に動作することを確認
- [ ] `npm run build` 成功を確認済み