### PR TITLE
feat: Issue #21 面接履歴一覧・詳細

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,13 +1,25 @@
 import Link from "next/link";
-import { Plus } from "lucide-react";
+import { Plus, ClipboardList } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import type { Database } from "@/types/supabase";
+import type { Database, InterviewCategory } from "@/types/database";
+import { InterviewCard } from "@/components/interview-card";
+import { InterviewFilter, type SortOption } from "@/components/interview-filter";
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
+type Feedback = Database["public"]["Tables"]["feedbacks"]["Row"];
 
-export default async function DashboardPage() {
+/** 面接 + 最新フィードバックの結合型 */
+type InterviewWithScore = Interview & {
+  overallScore: number | null;
+};
+
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -17,54 +29,146 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
-  const { data } = await supabase
-    .from("interviews")
-    .select("*")
-    .order("created_at", { ascending: false });
+  // --- URL パラメータ取得 ---
+  const params = await searchParams;
+  const categoryParam = (params.category as string) || "all";
+  const sortParam = (params.sort as string) || "date_desc";
 
-  const interviews = (data ?? []) as Interview[];
+  const currentCategory = ["arubaito", "intern", "new_grad", "other", "all"].includes(
+    categoryParam
+  )
+    ? (categoryParam as InterviewCategory | "all")
+    : "all";
+
+  const currentSort = ["date_desc", "date_asc", "score_desc", "score_asc"].includes(
+    sortParam
+  )
+    ? (sortParam as SortOption)
+    : "date_desc";
+
+  // --- データ取得 ---
+  let interviewQuery = supabase.from("interviews").select("*");
+
+  if (currentCategory !== "all") {
+    interviewQuery = interviewQuery.eq("interview_category", currentCategory);
+  }
+
+  // DB レベルでのソート（日付順の場合）
+  if (currentSort === "date_desc" || currentSort === "score_desc" || currentSort === "score_asc") {
+    interviewQuery = interviewQuery.order("interview_date", {
+      ascending: false,
+      nullsFirst: false,
+    });
+  } else {
+    interviewQuery = interviewQuery.order("interview_date", {
+      ascending: true,
+      nullsFirst: false,
+    });
+  }
+
+  const { data: interviewsData } = await interviewQuery;
+  const interviews = (interviewsData ?? []) as Interview[];
+
+  // フィードバック取得（全面接分を一括取得）
+  const interviewIds = interviews.map((i) => i.id);
+
+  let feedbacks: Feedback[] = [];
+  if (interviewIds.length > 0) {
+    const { data: feedbacksData } = await supabase
+      .from("feedbacks")
+      .select("*")
+      .in("interview_id", interviewIds);
+    feedbacks = (feedbacksData ?? []) as Feedback[];
+  }
+
+  // 各面接の最新フィードバックのスコアをマッピング
+  const scoreMap = new Map<string, number>();
+  for (const fb of feedbacks) {
+    const existing = scoreMap.get(fb.interview_id);
+    if (existing === undefined || fb.overall_score > existing) {
+      scoreMap.set(fb.interview_id, fb.overall_score);
+    }
+  }
+
+  const interviewsWithScore: InterviewWithScore[] = interviews.map((iv) => ({
+    ...iv,
+    overallScore: scoreMap.get(iv.id) ?? null,
+  }));
+
+  // スコア順ソート（アプリレベル）
+  if (currentSort === "score_desc") {
+    interviewsWithScore.sort((a, b) => {
+      if (a.overallScore === null && b.overallScore === null) return 0;
+      if (a.overallScore === null) return 1;
+      if (b.overallScore === null) return -1;
+      return b.overallScore - a.overallScore;
+    });
+  } else if (currentSort === "score_asc") {
+    interviewsWithScore.sort((a, b) => {
+      if (a.overallScore === null && b.overallScore === null) return 0;
+      if (a.overallScore === null) return 1;
+      if (b.overallScore === null) return -1;
+      return a.overallScore - b.overallScore;
+    });
+  }
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {/* ヘッダー */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">ダッシュボード</h1>
+        <h1 className="text-2xl font-bold">面接履歴</h1>
         <Button asChild>
           <Link href="/interview/new">
             <Plus className="mr-2 h-4 w-4" />
-            新しい面接を始める
+            新規面接を記録
           </Link>
         </Button>
       </div>
 
-      <div className="mt-8">
-        {interviews.length === 0 ? (
+      {/* フィルタ・ソート */}
+      <div className="mt-6">
+        <InterviewFilter
+          currentCategory={currentCategory}
+          currentSort={currentSort}
+          totalCount={interviewsWithScore.length}
+        />
+      </div>
+
+      {/* 一覧 */}
+      <div className="mt-6">
+        {interviewsWithScore.length === 0 ? (
           <div className="rounded-lg border border-dashed p-12 text-center">
-            <p className="text-muted-foreground">
-              まだ面接セッションがありません
+            <ClipboardList className="mx-auto h-12 w-12 text-muted-foreground/50" />
+            <h2 className="mt-4 text-lg font-semibold">
+              {currentCategory !== "all"
+                ? "条件に一致する面接がありません"
+                : "最初の面接を記録しましょう"}
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {currentCategory !== "all"
+                ? "フィルタ条件を変更するか、新しい面接を記録してください。"
+                : "面接を登録して最初のフィードバックを受けましょう。"}
             </p>
-            <Button className="mt-4" asChild>
+            <Button className="mt-6" asChild>
               <Link href="/interview/new">
                 <Plus className="mr-2 h-4 w-4" />
-                新しい面接を始める
+                新規面接を記録
               </Link>
             </Button>
           </div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {interviews.map((interview) => (
-              <Link
+            {interviewsWithScore.map((interview) => (
+              <InterviewCard
                 key={interview.id}
-                href={`/interview/${interview.id}`}
-                className="rounded-lg border p-4 transition-colors hover:bg-accent"
-              >
-                <h3 className="font-semibold">{interview.title}</h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {new Date(interview.created_at).toLocaleDateString("ja-JP")}
-                </p>
-                <span className="mt-2 inline-block rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium">
-                  {interview.status}
-                </span>
-              </Link>
+                id={interview.id}
+                companyName={interview.company_name_snapshot}
+                category={interview.interview_category}
+                round={interview.interview_round}
+                interviewDate={interview.interview_date}
+                overallScore={interview.overallScore}
+                status={interview.status}
+              />
             ))}
           </div>
         )}

--- a/src/components/interview-card.tsx
+++ b/src/components/interview-card.tsx
@@ -1,0 +1,188 @@
+import Link from "next/link";
+import { Calendar, Building2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import type {
+  InterviewCategory,
+  InterviewRound,
+  InterviewStatus,
+} from "@/types/database";
+
+// ============================================================
+// カテゴリ表示設定
+// ============================================================
+
+const CATEGORY_CONFIG: Record<
+  InterviewCategory,
+  { label: string; className: string }
+> = {
+  arubaito: {
+    label: "アルバイト",
+    className: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  },
+  intern: {
+    label: "インターン",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  },
+  new_grad: {
+    label: "新卒",
+    className:
+      "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+  },
+  other: {
+    label: "その他",
+    className: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+  },
+};
+
+const ROUND_LABELS: Record<InterviewRound, string> = {
+  first: "一次面接",
+  second: "二次面接",
+  third: "三次面接",
+  final: "最終面接",
+  gd: "GD",
+  case: "ケース",
+  other: "その他",
+};
+
+const STATUS_CONFIG: Record<
+  InterviewStatus,
+  { label: string; className: string }
+> = {
+  uploaded: {
+    label: "アップロード済",
+    className: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  },
+  transcribing: {
+    label: "文字起こし中",
+    className: "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+  },
+  analyzing: {
+    label: "分析中",
+    className: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200",
+  },
+  completed: {
+    label: "完了",
+    className: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  },
+  error: {
+    label: "エラー",
+    className: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  },
+};
+
+// ============================================================
+// スコアの色
+// ============================================================
+
+function getScoreColor(score: number): string {
+  if (score >= 80) return "text-green-600 dark:text-green-400";
+  if (score >= 60) return "text-yellow-600 dark:text-yellow-400";
+  return "text-red-600 dark:text-red-400";
+}
+
+// ============================================================
+// Props
+// ============================================================
+
+export interface InterviewCardProps {
+  id: string;
+  companyName: string;
+  category: InterviewCategory;
+  round: InterviewRound | null;
+  interviewDate: string | null;
+  overallScore: number | null;
+  status: InterviewStatus;
+}
+
+// ============================================================
+// Component
+// ============================================================
+
+export function InterviewCard({
+  id,
+  companyName,
+  category,
+  round,
+  interviewDate,
+  overallScore,
+  status,
+}: InterviewCardProps) {
+  const catConfig = CATEGORY_CONFIG[category];
+  const statusConfig = STATUS_CONFIG[status];
+
+  return (
+    <Link
+      href={`/interview/${id}/result`}
+      className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+    >
+      <Card className="transition-shadow duration-200 group-hover:shadow-md h-full">
+        <CardHeader className="pb-2">
+          {/* 企業名 */}
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">{companyName || "企業名なし"}</span>
+          </CardTitle>
+
+          {/* バッジ群 */}
+          <div className="flex flex-wrap items-center gap-1.5 mt-1">
+            <Badge variant="outline" className={catConfig.className}>
+              {catConfig.label}
+            </Badge>
+            {category === "new_grad" && round && (
+              <Badge variant="secondary">{ROUND_LABELS[round]}</Badge>
+            )}
+            <Badge variant="outline" className={statusConfig.className}>
+              {statusConfig.label}
+            </Badge>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-3">
+          {/* 面接日 */}
+          {interviewDate && (
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Calendar className="h-3.5 w-3.5" />
+              <time dateTime={interviewDate}>
+                {new Date(interviewDate).toLocaleDateString("ja-JP", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+            </div>
+          )}
+
+          {/* 総合スコア */}
+          {overallScore !== null ? (
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">
+                  総合スコア
+                </span>
+                <span className={`text-sm font-bold ${getScoreColor(overallScore)}`}>
+                  {overallScore}
+                  <span className="text-xs font-normal text-muted-foreground">
+                    /100
+                  </span>
+                </span>
+              </div>
+              <Progress value={overallScore} className="h-1.5" />
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              スコア未算出
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/interview-filter.tsx
+++ b/src/components/interview-filter.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import type { InterviewCategory } from "@/types/database";
+
+/** フィルタで使用するカテゴリ定義 */
+const CATEGORIES: { value: InterviewCategory | "all"; label: string }[] = [
+  { value: "all", label: "全て" },
+  { value: "arubaito", label: "アルバイト" },
+  { value: "intern", label: "インターン" },
+  { value: "new_grad", label: "新卒" },
+  { value: "other", label: "その他" },
+];
+
+/** ソートオプション */
+const SORT_OPTIONS = [
+  { value: "date_desc", label: "新しい順" },
+  { value: "date_asc", label: "古い順" },
+  { value: "score_desc", label: "スコア高い順" },
+  { value: "score_asc", label: "スコア低い順" },
+] as const;
+
+export type SortOption = (typeof SORT_OPTIONS)[number]["value"];
+
+interface InterviewFilterProps {
+  currentCategory: InterviewCategory | "all";
+  currentSort: SortOption;
+  totalCount: number;
+}
+
+export function InterviewFilter({
+  currentCategory,
+  currentSort,
+  totalCount,
+}: InterviewFilterProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const createQueryString = useCallback(
+    (params: Record<string, string>) => {
+      const newParams = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(params)) {
+        if (value === "all" || value === "date_desc") {
+          newParams.delete(key);
+        } else {
+          newParams.set(key, value);
+        }
+      }
+      return newParams.toString();
+    },
+    [searchParams]
+  );
+
+  const handleCategoryChange = (category: InterviewCategory | "all") => {
+    const qs = createQueryString({ category });
+    router.push(qs ? `/dashboard?${qs}` : "/dashboard");
+  };
+
+  const handleSortChange = (sort: SortOption) => {
+    const qs = createQueryString({ sort });
+    router.push(qs ? `/dashboard?${qs}` : "/dashboard");
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* カテゴリフィルタ */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium text-muted-foreground mr-1">
+          カテゴリ:
+        </span>
+        {CATEGORIES.map((cat) => (
+          <Button
+            key={cat.value}
+            variant={currentCategory === cat.value ? "default" : "outline"}
+            size="sm"
+            onClick={() => handleCategoryChange(cat.value)}
+          >
+            {cat.label}
+          </Button>
+        ))}
+      </div>
+
+      {/* ソート・件数 */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm text-muted-foreground">
+          {totalCount}件の面接履歴
+        </p>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground">
+            並び替え:
+          </span>
+          {SORT_OPTIONS.map((opt) => (
+            <Button
+              key={opt.value}
+              variant={currentSort === opt.value ? "secondary" : "ghost"}
+              size="xs"
+              onClick={() => handleSortChange(opt.value)}
+            >
+              {opt.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #21

## 概要
ダッシュボードページを面接履歴一覧に刷新し、カテゴリフィルタ・ソート機能を実装。

## 変更内容
- `src/app/dashboard/page.tsx`: Supabase から interviews + feedbacks をJOIN取得し、カード形式で一覧表示。カテゴリフィルタ（全て/アルバイト/インターン/新卒/その他）、ソート（日付順/スコア順）、空状態UIを実装
- `src/components/interview-card.tsx`: 面接カードコンポーネント（企業名、カテゴリバッジ色分け、面接日、総合スコア+プログレスバー、ラウンド表示、ステータスバッジ）
- `src/components/interview-filter.tsx`: Client Component。カテゴリフィルタボタングループ + ソートボタン。URLパラメータで状態管理