### PR TITLE
fix: QA review - security and performance fixes

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -488,6 +488,10 @@ export async function POST(request: Request) {
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     console.error("[analyze] Error:", errorMessage);
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
+    // 内部エラーの詳細をクライアントに露出しない
+    return NextResponse.json(
+      { error: "分析処理中にエラーが発生しました。しばらくしてから再度お試しください。" },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -37,11 +37,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // interviews レコードを取得
+    // interviews レコードを取得（所有権チェック込み）
     const { data: interview, error: fetchError } = await supabase
       .from("interviews")
       .select("*")
       .eq("id", interview_id)
+      .eq("user_id", user.id)
       .single();
 
     if (fetchError || !interview) {
@@ -76,8 +77,8 @@ export async function POST(request: Request) {
     // ポーリングで完了を待つ
     const result = await pollTranscript(transcriptData.id, apiKey);
 
-    // utterances を transcripts テーブルに保存
-    if (result.utterances) {
+    // utterances を transcripts テーブルに一括保存（N+1 回避）
+    if (result.utterances && result.utterances.length > 0) {
       const transcripts = result.utterances.map(
         (u: { speaker: string; text: string; start: number; end: number }, index: number) => ({
           interview_id,
@@ -88,8 +89,12 @@ export async function POST(request: Request) {
         })
       );
 
-      for (const t of transcripts) {
-        await supabase.from("transcripts").insert(t as never);
+      const { error: insertError } = await supabase
+        .from("transcripts")
+        .insert(transcripts as never[]);
+
+      if (insertError) {
+        throw new Error(`文字起こしデータの保存に失敗しました: ${insertError.message}`);
       }
     }
 

--- a/src/app/interview/[id]/result/page.tsx
+++ b/src/app/interview/[id]/result/page.tsx
@@ -24,6 +24,7 @@ export default async function ResultPage({
     .from("interviews")
     .select("*")
     .eq("id", id)
+    .eq("user_id", user.id)
     .single();
 
   const interview = interviewData as Interview | null;

--- a/src/app/interview/new/page.tsx
+++ b/src/app/interview/new/page.tsx
@@ -117,10 +117,12 @@ export default function NewInterviewPage() {
 
     try {
       const supabase = createClient();
+      // ワイルドカード文字をエスケープして ilike インジェクションを防止
+      const escaped = query.replace(/[%_\\]/g, "\\$&");
       const { data } = await supabase
         .from("companies")
         .select("name")
-        .ilike("name", `%${query}%`)
+        .ilike("name", `%${escaped}%`)
         .limit(5);
 
       const companies = data as { name: string }[] | null;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -5,9 +5,18 @@ import type { Database } from "@/types/supabase";
 export async function createClient() {
   const cookieStore = await cookies();
 
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set"
+    );
+  }
+
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseAnonKey,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## Summary
- **Critical**: `transcribe/route.ts` に `user_id` による所有権チェックを追加（IDOR脆弱性修正）
- **Critical**: `transcribe/route.ts` の N+1 クエリをバルクインサートに変更
- **High**: `result/page.tsx` に `user_id` による所有権チェックを追加（IDOR脆弱性修正）
- **High**: `new/page.tsx` の ilike クエリでワイルドカード文字をエスケープ（インジェクション防止）
- **High**: `analyze/route.ts` のエラーレスポンスから内部エラー詳細を隠蔽
- **High**: `server.ts` の環境変数に非nullアサーション (`!`) ではなく明示的バリデーションを追加

## Test plan
- [ ] transcribe API に他ユーザーの interview_id を渡して 404 が返ることを確認
- [ ] result ページで他ユーザーの interview ID にアクセスしてリダイレクトされることを確認
- [ ] 企業名サジェストで `%` や `_` を含む文字列を入力して正常動作することを確認
- [ ] analyze API でエラー発生時に内部エラー詳細が返らないことを確認
- [ ] 環境変数未設定時に明確なエラーメッセージが表示されることを確認
- [ ] `npm run build` が成功することを確認（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)