### PR TITLE
fix: #47 QA Review Medium/Low priority findings

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -376,6 +376,7 @@ export async function POST(request: Request) {
     }
 
     // ステータスを analyzing に更新
+    // as never: Supabase 生成型が未定義のため型アサーションが必要。supabase gen types 実行後に除去可能。
     await supabase
       .from("interviews")
       .update({ status: "analyzing" } as never)
@@ -404,6 +405,7 @@ export async function POST(request: Request) {
       transcriptText = interview.transcript as string;
     } else {
       // ステータスをエラーに戻す
+      // as never: Supabase 生成型が未定義のため型アサーションが必要。supabase gen types 実行後に除去可能。
       await supabase
         .from("interviews")
         .update({ status: "error" } as never)
@@ -446,6 +448,7 @@ export async function POST(request: Request) {
     const feedback = await callClaudeWithRetry(anthropic, systemPrompt, userPrompt);
 
     // feedbacks テーブルに保存（履歴として追加、上書きしない）
+    // as never: Supabase 生成型が未定義のため型アサーションが必要。supabase gen types 実行後に除去可能。
     const { error: insertError } = await supabase.from("feedbacks").insert({
       interview_id: interviewId,
       user_id: user.id,
@@ -468,6 +471,7 @@ export async function POST(request: Request) {
     }
 
     // ステータスを completed に更新
+    // as never: Supabase 生成型が未定義のため型アサーションが必要。supabase gen types 実行後に除去可能。
     await supabase
       .from("interviews")
       .update({ status: "completed" } as never)
@@ -484,6 +488,7 @@ export async function POST(request: Request) {
     if (interviewId) {
       try {
         const supabase = await createClient();
+        // as never: Supabase 生成型が未定義のため型アサーションが必要。supabase gen types 実行後に除去可能。
         await supabase
           .from("interviews")
           .update({ status: "error" } as never)

--- a/src/app/dashboard/growth/page.tsx
+++ b/src/app/dashboard/growth/page.tsx
@@ -6,14 +6,7 @@ import { StatsCard } from "@/components/stats-card";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { CategoryScores } from "@/types/database";
 
-// カテゴリスコアの日本語ラベル
-const CATEGORY_LABELS: Record<string, string> = {
-  logic: "論理性",
-  specificity: "具体性",
-  enthusiasm: "熱意",
-  manners: "マナー",
-  question_handling: "質問対応",
-};
+import { CATEGORY_LABELS } from "@/lib/constants";
 
 // 面接カテゴリの日本語ラベル
 const INTERVIEW_CATEGORY_LABELS: Record<string, string> = {
@@ -57,10 +50,13 @@ export default async function GrowthPage() {
   const interviewIds = interviewList.map((i) => i.id);
 
   // フィードバックを一括取得
-  const { data: feedbacks } = await supabase
-    .from("feedbacks")
-    .select("interview_id, overall_score, category_scores, created_at")
-    .in("interview_id", interviewIds.length > 0 ? interviewIds : ["__none__"]);
+  // 面接IDが0件の場合はクエリをスキップし、空配列として扱う
+  const { data: feedbacks } = interviewIds.length > 0
+    ? await supabase
+        .from("feedbacks")
+        .select("interview_id, overall_score, category_scores, created_at")
+        .in("interview_id", interviewIds)
+    : { data: null };
 
   const feedbackList = (feedbacks ?? []) as {
     interview_id: string;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -76,7 +76,7 @@ export default async function DashboardPage({
   if (interviewIds.length > 0) {
     const { data: feedbacksData } = await supabase
       .from("feedbacks")
-      .select("*")
+      .select("interview_id, overall_score")
       .in("interview_id", interviewIds);
     feedbacks = (feedbacksData ?? []) as Feedback[];
   }

--- a/src/app/interview/[id]/processing/page.tsx
+++ b/src/app/interview/[id]/processing/page.tsx
@@ -124,6 +124,8 @@ export default function ProcessingPage({
       if (cancelled) return;
 
       try {
+        // 注: user_id による明示的フィルタは追加していない。
+        // Supabase RLS ポリシーにより、認証ユーザーは自分の interviews のみ取得可能。
         const { data, error } = await supabase
           .from("interviews")
           .select("status")

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -15,6 +15,7 @@ import { Progress } from "@/components/ui/progress";
 import type { Database } from "@/types/supabase";
 import type { Json } from "@/types/supabase";
 import type { CategoryScores } from "@/types/database";
+import { CATEGORY_LABELS } from "@/lib/constants";
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Transcript = Database["public"]["Tables"]["transcripts"]["Row"];
@@ -32,8 +33,15 @@ interface FillerWord {
 }
 
 function parseJsonArray<T>(data: Json): T[] {
-  if (Array.isArray(data)) return data as T[];
-  return [];
+  if (!Array.isArray(data)) return [];
+  // null/undefined を除外してキャスト
+  return data.filter((item) => item != null) as T[];
+}
+
+/** string 配列専用のパーサー。各要素が string であることを保証する */
+function parseStringArray(data: Json): string[] {
+  if (!Array.isArray(data)) return [];
+  return data.filter((item): item is string => typeof item === "string");
 }
 
 // ============================================================
@@ -68,17 +76,6 @@ function ScoreDisplay({ score }: { score: number }) {
 // ============================================================
 // カテゴリ別スコア表示
 // ============================================================
-
-const CATEGORY_LABELS: Record<string, string> = {
-  communication: "コミュニケーション",
-  content: "回答内容",
-  manner: "マナー",
-  logic: "論理性",
-  specificity: "具体性",
-  enthusiasm: "熱意",
-  manners: "マナー",
-  question_handling: "質問対応",
-};
 
 function CategoryScoreBar({
   label,
@@ -154,16 +151,16 @@ export function ResultContent({
     ? parseJsonArray<FillerWord>(feedback.filler_words)
     : [];
   const goodPoints = feedback
-    ? parseJsonArray<string>(feedback.good_points)
+    ? parseStringArray(feedback.good_points)
     : [];
   const improvementPoints = feedback
-    ? parseJsonArray<string>(feedback.improvement_points)
+    ? parseStringArray(feedback.improvement_points)
     : [];
   const strengths = feedback
-    ? parseJsonArray<string>(feedback.strengths)
+    ? parseStringArray(feedback.strengths)
     : [];
   const improvements = feedback
-    ? parseJsonArray<string>(feedback.improvements)
+    ? parseStringArray(feedback.improvements)
     : [];
 
   // good_points が空の場合は strengths にフォールバック

--- a/src/app/interview/new/page.tsx
+++ b/src/app/interview/new/page.tsx
@@ -78,7 +78,7 @@ export default function NewInterviewPage() {
   // --- 下書き保存・復元 ---
   useEffect(() => {
     try {
-      const saved = localStorage.getItem(DRAFT_STORAGE_KEY);
+      const saved = sessionStorage.getItem(DRAFT_STORAGE_KEY);
       if (saved) {
         const draft: DraftData = JSON.parse(saved);
         if (draft.companyName) setCompanyName(draft.companyName);
@@ -101,7 +101,7 @@ export default function NewInterviewPage() {
       transcript,
     };
     try {
-      localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+      sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
     } catch {
       // ストレージ書き込み失敗は無視
     }
@@ -331,7 +331,7 @@ export default function NewInterviewPage() {
       }
 
       // 下書きをクリア
-      localStorage.removeItem(DRAFT_STORAGE_KEY);
+      sessionStorage.removeItem(DRAFT_STORAGE_KEY);
 
       router.push("/dashboard");
       router.refresh();

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -175,7 +175,8 @@ export default function ProfilePage() {
   };
 
   // 保存（二重送信防止付き）
-  const handleSave = async () => {
+  const handleSave = async (e?: React.FormEvent) => {
+    e?.preventDefault();
     if (savingRef.current) return;
 
     // バリデーション
@@ -270,7 +271,7 @@ export default function ProfilePage() {
         </div>
       )}
 
-      <div className="space-y-6">
+      <form onSubmit={handleSave} className="space-y-6">
         {/* 基本情報 */}
         <Card>
           <CardHeader>
@@ -568,7 +569,7 @@ export default function ProfilePage() {
 
         {/* 保存ボタン */}
         <div className="flex justify-end">
-          <Button onClick={handleSave} disabled={saving} size="lg">
+          <Button type="submit" disabled={saving} size="lg">
             {saving ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : (
@@ -577,7 +578,7 @@ export default function ProfilePage() {
             {saving ? "保存中..." : "保存する"}
           </Button>
         </div>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * analyze API が返す4カテゴリに対応するラベル定義。
+ * result-content.tsx / growth/page.tsx で共通利用する。
+ */
+export const CATEGORY_LABELS: Record<string, string> = {
+  communication: "コミュニケーション",
+  content: "回答内容",
+  manner: "マナー",
+  logic: "論理性",
+};


### PR DESCRIPTION
## Summary
- **M-1**: `dashboard/page.tsx` の `select("*")` を `select("interview_id, overall_score")` に変更し、不要なカラム取得を削減
- **M-2**: `growth/page.tsx` の `["__none__"]` ハックを条件分岐による早期スキップに変更
- **M-3**: `result-content.tsx` に `parseStringArray` を追加し、各要素が string であることを型ガードで保証
- **M-4**: `CATEGORY_LABELS` を `src/lib/constants.ts` に共通定義として抽出し、analyze API が返す4カテゴリ（communication, content, manner, logic）に統一
- **M-5**: `processing/page.tsx` のポーリングクエリに「RLS に依存」のコメントを追記
- **L-1**: `analyze/route.ts` の `as never` 型アサーションに理由コメントを付記
- **L-2**: `interview/new/page.tsx` の下書き保存を `localStorage` から `sessionStorage` に変更
- **L-3**: `profile/page.tsx` を `<form onSubmit>` パターンに変更し、Enter キー送信を有効化

closes #47

## Test plan
- [ ] ダッシュボードページが正常に表示されること
- [ ] 成長記録ページが面接0件でもエラーにならないこと
- [ ] 面接結果ページのカテゴリ別スコアが4カテゴリで表示されること
- [ ] 新規面接登録ページの下書きがタブを閉じると消えること
- [ ] プロフィールページで Enter キーによる送信が動作すること
- [ ] `npm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)