### PR TITLE
feat: #30 オンボーディングフロー（初回登録ウィザード）

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import type { Database } from "@/types/database";
+
+type ProfileInsert = Database["public"]["Tables"]["profiles"]["Insert"];
+
+/** バリデーション: 表示名は1~50文字 */
+function validateDisplayName(name: unknown): string | null {
+  if (name === null || name === undefined || name === "") return null;
+  if (typeof name !== "string") return null;
+  const trimmed = name.trim();
+  if (trimmed.length < 1 || trimmed.length > 50) return null;
+  return trimmed;
+}
+
+/** バリデーション: テキストフィールド (最大100文字) */
+function validateText(value: unknown, maxLength = 100): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length > maxLength) return null;
+  return trimmed;
+}
+
+/** バリデーション: 配列フィールド (最大5件) */
+function validateArray(value: unknown, maxItems = 5): string[] {
+  if (!Array.isArray(value)) return [];
+  const filtered = value.filter(
+    (item): item is string => typeof item === "string" && item.trim().length > 0
+  );
+  return filtered.slice(0, maxItems);
+}
+
+const VALID_JOB_HUNTING_STATUSES = [
+  "not_started",
+  "preparing",
+  "active",
+  "offered",
+  "decided",
+  "other",
+] as const;
+
+/** バリデーション: 就活ステータス */
+function validateJobHuntingStatus(
+  value: unknown
+): Database["public"]["Enums"]["job_hunting_status"] {
+  if (
+    typeof value === "string" &&
+    VALID_JOB_HUNTING_STATUSES.includes(
+      value as (typeof VALID_JOB_HUNTING_STATUSES)[number]
+    )
+  ) {
+    return value as Database["public"]["Enums"]["job_hunting_status"];
+  }
+  return "not_started";
+}
+
+/**
+ * PUT /api/onboarding
+ * オンボーディングデータの保存
+ * - 認証チェック
+ * - プロフィール upsert
+ * - onboarding_completed = true にセット
+ * - Cookie にフラグをセット
+ */
+export async function PUT(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    // スキップの場合: onboarding_completed のみセット
+    if (body.skip === true) {
+      const { error } = await supabase
+        .from("profiles")
+        .upsert(
+          {
+            user_id: user.id,
+            onboarding_completed: true,
+            updated_at: new Date().toISOString(),
+          } as never,
+          { onConflict: "user_id" }
+        );
+
+      if (error) {
+        console.error("Onboarding skip error:", error);
+        return NextResponse.json(
+          { error: "オンボーディングの完了に失敗しました" },
+          { status: 500 }
+        );
+      }
+
+      // Cookie にオンボーディング完了フラグをセット
+      const cookieStore = await cookies();
+      cookieStore.set("onboarding_completed", "true", {
+        path: "/",
+        httpOnly: false,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 60 * 60 * 24 * 365,
+      });
+
+      return NextResponse.json({ success: true });
+    }
+
+    // 通常のオンボーディングデータ保存
+    const displayName = validateDisplayName(body.display_name);
+    if (
+      body.display_name !== undefined &&
+      body.display_name !== null &&
+      body.display_name !== "" &&
+      !displayName
+    ) {
+      return NextResponse.json(
+        { error: "表示名は1~50文字で入力してください" },
+        { status: 400 }
+      );
+    }
+
+    const university = validateText(body.university, 100);
+    const faculty = validateText(body.faculty, 100);
+    const targetIndustry = validateArray(body.target_industry, 5);
+    const targetJobType = validateArray(body.target_job_type, 5);
+    const jobHuntingStatus = validateJobHuntingStatus(body.job_hunting_status);
+
+    const profileData: ProfileInsert = {
+      user_id: user.id,
+      display_name: displayName,
+      university,
+      faculty,
+      target_industry: targetIndustry,
+      target_job_type: targetJobType,
+      job_hunting_status: jobHuntingStatus,
+      onboarding_completed: true,
+      updated_at: new Date().toISOString(),
+    };
+
+    const { data, error } = await supabase
+      .from("profiles")
+      .upsert(profileData as never, { onConflict: "user_id" })
+      .select()
+      .single();
+
+    if (error) {
+      console.error("Onboarding upsert error:", error);
+      return NextResponse.json(
+        { error: "プロフィールの保存に失敗しました" },
+        { status: 500 }
+      );
+    }
+
+    // Cookie にオンボーディング完了フラグをセット
+    const cookieStore = await cookies();
+    cookieStore.set("onboarding_completed", "true", {
+      path: "/",
+      httpOnly: false,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 365,
+    });
+
+    return NextResponse.json({ profile: data });
+  } catch {
+    return NextResponse.json(
+      { error: "サーバーエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/onboarding/onboarding-wizard.tsx
+++ b/src/app/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { useState, useRef } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Loader2, CheckCircle, ArrowRight, ArrowLeft, X } from "lucide-react";
+
+// ============================================================
+// 選択肢定義（プロフィールページと同じ定数）
+// ============================================================
+
+const INDUSTRIES = [
+  "IT",
+  "金融",
+  "商社",
+  "メーカー",
+  "コンサル",
+  "広告",
+  "不動産",
+  "公務員",
+  "その他",
+] as const;
+
+const JOB_TYPES = [
+  "エンジニア",
+  "営業",
+  "企画",
+  "マーケティング",
+  "事務",
+  "研究",
+  "デザイン",
+  "その他",
+] as const;
+
+const JOB_HUNTING_STATUSES = [
+  { value: "not_started", label: "未開始" },
+  { value: "preparing", label: "就活準備中" },
+  { value: "active", label: "エントリー・選考中" },
+  { value: "offered", label: "内定あり" },
+  { value: "decided", label: "就活終了" },
+  { value: "other", label: "その他" },
+] as const;
+
+const TOTAL_STEPS = 3;
+
+// ============================================================
+// コンポーネント
+// ============================================================
+
+export function OnboardingWizard() {
+  const [currentStep, setCurrentStep] = useState(1);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const savingRef = useRef(false);
+
+  // ステップ1: 基本情報
+  const [displayName, setDisplayName] = useState("");
+  const [university, setUniversity] = useState("");
+  const [faculty, setFaculty] = useState("");
+
+  // ステップ2: 志望情報
+  const [targetIndustry, setTargetIndustry] = useState<string[]>([]);
+  const [targetJobType, setTargetJobType] = useState<string[]>([]);
+  const [jobHuntingStatus, setJobHuntingStatus] = useState("not_started");
+
+  // 複数選択トグル
+  const toggleSelection = (
+    current: string[],
+    setter: (v: string[]) => void,
+    value: string,
+    maxItems: number
+  ) => {
+    if (current.includes(value)) {
+      setter(current.filter((v) => v !== value));
+    } else if (current.length < maxItems) {
+      setter([...current, value]);
+    }
+  };
+
+  // API にデータを保存
+  const saveOnboarding = async (skipData: boolean) => {
+    if (savingRef.current) return;
+    savingRef.current = true;
+    setSaving(true);
+    setError("");
+
+    try {
+      const body = skipData
+        ? { skip: true }
+        : {
+            display_name: displayName.trim() || null,
+            university: university.trim() || null,
+            faculty: faculty.trim() || null,
+            target_industry: targetIndustry,
+            target_job_type: targetJobType,
+            job_hunting_status: jobHuntingStatus,
+          };
+
+      const res = await fetch("/api/onboarding", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "保存に失敗しました");
+      }
+
+      setCurrentStep(3);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "保存に失敗しました";
+      setError(message);
+    } finally {
+      setSaving(false);
+      savingRef.current = false;
+    }
+  };
+
+  // 「次へ」ボタン
+  const handleNext = () => {
+    if (currentStep === 1) {
+      if (displayName.trim().length > 0 && displayName.trim().length > 50) {
+        setError("表示名は1~50文字で入力してください");
+        return;
+      }
+      setError("");
+      setCurrentStep(2);
+    } else if (currentStep === 2) {
+      saveOnboarding(false);
+    }
+  };
+
+  // 「戻る」ボタン
+  const handleBack = () => {
+    if (currentStep > 1) {
+      setError("");
+      setCurrentStep(currentStep - 1);
+    }
+  };
+
+  // 「スキップ」ボタン
+  const handleSkip = () => {
+    saveOnboarding(true);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* ステップインジケーター */}
+      <div className="flex items-center justify-center gap-2">
+        {Array.from({ length: TOTAL_STEPS }, (_, i) => i + 1).map((step) => (
+          <div key={step} className="flex items-center gap-2">
+            <div
+              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium ${
+                step === currentStep
+                  ? "bg-primary text-primary-foreground"
+                  : step < currentStep
+                    ? "bg-primary/20 text-primary"
+                    : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {step < currentStep ? (
+                <CheckCircle className="h-4 w-4" />
+              ) : (
+                step
+              )}
+            </div>
+            {step < TOTAL_STEPS && (
+              <div
+                className={`h-0.5 w-8 ${
+                  step < currentStep ? "bg-primary" : "bg-muted"
+                }`}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      <p className="text-center text-sm text-muted-foreground">
+        ステップ {currentStep} / {TOTAL_STEPS}
+      </p>
+
+      {/* エラー表示 */}
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* ステップ1: 基本情報 */}
+      {currentStep === 1 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>基本情報</CardTitle>
+            <CardDescription>
+              あなたの基本的な情報を教えてください。後からプロフィールページで変更できます。
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="displayName">表示名</Label>
+              <Input
+                id="displayName"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="山田 太郎"
+                maxLength={50}
+                aria-describedby="displayName-hint"
+              />
+              <p
+                id="displayName-hint"
+                className="text-xs text-muted-foreground"
+              >
+                1~50文字（任意）
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="university">大学名</Label>
+              <Input
+                id="university"
+                value={university}
+                onChange={(e) => setUniversity(e.target.value)}
+                placeholder="東京大学"
+                maxLength={100}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="faculty">学部・学科</Label>
+              <Input
+                id="faculty"
+                value={faculty}
+                onChange={(e) => setFaculty(e.target.value)}
+                placeholder="工学部 情報工学科"
+                maxLength={100}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ステップ2: 志望情報 */}
+      {currentStep === 2 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>志望情報</CardTitle>
+            <CardDescription>
+              志望する業界・職種・就活状況を選択してください。AIフィードバックのパーソナライズに活用されます。
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <Label>
+                志望業界
+                <span className="ml-2 text-xs text-muted-foreground">
+                  (最大5つ)
+                </span>
+              </Label>
+              <div className="flex flex-wrap gap-2">
+                {INDUSTRIES.map((industry) => {
+                  const selected = targetIndustry.includes(industry);
+                  return (
+                    <button
+                      key={industry}
+                      type="button"
+                      onClick={() =>
+                        toggleSelection(
+                          targetIndustry,
+                          setTargetIndustry,
+                          industry,
+                          5
+                        )
+                      }
+                      aria-pressed={selected}
+                      className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-medium transition-colors ${
+                        selected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border bg-background text-foreground hover:bg-accent"
+                      }`}
+                    >
+                      {industry}
+                      {selected && <X className="ml-1 h-3 w-3" />}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>
+                志望職種
+                <span className="ml-2 text-xs text-muted-foreground">
+                  (最大5つ)
+                </span>
+              </Label>
+              <div className="flex flex-wrap gap-2">
+                {JOB_TYPES.map((jobType) => {
+                  const selected = targetJobType.includes(jobType);
+                  return (
+                    <button
+                      key={jobType}
+                      type="button"
+                      onClick={() =>
+                        toggleSelection(
+                          targetJobType,
+                          setTargetJobType,
+                          jobType,
+                          5
+                        )
+                      }
+                      aria-pressed={selected}
+                      className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-medium transition-colors ${
+                        selected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border bg-background text-foreground hover:bg-accent"
+                      }`}
+                    >
+                      {jobType}
+                      {selected && <X className="ml-1 h-3 w-3" />}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="jobHuntingStatus">就活状況</Label>
+              <select
+                id="jobHuntingStatus"
+                value={jobHuntingStatus}
+                onChange={(e) => setJobHuntingStatus(e.target.value)}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                aria-label="就活状況"
+              >
+                {JOB_HUNTING_STATUSES.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ステップ3: 完了 */}
+      {currentStep === 3 && (
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+              <CheckCircle className="h-8 w-8 text-green-600" />
+            </div>
+            <CardTitle className="text-2xl">セットアップ完了！</CardTitle>
+            <CardDescription>
+              プロフィールの設定が完了しました。さっそく面接練習を始めましょう。
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col items-center gap-4">
+            <Button asChild size="lg">
+              <Link href="/dashboard">
+                ダッシュボードへ
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              プロフィールは
+              <Link
+                href="/profile"
+                className="text-primary hover:underline"
+              >
+                プロフィールページ
+              </Link>
+              からいつでも変更できます。
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ナビゲーションボタン */}
+      {currentStep < 3 && (
+        <div className="flex items-center justify-between">
+          <div>
+            {currentStep > 1 && (
+              <Button
+                variant="outline"
+                onClick={handleBack}
+                disabled={saving}
+              >
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                戻る
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              onClick={handleSkip}
+              disabled={saving}
+            >
+              {saving && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              スキップ
+            </Button>
+            <Button onClick={handleNext} disabled={saving}>
+              {saving && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              {currentStep === 2 ? "完了" : "次へ"}
+              {!saving && currentStep < 2 && (
+                <ArrowRight className="ml-2 h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { OnboardingWizard } from "./onboarding-wizard";
+
+/**
+ * オンボーディングページ (Server Component)
+ * - 未認証ユーザーは /login にリダイレクト
+ * - 既にオンボーディング完了済みのユーザーは /dashboard にリダイレクト
+ */
+export default async function OnboardingPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  // オンボーディング完了チェック
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("user_id", user.id)
+    .single();
+
+  if ((profile as { onboarding_completed?: boolean } | null)?.onboarding_completed) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <OnboardingWizard />
+    </div>
+  );
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-const protectedRoutes = ["/dashboard", "/interview"];
+const protectedRoutes = ["/dashboard", "/interview", "/profile"];
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
@@ -46,6 +46,24 @@ export async function updateSession(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);
+  }
+
+  if (user && !request.cookies.get("onboarding_completed")?.value) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("onboarding_completed")
+      .eq("user_id", user.id)
+      .single();
+
+    if ((profile as { onboarding_completed?: boolean } | null)?.onboarding_completed) {
+      supabaseResponse.cookies.set("onboarding_completed", "true", {
+        path: "/",
+        httpOnly: false,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 60 * 60 * 24 * 365,
+      });
+    }
   }
 
   return supabaseResponse;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,6 +73,29 @@ function checkRateLimit(ip: string): { allowed: boolean; remaining: number; rese
   };
 }
 
+const ONBOARDING_BYPASS_PREFIXES = [
+  "/onboarding",
+  "/api/",
+  "/auth/",
+  "/legal/",
+  "/_next/",
+  "/login",
+  "/signup",
+];
+
+const ONBOARDING_REQUIRED_PREFIXES = [
+  "/dashboard",
+  "/interview",
+  "/profile",
+];
+
+function shouldCheckOnboarding(pathname: string): boolean {
+  if (ONBOARDING_BYPASS_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return false;
+  }
+  return ONBOARDING_REQUIRED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
 export async function middleware(request: NextRequest) {
   // /api/* へのリクエストにレート制限を適用
   if (request.nextUrl.pathname.startsWith("/api/")) {
@@ -102,7 +125,22 @@ export async function middleware(request: NextRequest) {
     return response;
   }
 
-  return await updateSession(request);
+  const response = await updateSession(request);
+
+  if (shouldCheckOnboarding(request.nextUrl.pathname)) {
+    const onboardingCompleted = request.cookies.get("onboarding_completed")?.value;
+    const hasSession = request.cookies.getAll().some(
+      (cookie) => cookie.name.startsWith("sb-") && cookie.name.endsWith("-auth-token")
+    );
+
+    if (hasSession && onboardingCompleted !== "true") {
+      const url = request.nextUrl.clone();
+      url.pathname = "/onboarding";
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return response;
 }
 
 export const config = {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -106,6 +106,7 @@ export interface Database {
           job_hunting_status: JobHuntingStatus;
           job_hunting_start_date: string | null;
           preferred_work_location: string[];
+          onboarding_completed: boolean;
           created_at: string;
           updated_at: string;
         };
@@ -122,6 +123,7 @@ export interface Database {
           job_hunting_status?: JobHuntingStatus;
           job_hunting_start_date?: string | null;
           preferred_work_location?: string[];
+          onboarding_completed?: boolean;
           created_at?: string;
           updated_at?: string;
         };
@@ -138,6 +140,7 @@ export interface Database {
           job_hunting_status?: JobHuntingStatus;
           job_hunting_start_date?: string | null;
           preferred_work_location?: string[];
+          onboarding_completed?: boolean;
           created_at?: string;
           updated_at?: string;
         };

--- a/supabase/migrations/00004_onboarding.sql
+++ b/supabase/migrations/00004_onboarding.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- Issue #30: オンボーディングフロー
+-- profiles テーブルに onboarding_completed カラムを追加
+-- ============================================================
+
+-- onboarding_completed カラム追加（デフォルトは FALSE）
+ALTER TABLE public.profiles
+ADD COLUMN IF NOT EXISTS onboarding_completed BOOLEAN DEFAULT FALSE;
+
+-- 既存レコードは全て TRUE にセット（既存ユーザーにはウィザード不要）
+UPDATE public.profiles
+SET onboarding_completed = TRUE
+WHERE onboarding_completed IS NULL OR onboarding_completed = FALSE;


### PR DESCRIPTION
## Summary
- profiles テーブルに `onboarding_completed` カラムを追加し、既存ユーザーは `TRUE` に設定
- 3ステップのオンボーディングウィザードを実装（基本情報 → 志望情報 → 完了）
- Cookie ベースの軽量なオンボーディングチェックを middleware に追加
- スキップ機能付き、各ステップで入力済みデータを API に保存

## 変更ファイル
- `supabase/migrations/00004_onboarding.sql` - DB マイグレーション
- `src/types/database.ts` - 型定義更新
- `src/app/onboarding/page.tsx` - Server Component（認証チェック + リダイレクト）
- `src/app/onboarding/onboarding-wizard.tsx` - Client Component（ステップウィザード UI）
- `src/app/api/onboarding/route.ts` - PUT API Route
- `src/middleware.ts` - オンボーディングリダイレクトロジック追加
- `src/lib/supabase/middleware.ts` - Cookie セットロジック追加

## Test plan
- [ ] 新規ユーザーがサインアップ後、`/dashboard` にアクセスすると `/onboarding` にリダイレクトされること
- [ ] ステップ1で基本情報を入力し「次へ」で進めること
- [ ] ステップ2で志望情報を選択し「完了」でデータが保存されること
- [ ] 「スキップ」ボタンでオンボーディングを省略できること
- [ ] 完了後は `/dashboard` にアクセスできること（リダイレクトされない）
- [ ] 既存ユーザーは `/onboarding` にアクセスすると `/dashboard` にリダイレクトされること

closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)