### PR TITLE
feat: #34 SEO対策（メタタグ・OGP・構造化データ）

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { Plus, ClipboardList } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -6,6 +7,11 @@ import { redirect } from "next/navigation";
 import type { Database, InterviewCategory } from "@/types/database";
 import { InterviewCard } from "@/components/interview-card";
 import { InterviewFilter, type SortOption } from "@/components/interview-filter";
+
+export const metadata: Metadata = {
+  title: "ダッシュボード",
+  robots: { index: false, follow: false },
+};
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Feedback = Database["public"]["Tables"]["feedbacks"]["Row"];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,10 +14,35 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const siteUrl = "https://interviewcoach.jp";
+const siteName = "InterviewCoach";
+const defaultDescription =
+  "面接練習の録音をAIが分析し、回答内容・話し方の両面からフィードバックを自動生成。新卒就活を成功に導くAI面接コーチ。";
+
 export const metadata: Metadata = {
-  title: "InterviewCoach",
-  description:
-    "面接練習の録音をAIが分析し、回答内容・話し方の両面からフィードバックを自動生成",
+  title: {
+    default: siteName,
+    template: `%s | ${siteName}`,
+  },
+  description: defaultDescription,
+  metadataBase: new URL(siteUrl),
+  openGraph: {
+    title: siteName,
+    description: defaultDescription,
+    type: "website",
+    locale: "ja_JP",
+    url: siteUrl,
+    siteName,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteName,
+    description: defaultDescription,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/src/app/legal/privacy/page.tsx
+++ b/src/app/legal/privacy/page.tsx
@@ -2,9 +2,15 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "プライバシーポリシー | InterviewCoach",
+  title: "プライバシーポリシー",
   description:
     "InterviewCoach のプライバシーポリシー。個人情報の取り扱いについてご説明します。",
+  openGraph: {
+    title: "プライバシーポリシー | InterviewCoach",
+    description:
+      "InterviewCoach のプライバシーポリシー。個人情報の取り扱いについてご説明します。",
+    url: "https://interviewcoach.jp/legal/privacy",
+  },
 };
 
 const sections = [

--- a/src/app/legal/terms/page.tsx
+++ b/src/app/legal/terms/page.tsx
@@ -2,9 +2,15 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "利用規約 | InterviewCoach",
+  title: "利用規約",
   description:
     "InterviewCoach の利用規約。サービスのご利用条件について定めています。",
+  openGraph: {
+    title: "利用規約 | InterviewCoach",
+    description:
+      "InterviewCoach の利用規約。サービスのご利用条件について定めています。",
+    url: "https://interviewcoach.jp/legal/terms",
+  },
 };
 
 const sections = [

--- a/src/app/legal/tokushoho/page.tsx
+++ b/src/app/legal/tokushoho/page.tsx
@@ -2,9 +2,15 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "特定商取引法に基づく表記 | InterviewCoach",
+  title: "特定商取引法に基づく表記",
   description:
     "InterviewCoach の特定商取引法に基づく表記。事業者情報・販売条件等を記載しています。",
+  openGraph: {
+    title: "特定商取引法に基づく表記 | InterviewCoach",
+    description:
+      "InterviewCoach の特定商取引法に基づく表記。事業者情報・販売条件等を記載しています。",
+    url: "https://interviewcoach.jp/legal/tokushoho",
+  },
 };
 
 const items = [

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "初期設定",
+  robots: { index: false, follow: false },
+};
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import {
   Brain,
@@ -21,9 +22,63 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
+export const metadata: Metadata = {
+  title: "InterviewCoach - AI面接フィードバック",
+  description:
+    "面接練習の録音をAIが分析し、回答内容・話し方の両面からフィードバックを自動生成。新卒就活を成功に導くAI面接コーチ。",
+  openGraph: {
+    title: "InterviewCoach - AI面接フィードバック",
+    description:
+      "面接練習の録音をAIが分析し、回答内容・話し方の両面からフィードバックを自動生成。新卒就活を成功に導くAI面接コーチ。",
+    url: "https://interviewcoach.jp",
+  },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebApplication",
+      name: "InterviewCoach",
+      url: "https://interviewcoach.jp",
+      description:
+        "面接練習の録音をAIが分析し、回答内容・話し方の両面からフィードバックを自動生成。新卒就活を成功に導くAI面接コーチ。",
+      applicationCategory: "BusinessApplication",
+      operatingSystem: "Web",
+      offers: [
+        {
+          "@type": "Offer",
+          name: "無料プラン",
+          price: "0",
+          priceCurrency: "JPY",
+          description: "月3回まで面接分析、基本的なAIフィードバック、スコア表示",
+        },
+        {
+          "@type": "Offer",
+          name: "Pro プラン",
+          price: "980",
+          priceCurrency: "JPY",
+          description:
+            "無制限の面接分析、詳細なAIフィードバック、成長トラッキング、パーソナライズ分析",
+        },
+      ],
+    },
+    {
+      "@type": "Organization",
+      name: "InterviewCoach",
+      url: "https://interviewcoach.jp",
+      email: "support@interviewcoach.jp",
+    },
+  ],
+};
+
 export default function Home() {
   return (
     <div className="flex flex-col">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* ヒーローセクション */}
       <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-primary/5 to-background px-4 py-24 sm:py-32">
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-primary/20 via-transparent to-transparent" />

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "プロフィール設定 | InterviewCoach",
+  title: "プロフィール設定",
   description:
     "プロフィール情報を入力して、AIフィードバックをパーソナライズしましょう。",
+  robots: { index: false, follow: false },
 };
 
 export default function ProfileLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/dashboard",
+        "/interview",
+        "/profile",
+        "/onboarding",
+        "/settings",
+        "/api",
+      ],
+    },
+    sitemap: "https://interviewcoach.jp/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = "https://interviewcoach.jp";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${siteUrl}/legal/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${siteUrl}/legal/terms`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${siteUrl}/legal/tokushoho`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- ルート layout.tsx にメタデータ（title template, OGP, Twitter Card, robots）を設定
- LP ページに個別メタデータと JSON-LD 構造化データ（WebApplication + Organization）を追加
- 法的ページ（プライバシーポリシー、利用規約、特定商取引法）に個別 OGP メタデータを設定
- 認証必要ページ（ダッシュボード、プロフィール、オンボーディング）に noindex を設定
- Next.js Sitemap API による sitemap.ts を追加（公開ページのみ）
- Next.js Robots API による robots.ts を追加（認証ページ・API を Disallow）

closes #34

## Test plan
- [ ] `npm run build` が成功すること
- [ ] `/sitemap.xml` にアクセスして公開ページが列挙されていること
- [ ] `/robots.txt` にアクセスして Disallow ルールが正しいこと
- [ ] 各ページの `<title>` が title template に沿っていること
- [ ] LP ページのソースに JSON-LD script タグが含まれていること
- [ ] 認証ページのメタタグに `noindex` が設定されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)