### PR TITLE
fix: #59 CSV インジェクション対策を追加

### DIFF
--- a/src/app/api/export/csv/route.ts
+++ b/src/app/api/export/csv/route.ts
@@ -24,17 +24,26 @@ const ROUND_MAP: Record<string, string> = {
   other: "その他",
 };
 
-/** CSV 用に値をエスケープする（ダブルクォートで囲み、内部のダブルクォートをエスケープ） */
+/** CSV 用に値をエスケープする（CSV インジェクション対策 + ダブルクォートエスケープ） */
 function escapeCsvValue(value: string): string {
-  if (
-    value.includes(",") ||
-    value.includes('"') ||
-    value.includes("\n") ||
-    value.includes("\r")
-  ) {
-    return `"${value.replace(/"/g, '""')}"`;
+  let escaped = value;
+
+  // CSV インジェクション対策: 数式として解釈される文字で始まる場合はシングルクォートを付与
+  if (/^[=+\-@\t\r]/.test(escaped)) {
+    escaped = "'" + escaped;
   }
-  return value;
+
+  // ダブルクォートのエスケープ・カンマ・改行を含む場合はダブルクォートで囲む
+  if (
+    escaped.includes(",") ||
+    escaped.includes('"') ||
+    escaped.includes("\n") ||
+    escaped.includes("\r")
+  ) {
+    escaped = '"' + escaped.replace(/"/g, '""') + '"';
+  }
+
+  return escaped;
 }
 
 /** 最大エクスポート件数 */


### PR DESCRIPTION
## Summary
- `escapeCsvValue()` 関数に CSV Formula Injection 対策を追加
- セル値が `=`, `+`, `-`, `@`, `\t`, `\r` で始まる場合、先頭にシングルクォート `'` を付与して Excel での数式実行を防止
- 既存のダブルクォートエスケープ処理はそのまま維持

## Test plan
- [ ] `=CMD|'/C calc'!A0` のような企業名を含むデータでCSVエクスポートし、先頭にシングルクォートが付与されていることを確認
- [ ] `+`, `-`, `@` で始まる値でも同様にエスケープされることを確認
- [ ] 通常の文字列（日本語企業名など）が影響を受けないことを確認
- [ ] `npm run build` が成功することを確認済み

closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)