### PR TITLE
fix: #63 Cookie httpOnly 修正

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -104,7 +104,7 @@ export async function PUT(request: Request) {
       const cookieStore = await cookies();
       cookieStore.set("onboarding_completed", "true", {
         path: "/",
-        httpOnly: false,
+        httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         maxAge: 60 * 60 * 24 * 365,
@@ -163,7 +163,7 @@ export async function PUT(request: Request) {
     const cookieStore = await cookies();
     cookieStore.set("onboarding_completed", "true", {
       path: "/",
-      httpOnly: false,
+      httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
       maxAge: 60 * 60 * 24 * 365,

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -58,7 +58,7 @@ export async function updateSession(request: NextRequest) {
     if ((profile as { onboarding_completed?: boolean } | null)?.onboarding_completed) {
       supabaseResponse.cookies.set("onboarding_completed", "true", {
         path: "/",
-        httpOnly: false,
+        httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         maxAge: 60 * 60 * 24 * 365,


### PR DESCRIPTION
## Summary

- `onboarding_completed` Cookie の `httpOnly` を `false` から `true` に変更
- JavaScript (`document.cookie`) 経由でのオンボーディングバイパスを防止
- サーバーサイドでのみ Cookie を読み取っているため、機能への影響なし

## 修正箇所

| ファイル | 変更内容 |
|---|---|
| `src/app/api/onboarding/route.ts` | Cookie 設定 2箇所を `httpOnly: true` に変更 |
| `src/lib/supabase/middleware.ts` | Cookie 設定 1箇所を `httpOnly: true` に変更 |

## 影響範囲の確認

- `onboarding_completed` Cookie の読み取りは全てサーバーサイド（`request.cookies.get()` / Next.js `cookies()`）で行われており、クライアントサイドでの `document.cookie` 参照は存在しない
- `httpOnly: true` への変更による機能的な影響はなし

## Test plan

- [ ] オンボーディング完了後、Cookie が `httpOnly` で設定されることを DevTools > Application > Cookies で確認
- [ ] ブラウザコンソールで `document.cookie` に `onboarding_completed` が含まれないことを確認
- [ ] オンボーディングフローが正常に動作することを確認
- [ ] `npm run build` 成功確認済み

closes #63