### PR TITLE
fix: #66 #67 #68 #69 Sprint 3 バグ修正

### DIFF
--- a/src/app/api/export/csv/route.ts
+++ b/src/app/api/export/csv/route.ts
@@ -84,7 +84,7 @@ export async function GET() {
 
     // フィードバック取得
     const interviewIds = interviews.map((i) => i.id);
-    let feedbackMap = new Map<string, Feedback>();
+    const feedbackMap = new Map<string, Feedback>();
 
     if (interviewIds.length > 0) {
       const { data: feedbacksData } = await supabase

--- a/src/app/api/export/pdf/route.ts
+++ b/src/app/api/export/pdf/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import type { Database, CategoryScores } from "@/types/database";
+import { CATEGORY_LABELS } from "@/lib/constants";
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Feedback = Database["public"]["Tables"]["feedbacks"]["Row"];
@@ -22,18 +23,6 @@ const ROUND_MAP: Record<string, string> = {
   gd: "GD",
   case: "ケース",
   other: "その他",
-};
-
-/** カテゴリ別スコアの日本語ラベル */
-const SCORE_CATEGORY_LABELS: Record<string, string> = {
-  communication: "コミュニケーション",
-  content: "回答内容",
-  manner: "マナー",
-  logic: "論理性",
-  specificity: "具体性",
-  enthusiasm: "熱意",
-  manners: "マナー",
-  question_handling: "質問対応",
 };
 
 /** 最大エクスポート件数 */
@@ -121,7 +110,7 @@ function renderSingleReport(
                 .map(
                   ([key, value]) => `
                 <div class="category-score-row">
-                  <span class="category-label">${escapeHtml(SCORE_CATEGORY_LABELS[key] || key)}</span>
+                  <span class="category-label">${escapeHtml(CATEGORY_LABELS[key] || key)}</span>
                   <div class="score-bar-container">
                     <div class="score-bar" style="width: ${value}%; background-color: ${scoreColor(value)}"></div>
                   </div>
@@ -219,7 +208,7 @@ export async function GET(request: NextRequest) {
     const interviewId = searchParams.get("id");
 
     let interviews: Interview[] = [];
-    let feedbackMap = new Map<string, Feedback>();
+    const feedbackMap = new Map<string, Feedback>();
 
     if (interviewId) {
       // 特定の面接を取得

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -20,7 +20,7 @@ export default async function OnboardingPage() {
   // オンボーディング完了チェック
   const { data: profile } = await supabase
     .from("profiles")
-    .select("*")
+    .select("onboarding_completed")
     .eq("user_id", user.id)
     .single();
 

--- a/src/components/export-buttons.tsx
+++ b/src/components/export-buttons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Download, Printer, FileDown, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -81,9 +81,12 @@ export function ExportButtons({
   };
 
   // エラー表示を一定時間後に消す
-  if (error) {
-    setTimeout(() => setError(null), 5000);
-  }
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => setError(null), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error]);
 
   if (variant === "inline") {
     return (


### PR DESCRIPTION
## Summary
- **#66**: `src/app/api/export/pdf/route.ts` の独自 `SCORE_CATEGORY_LABELS` を削除し、`src/lib/constants.ts` の共通 `CATEGORY_LABELS` をインポートして使用するように統一
- **#67**: `src/app/onboarding/page.tsx` の `select("*")` を `select("onboarding_completed")` に変更し、不要なカラム取得を排除
- **#68**: `src/app/api/export/csv/route.ts` と `src/app/api/export/pdf/route.ts` の `feedbackMap` 宣言を `let` から `const` に変更
- **#69**: `src/components/export-buttons.tsx` のレンダー内 `setTimeout` を `useEffect` に移行し、`clearTimeout` によるクリーンアップを追加

closes #66, closes #67, closes #68, closes #69

## Test plan
- [ ] `npm run build` が成功すること（確認済み）
- [ ] PDF エクスポートでカテゴリ別スコアのラベルが正しく表示されること
- [ ] オンボーディングフローが正常に動作すること
- [ ] CSV/PDF エクスポートが正常に動作すること
- [ ] エクスポートボタンのエラー表示が5秒後に正常に消えること