### PR TITLE
feat: #82 E2E テスト導入（Playwright）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("ランディングページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("ページタイトルが正しく表示される", async ({ page }) => {
+    await expect(page).toHaveTitle(/InterviewCoach/);
+  });
+
+  test("ヒーローセクションが表示される", async ({ page }) => {
+    // メインコピーの表示
+    await expect(
+      page.getByRole("heading", { level: 1 })
+    ).toContainText("面接、もう一人で");
+
+    // サブコピーの表示
+    await expect(page.getByText("AIがあなたの面接を分析し")).toBeVisible();
+
+    // CTA ボタンの表示
+    await expect(
+      page.getByRole("link", { name: "無料で始める" }).first()
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "詳しく見る" })
+    ).toBeVisible();
+  });
+
+  test("特徴セクションが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "3つの強みで面接力を伸ばす" })
+    ).toBeVisible();
+
+    // 3つの特徴カードの確認
+    await expect(page.getByText("AI分析")).toBeVisible();
+    await expect(page.getByText("成長トラッキング")).toBeVisible();
+    await expect(page.getByText("パーソナライズ")).toBeVisible();
+  });
+
+  test("使い方セクションが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "かんたん3ステップ" })
+    ).toBeVisible();
+
+    await expect(page.getByText("面接を記録")).toBeVisible();
+    await expect(page.getByText("AIが分析")).toBeVisible();
+    await expect(page.getByText("フィードバックで改善")).toBeVisible();
+  });
+
+  test("料金プランセクションが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "料金プラン" }).first()
+    ).toBeVisible();
+
+    // 無料プランの表示
+    await expect(
+      page.getByRole("heading", { name: "無料プラン" }).first()
+    ).toBeVisible();
+    await expect(page.getByText("¥0").first()).toBeVisible();
+
+    // Pro プランの表示
+    await expect(
+      page.getByRole("heading", { name: "Pro プラン" }).first()
+    ).toBeVisible();
+    await expect(page.getByText("¥980").first()).toBeVisible();
+  });
+
+  test("CTA セクションが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "今すぐ始めよう" })
+    ).toBeVisible();
+  });
+
+  test("フッターにリンクが表示される", async ({ page }) => {
+    const footer = page.locator("footer");
+
+    await expect(footer.getByRole("link", { name: "利用規約" })).toBeVisible();
+    await expect(
+      footer.getByRole("link", { name: "プライバシーポリシー" })
+    ).toBeVisible();
+    await expect(
+      footer.getByRole("link", { name: "特定商取引法に基づく表記" })
+    ).toBeVisible();
+  });
+
+  test("フッターのコピーライトが表示される", async ({ page }) => {
+    await expect(
+      page.locator("footer").getByText("InterviewCoach. All rights reserved.")
+    ).toBeVisible();
+  });
+});

--- a/e2e/legal-pages.spec.ts
+++ b/e2e/legal-pages.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("プライバシーポリシーページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/legal/privacy");
+  });
+
+  test("ページタイトルが正しく表示される", async ({ page }) => {
+    await expect(page).toHaveTitle(/プライバシーポリシー/);
+  });
+
+  test("見出しが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { level: 1, name: "プライバシーポリシー" })
+    ).toBeVisible();
+  });
+
+  test("目次が表示される", async ({ page }) => {
+    await expect(page.getByText("目次")).toBeVisible();
+    await expect(page.getByRole("link", { name: "はじめに" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "お問い合わせ" })
+    ).toBeVisible();
+  });
+
+  test("主要セクションが存在する", async ({ page }) => {
+    await expect(page.getByText("1. はじめに")).toBeVisible();
+    await expect(page.getByText("3. 収集する情報")).toBeVisible();
+    await expect(page.getByText("5. 第三者提供")).toBeVisible();
+    await expect(page.getByText("13. お問い合わせ")).toBeVisible();
+  });
+
+  test("トップページへの戻りリンクが存在する", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "トップページに戻る" })
+    ).toBeVisible();
+  });
+});
+
+test.describe("利用規約ページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/legal/terms");
+  });
+
+  test("ページタイトルが正しく表示される", async ({ page }) => {
+    await expect(page).toHaveTitle(/利用規約/);
+  });
+
+  test("見出しが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { level: 1, name: "利用規約" })
+    ).toBeVisible();
+  });
+
+  test("目次が表示される", async ({ page }) => {
+    await expect(page.getByText("目次")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "第1条 総則" })
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "附則" })).toBeVisible();
+  });
+
+  test("主要セクションが存在する", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "第1条 総則" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "第5条 禁止事項" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "第13条 準拠法・管轄裁判所" })
+    ).toBeVisible();
+  });
+
+  test("トップページへの戻りリンクが存在する", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "トップページに戻る" })
+    ).toBeVisible();
+  });
+});
+
+test.describe("特定商取引法に基づく表記ページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/legal/tokushoho");
+  });
+
+  test("ページタイトルが正しく表示される", async ({ page }) => {
+    await expect(page).toHaveTitle(/特定商取引法に基づく表記/);
+  });
+
+  test("見出しが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { level: 1, name: "特定商取引法に基づく表記" })
+    ).toBeVisible();
+  });
+
+  test("テーブルに必須項目が表示される", async ({ page }) => {
+    await expect(page.getByText("販売業者")).toBeVisible();
+    await expect(page.getByText("販売価格")).toBeVisible();
+    await expect(page.getByText("支払方法")).toBeVisible();
+    await expect(page.getByText("返品・キャンセル")).toBeVisible();
+    await expect(page.getByText("動作環境")).toBeVisible();
+  });
+
+  test("問い合わせメールアドレスが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "support@interviewcoach.jp" }).first()
+    ).toBeVisible();
+  });
+
+  test("関連ページへのリンクが存在する", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "利用規約" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "プライバシーポリシー" })
+    ).toBeVisible();
+  });
+
+  test("トップページへの戻りリンクが存在する", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "トップページに戻る" })
+    ).toBeVisible();
+  });
+});

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("SEO メタ情報", () => {
+  test("トップページに meta description が設定されている", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const description = page.locator('meta[name="description"]');
+    await expect(description).toHaveAttribute("content", /.+/);
+  });
+
+  test("トップページに OGP タグが設定されている", async ({ page }) => {
+    await page.goto("/");
+
+    // og:title
+    const ogTitle = page.locator('meta[property="og:title"]');
+    await expect(ogTitle).toHaveAttribute("content", /InterviewCoach/);
+
+    // og:description
+    const ogDescription = page.locator('meta[property="og:description"]');
+    await expect(ogDescription).toHaveAttribute("content", /.+/);
+
+    // og:url
+    const ogUrl = page.locator('meta[property="og:url"]');
+    await expect(ogUrl).toHaveAttribute("content", /.+/);
+
+    // og:type
+    const ogType = page.locator('meta[property="og:type"]');
+    await expect(ogType).toHaveAttribute("content", "website");
+
+    // og:locale
+    const ogLocale = page.locator('meta[property="og:locale"]');
+    await expect(ogLocale).toHaveAttribute("content", "ja_JP");
+  });
+
+  test("トップページに Twitter Card タグが設定されている", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const twitterCard = page.locator('meta[name="twitter:card"]');
+    await expect(twitterCard).toHaveAttribute(
+      "content",
+      "summary_large_image"
+    );
+
+    const twitterTitle = page.locator('meta[name="twitter:title"]');
+    await expect(twitterTitle).toHaveAttribute("content", /InterviewCoach/);
+  });
+
+  test("トップページに JSON-LD 構造化データが埋め込まれている", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const jsonLd = page.locator('script[type="application/ld+json"]');
+    await expect(jsonLd).toBeAttached();
+
+    const content = await jsonLd.textContent();
+    expect(content).toBeTruthy();
+
+    const parsed = JSON.parse(content!);
+    expect(parsed["@context"]).toBe("https://schema.org");
+  });
+
+  test("html lang 属性が ja に設定されている", async ({ page }) => {
+    await page.goto("/");
+    const html = page.locator("html");
+    await expect(html).toHaveAttribute("lang", "ja");
+  });
+});
+
+test.describe("robots.txt / sitemap.xml", () => {
+  test("robots.txt にアクセスできる", async ({ request }) => {
+    const response = await request.get("/robots.txt");
+    expect(response.ok()).toBeTruthy();
+
+    const body = await response.text();
+    expect(body).toContain("User-Agent:");
+    expect(body).toContain("Allow: /");
+    expect(body).toContain("sitemap.xml");
+  });
+
+  test("robots.txt で認証ページがブロックされている", async ({
+    request,
+  }) => {
+    const response = await request.get("/robots.txt");
+    const body = await response.text();
+
+    expect(body).toContain("Disallow: /dashboard");
+    expect(body).toContain("Disallow: /interview");
+    expect(body).toContain("Disallow: /profile");
+    expect(body).toContain("Disallow: /api");
+  });
+
+  test("sitemap.xml にアクセスできる", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    expect(response.ok()).toBeTruthy();
+
+    const body = await response.text();
+    expect(body).toContain("<urlset");
+    expect(body).toContain("interviewcoach.jp");
+  });
+
+  test("sitemap.xml に主要ページが含まれている", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    const body = await response.text();
+
+    // 公開ページの URL が含まれていることを確認
+    expect(body).toContain("interviewcoach.jp</loc>");
+    expect(body).toContain("/legal/privacy</loc>");
+    expect(body).toContain("/legal/terms</loc>");
+    expect(body).toContain("/legal/tokushoho</loc>");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1985,6 +1986,23 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -9623,6 +9641,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
@@ -24,6 +26,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright E2E テスト設定
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  /* テスト実行の最大タイムアウト */
+  timeout: 30_000,
+  /* expect のタイムアウト */
+  expect: {
+    timeout: 5_000,
+  },
+  /* テスト全体のタイムアウト（CI 環境向け） */
+  globalTimeout: 10 * 60_000,
+  /* CI では並列実行を抑制 */
+  fullyParallel: true,
+  /* CI ではリトライを 2 回に設定 */
+  retries: process.env.CI ? 2 : 0,
+  /* CI ではワーカー数を 1 に制限 */
+  workers: process.env.CI ? 1 : undefined,
+  /* レポーター */
+  reporter: "html",
+  /* 全プロジェクト共通設定 */
+  use: {
+    baseURL: "http://localhost:3000",
+    /* 失敗時にスクリーンショットを自動取得 */
+    screenshot: "only-on-failure",
+    /* 失敗時にトレースを取得 */
+    trace: "on-first-retry",
+  },
+  /* ブラウザプロジェクト（MVP: Chromium のみ） */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  /* dev サーバーの自動起動設定 */
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary
- Playwright を導入し、公開ページ（LP、法的ページ）の E2E テスト基盤を構築
- SEO（meta タグ、OGP、robots.txt、sitemap.xml）の自動テストを追加
- MVP として Chromium のみ、認証不要のページを対象とした構成

## 変更内容
- `playwright.config.ts`: Chromium のみ、baseURL `localhost:3000`、webServer 自動起動、失敗時スクリーンショット取得
- `e2e/landing.spec.ts`: LP のヒーロー、特徴、料金プラン、フッターの表示確認
- `e2e/legal-pages.spec.ts`: プライバシーポリシー、利用規約、特定商取引法ページの表示確認
- `e2e/seo.spec.ts`: meta description、OGP、Twitter Card、JSON-LD、robots.txt、sitemap.xml の確認
- `package.json`: `test:e2e` / `test:e2e:ui` スクリプト追加、`@playwright/test` 追加
- `.gitignore`: Playwright 関連ディレクトリ（test-results, playwright-report 等）を除外

## Test plan
- [ ] `npm run test:e2e` でテストが実行されること
- [ ] 全テストがパスすること
- [ ] `npm run build` が成功すること

closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)