### PR TITLE
feat: #79 面接のタグ・メモ機能

### DIFF
--- a/src/app/api/interviews/[id]/notes/route.ts
+++ b/src/app/api/interviews/[id]/notes/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { MAX_NOTES_LENGTH } from "@/lib/constants";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user)
+      return NextResponse.json(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+
+    const body = await request.json();
+    const { notes } = body as { notes: string };
+
+    if (typeof notes !== "string")
+      return NextResponse.json(
+        { error: "メモは文字列で指定してください" },
+        { status: 400 }
+      );
+    if (notes.length > MAX_NOTES_LENGTH)
+      return NextResponse.json(
+        {
+          error:
+            "メモは" + MAX_NOTES_LENGTH + "文字以内で入力してください",
+        },
+        { status: 400 }
+      );
+
+    const { error } = await supabase
+      .from("interviews")
+      .update({ notes: notes || null } as never)
+      .eq("id", id)
+      .eq("user_id", user.id);
+
+    if (error)
+      return NextResponse.json(
+        { error: "メモの保存に失敗しました" },
+        { status: 500 }
+      );
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json(
+      { error: "予期しないエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/interviews/[id]/tags/route.ts
+++ b/src/app/api/interviews/[id]/tags/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { MAX_TAGS_PER_INTERVIEW } from "@/lib/constants";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user)
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+
+    const { data: interview } = await supabase
+      .from("interviews")
+      .select("id")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
+    if (!interview)
+      return NextResponse.json({ error: "面接が見つかりません" }, { status: 404 });
+
+    const { data, error } = await supabase
+      .from("interview_tags")
+      .select("tag_id, tags(id, name, color, created_at)")
+      .eq("interview_id", id);
+    if (error)
+      return NextResponse.json(
+        { error: "タグの取得に失敗しました" },
+        { status: 500 }
+      );
+
+    const tags = ((data ?? []) as never[])
+      .map((row: Record<string, unknown>) => {
+        const tag = row.tags;
+        if (!tag || Array.isArray(tag)) return null;
+        return tag;
+      })
+      .filter(Boolean);
+
+    return NextResponse.json({ tags });
+  } catch {
+    return NextResponse.json(
+      { error: "予期しないエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user)
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+
+    const { data: interview } = await supabase
+      .from("interviews")
+      .select("id")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
+    if (!interview)
+      return NextResponse.json({ error: "面接が見つかりません" }, { status: 404 });
+
+    const body = await request.json();
+    const { tag_ids } = body as { tag_ids: string[] };
+    if (!Array.isArray(tag_ids))
+      return NextResponse.json(
+        { error: "tag_ids は配列で指定してください" },
+        { status: 400 }
+      );
+    if (tag_ids.length > MAX_TAGS_PER_INTERVIEW)
+      return NextResponse.json(
+        { error: "タグは最大" + MAX_TAGS_PER_INTERVIEW + "個までです" },
+        { status: 400 }
+      );
+
+    const { error: deleteError } = await supabase
+      .from("interview_tags")
+      .delete()
+      .eq("interview_id", id);
+    if (deleteError)
+      return NextResponse.json(
+        { error: "タグの更新に失敗しました" },
+        { status: 500 }
+      );
+
+    if (tag_ids.length > 0) {
+      const rows = tag_ids.map((tag_id) => ({ interview_id: id, tag_id }));
+      const { error: insertError } = await supabase
+        .from("interview_tags")
+        .insert(rows as never);
+      if (insertError)
+        return NextResponse.json(
+          { error: "タグの追加に失敗しました" },
+          { status: 500 }
+        );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json(
+      { error: "予期しないエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { TAG_COLORS } from "@/lib/constants";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user)
+      return NextResponse.json(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+
+    const { data, error } = await supabase
+      .from("tags")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: true });
+
+    if (error)
+      return NextResponse.json(
+        { error: "タグの取得に失敗しました" },
+        { status: 500 }
+      );
+
+    return NextResponse.json({ tags: data ?? [] });
+  } catch {
+    return NextResponse.json(
+      { error: "予期しないエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user)
+      return NextResponse.json(
+        { error: "認証が必要です" },
+        { status: 401 }
+      );
+
+    const body = await request.json();
+    const { name, color } = body as { name: string; color?: string };
+
+    if (!name || typeof name !== "string")
+      return NextResponse.json(
+        { error: "タグ名は必須です" },
+        { status: 400 }
+      );
+
+    const trimmedName = name.trim();
+    if (trimmedName.length === 0 || trimmedName.length > 50)
+      return NextResponse.json(
+        { error: "タグ名は1～50文字で入力してください" },
+        { status: 400 }
+      );
+
+    const validColors = TAG_COLORS.map((c) => c.value);
+    const tagColor =
+      color && validColors.includes(color as (typeof validColors)[number])
+        ? color
+        : "blue";
+
+    const { data, error } = await supabase
+      .from("tags")
+      .insert({
+        user_id: user.id,
+        name: trimmedName,
+        color: tagColor,
+      } as never)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === "23505")
+        return NextResponse.json(
+          { error: "同じ名前のタグが既に存在します" },
+          { status: 409 }
+        );
+      return NextResponse.json(
+        { error: "タグの作成に失敗しました" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ tag: data }, { status: 201 });
+  } catch {
+    return NextResponse.json(
+      { error: "予期しないエラーが発生しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,10 +16,17 @@ export const metadata: Metadata = {
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Feedback = Database["public"]["Tables"]["feedbacks"]["Row"];
+type Tag = Database["public"]["Tables"]["tags"]["Row"];
+
+interface InterviewTagRow {
+  interview_id: string;
+  tag_id: string;
+}
 
 /** 面接 + 最新フィードバックの結合型 */
 type InterviewWithScore = Interview & {
   overallScore: number | null;
+  tags: Tag[];
 };
 
 export default async function DashboardPage({
@@ -40,6 +47,7 @@ export default async function DashboardPage({
   const params = await searchParams;
   const categoryParam = (params.category as string) || "all";
   const sortParam = (params.sort as string) || "date_desc";
+  const tagParam = (params.tag as string) || "";
 
   const currentCategory = ["arubaito", "intern", "new_grad", "other", "all"].includes(
     categoryParam
@@ -97,10 +105,45 @@ export default async function DashboardPage({
     }
   }
 
-  const interviewsWithScore: InterviewWithScore[] = interviews.map((iv) => ({
+  // タグ取得
+  const { data: userTagsData } = await supabase
+    .from("tags")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true });
+  const userTags = (userTagsData ?? []) as Tag[];
+
+  let interviewTagRows: InterviewTagRow[] = [];
+  if (interviewIds.length > 0) {
+    const { data: itData } = await supabase
+      .from("interview_tags")
+      .select("interview_id, tag_id")
+      .in("interview_id", interviewIds);
+    interviewTagRows = (itData ?? []) as InterviewTagRow[];
+  }
+
+  const tagMap = new Map<string, Tag[]>();
+  for (const row of interviewTagRows) {
+    const tag = userTags.find((t) => t.id === row.tag_id);
+    if (tag) {
+      const existing = tagMap.get(row.interview_id) ?? [];
+      existing.push(tag);
+      tagMap.set(row.interview_id, existing);
+    }
+  }
+
+  let interviewsWithScore: InterviewWithScore[] = interviews.map((iv) => ({
     ...iv,
     overallScore: scoreMap.get(iv.id) ?? null,
+    tags: tagMap.get(iv.id) ?? [],
   }));
+
+  // タグフィルタリング
+  if (tagParam) {
+    interviewsWithScore = interviewsWithScore.filter((iv) =>
+      iv.tags.some((t) => t.id === tagParam)
+    );
+  }
 
   // スコア順ソート（アプリレベル）
   if (currentSort === "score_desc") {
@@ -141,6 +184,8 @@ export default async function DashboardPage({
           currentCategory={currentCategory}
           currentSort={currentSort}
           totalCount={interviewsWithScore.length}
+          tags={userTags}
+          currentTag={tagParam}
         />
       </div>
 
@@ -150,12 +195,12 @@ export default async function DashboardPage({
           <div className="rounded-lg border border-dashed p-12 text-center">
             <ClipboardList className="mx-auto h-12 w-12 text-muted-foreground/50" />
             <h2 className="mt-4 text-lg font-semibold">
-              {currentCategory !== "all"
+              {currentCategory !== "all" || tagParam
                 ? "条件に一致する面接がありません"
                 : "最初の面接を記録しましょう"}
             </h2>
             <p className="mt-2 text-sm text-muted-foreground">
-              {currentCategory !== "all"
+              {currentCategory !== "all" || tagParam
                 ? "フィルタ条件を変更するか、新しい面接を記録してください。"
                 : "面接を登録して最初のフィードバックを受けましょう。"}
             </p>
@@ -178,6 +223,7 @@ export default async function DashboardPage({
                 interviewDate={interview.interview_date}
                 overallScore={interview.overallScore}
                 status={interview.status}
+                tags={interview.tags}
               />
             ))}
           </div>

--- a/src/app/interview/[id]/result/page.tsx
+++ b/src/app/interview/[id]/result/page.tsx
@@ -7,6 +7,13 @@ type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Transcript = Database["public"]["Tables"]["transcripts"]["Row"];
 type Feedback = Database["public"]["Tables"]["feedbacks"]["Row"];
 
+interface TagData {
+  id: string;
+  name: string;
+  color: string;
+  created_at: string;
+}
+
 export default async function ResultPage({
   params,
 }: {
@@ -49,11 +56,22 @@ export default async function ResultPage({
 
   const feedback = feedbackData as Feedback | null;
 
+  // 面接に付与されたタグを取得
+  const { data: interviewTagsData } = await supabase
+    .from("interview_tags")
+    .select("tag_id, tags(id, name, color, created_at)")
+    .eq("interview_id", id);
+
+  const interviewTags: TagData[] = ((interviewTagsData ?? []) as never[])
+    .map((row: Record<string, unknown>) => row.tags as TagData | null)
+    .filter((t): t is TagData => t !== null && !Array.isArray(t));
+
   return (
     <ResultContent
       interview={interview}
       transcripts={transcripts}
       feedback={feedback}
+      interviewTags={interviewTags}
     />
   );
 }

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -17,10 +17,19 @@ import type { Json } from "@/types/supabase";
 import type { CategoryScores } from "@/types/database";
 import { CATEGORY_LABELS } from "@/lib/constants";
 import { ExportButtons } from "@/components/export-buttons";
+import { TagSelector } from "@/components/tag-selector";
+import { NotesEditor } from "@/components/notes-editor";
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Transcript = Database["public"]["Tables"]["transcripts"]["Row"];
 type Feedback = Database["public"]["Tables"]["feedbacks"]["Row"];
+
+interface TagData {
+  id: string;
+  name: string;
+  color: string;
+  created_at: string;
+}
 
 interface Suggestion {
   original: string;
@@ -140,10 +149,12 @@ export function ResultContent({
   interview,
   transcripts,
   feedback,
+  interviewTags = [],
 }: {
   interview: Interview;
   transcripts: Transcript[];
   feedback: Feedback | null;
+  interviewTags?: TagData[];
 }) {
   const suggestions = feedback
     ? parseJsonArray<Suggestion>(feedback.suggestions)
@@ -204,6 +215,16 @@ export function ResultContent({
           </CardContent>
         </Card>
       )}
+
+      {/* タグ・メモセクション */}
+      <Card className="mb-6">
+        <CardContent className="space-y-6 pt-6">
+          <TagSelector interviewId={interview.id} initialTags={interviewTags} />
+          <div className="border-t pt-4">
+            <NotesEditor interviewId={interview.id} initialNotes={(interview as Interview & { notes?: string | null }).notes ?? null} />
+          </div>
+        </CardContent>
+      </Card>
 
       {/* スコア & カテゴリ別スコア */}
       {feedback && (

--- a/src/components/interview-card.tsx
+++ b/src/components/interview-card.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
+import { TagBadge } from "@/components/tag-badge";
 import type {
   InterviewCategory,
   InterviewRound,
@@ -100,6 +101,7 @@ export interface InterviewCardProps {
   interviewDate: string | null;
   overallScore: number | null;
   status: InterviewStatus;
+  tags?: { id: string; name: string; color: string }[];
 }
 
 // ============================================================
@@ -114,6 +116,7 @@ export function InterviewCard({
   interviewDate,
   overallScore,
   status,
+  tags = [],
 }: InterviewCardProps) {
   const catConfig = CATEGORY_CONFIG[category];
   const statusConfig = STATUS_CONFIG[status];
@@ -146,6 +149,17 @@ export function InterviewCard({
         </CardHeader>
 
         <CardContent className="space-y-3">
+          {/* タグ */}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {tags.slice(0, 3).map((tag) => (
+                <TagBadge key={tag.id} name={tag.name} color={tag.color} />
+              ))}
+              {tags.length > 3 && (
+                <span className="text-xs text-muted-foreground">+{tags.length - 3}</span>
+              )}
+            </div>
+          )}
           {/* 面接日 */}
           {interviewDate && (
             <div className="flex items-center gap-1.5 text-sm text-muted-foreground">

--- a/src/components/interview-filter.tsx
+++ b/src/components/interview-filter.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import type { InterviewCategory } from "@/types/database";
+import { TagBadge } from "@/components/tag-badge";
 
 /** フィルタで使用するカテゴリ定義 */
 const CATEGORIES: { value: InterviewCategory | "all"; label: string }[] = [
@@ -24,16 +25,26 @@ const SORT_OPTIONS = [
 
 export type SortOption = (typeof SORT_OPTIONS)[number]["value"];
 
+interface TagData {
+  id: string;
+  name: string;
+  color: string;
+}
+
 interface InterviewFilterProps {
   currentCategory: InterviewCategory | "all";
   currentSort: SortOption;
   totalCount: number;
+  tags?: TagData[];
+  currentTag?: string;
 }
 
 export function InterviewFilter({
   currentCategory,
   currentSort,
   totalCount,
+  tags = [],
+  currentTag = "",
 }: InterviewFilterProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -42,7 +53,7 @@ export function InterviewFilter({
     (params: Record<string, string>) => {
       const newParams = new URLSearchParams(searchParams.toString());
       for (const [key, value] of Object.entries(params)) {
-        if (value === "all" || value === "date_desc") {
+        if (value === "" || value === "all" || (key === "sort" && value === "date_desc")) {
           newParams.delete(key);
         } else {
           newParams.set(key, value);
@@ -55,6 +66,12 @@ export function InterviewFilter({
 
   const handleCategoryChange = (category: InterviewCategory | "all") => {
     const qs = createQueryString({ category });
+    router.push(qs ? `/dashboard?${qs}` : "/dashboard");
+  };
+
+  const handleTagChange = (tagId: string) => {
+    const newTag = currentTag === tagId ? "" : tagId;
+    const qs = createQueryString({ tag: newTag });
     router.push(qs ? `/dashboard?${qs}` : "/dashboard");
   };
 
@@ -81,6 +98,40 @@ export function InterviewFilter({
           </Button>
         ))}
       </div>
+
+      {/* タグフィルタ */}
+      {tags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground mr-1">
+            タグ:
+          </span>
+          <button
+            type="button"
+            onClick={() => handleTagChange("")}
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${
+              !currentTag
+                ? "bg-foreground text-background"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            }`}
+          >
+            全て
+          </button>
+          {tags.map((tag) => (
+            <button
+              key={tag.id}
+              type="button"
+              onClick={() => handleTagChange(tag.id)}
+              className={`transition-opacity ${
+                currentTag && currentTag !== tag.id
+                  ? "opacity-50 hover:opacity-80"
+                  : ""
+              }`}
+            >
+              <TagBadge name={tag.name} color={tag.color} />
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* ソート・件数 */}
       <div className="flex flex-wrap items-center justify-between gap-2">

--- a/src/components/notes-editor.tsx
+++ b/src/components/notes-editor.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { StickyNote, Check, Loader2 } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import { MAX_NOTES_LENGTH } from "@/lib/constants";
+
+interface NotesEditorProps {
+  interviewId: string;
+  initialNotes: string | null;
+}
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+export function NotesEditor({ interviewId, initialNotes }: NotesEditorProps) {
+  const [notes, setNotes] = useState(initialNotes ?? "");
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const saveNotes = useCallback(async (value: string) => {
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setSaveStatus("saving");
+    try {
+      const res = await fetch(`/api/interviews/${interviewId}/notes`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: value }),
+        signal: controller.signal,
+      });
+      if (res.ok) {
+        setSaveStatus("saved");
+        setTimeout(() => setSaveStatus("idle"), 2000);
+      } else {
+        setSaveStatus("error");
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      setSaveStatus("error");
+    }
+  }, [interviewId]);
+
+  const handleChange = useCallback((value: string) => {
+    setNotes(value);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => { saveNotes(value); }, 1000);
+  }, [saveNotes]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <StickyNote className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium text-muted-foreground">メモ</span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          {saveStatus === "saving" && (
+            <>
+              <Loader2 className="h-3 w-3 animate-spin" />
+              <span>保存中...</span>
+            </>
+          )}
+          {saveStatus === "saved" && (
+            <>
+              <Check className="h-3 w-3 text-green-500" />
+              <span className="text-green-600 dark:text-green-400">保存済み</span>
+            </>
+          )}
+          {saveStatus === "error" && (
+            <span className="text-red-600 dark:text-red-400">保存に失敗しました</span>
+          )}
+          <span>{notes.length}/{MAX_NOTES_LENGTH}</span>
+        </div>
+      </div>
+      <Textarea
+        placeholder="面接のメモを自由に記入できます..."
+        value={notes}
+        onChange={(e) => handleChange(e.target.value)}
+        maxLength={MAX_NOTES_LENGTH}
+        rows={4}
+        className="resize-y"
+      />
+    </div>
+  );
+}

--- a/src/components/tag-badge.tsx
+++ b/src/components/tag-badge.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { X } from "lucide-react";
+import { getTagColorConfig } from "@/lib/constants";
+
+interface TagBadgeProps {
+  name: string;
+  color: string;
+  removable?: boolean;
+  onRemove?: () => void;
+}
+
+export function TagBadge({ name, color, removable = false, onRemove }: TagBadgeProps) {
+  const colorConfig = getTagColorConfig(color);
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${colorConfig.bg} ${colorConfig.text}`}>
+      <span className={`inline-block h-1.5 w-1.5 rounded-full ${colorConfig.dot}`} />
+      {name}
+      {removable && onRemove && (
+        <button
+          type="button"
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(); }}
+          className="ml-0.5 rounded-full p-0.5 hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+          aria-label={`タグ「${name}」を削除`}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/components/tag-selector.tsx
+++ b/src/components/tag-selector.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Plus, Tag } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TagBadge } from "@/components/tag-badge";
+import {
+  TAG_COLORS,
+  PRESET_TAGS,
+  MAX_TAGS_PER_INTERVIEW,
+  getTagColorConfig,
+} from "@/lib/constants";
+
+interface TagData {
+  id: string;
+  name: string;
+  color: string;
+  created_at: string;
+}
+
+interface TagSelectorProps {
+  interviewId: string;
+  initialTags?: TagData[];
+}
+
+export function TagSelector({ interviewId, initialTags = [] }: TagSelectorProps) {
+  const [allTags, setAllTags] = useState<TagData[]>([]);
+  const [selectedTagIds, setSelectedTagIds] = useState<Set<string>>(new Set());
+  const [newTagName, setNewTagName] = useState("");
+  const [newTagColor, setNewTagColor] = useState("blue");
+  const [isCreating, setIsCreating] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setSelectedTagIds(new Set(initialTags.map((t) => t.id)));
+  }, [initialTags]);
+
+  const fetchAllTags = useCallback(async () => {
+    try {
+      const res = await fetch("/api/tags");
+      if (res.ok) {
+        const data = await res.json();
+        setAllTags(data.tags);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAllTags();
+  }, [fetchAllTags]);
+
+  const saveTagSelection = useCallback(
+    async (newSelectedIds: Set<string>) => {
+      setIsSaving(true);
+      try {
+        await fetch(`/api/interviews/${interviewId}/tags`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tag_ids: Array.from(newSelectedIds) }),
+        });
+      } catch {
+        /* ignore */
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [interviewId]
+  );
+
+  const toggleTag = useCallback(
+    (tagId: string) => {
+      setSelectedTagIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(tagId)) {
+          next.delete(tagId);
+        } else {
+          if (next.size >= MAX_TAGS_PER_INTERVIEW) return prev;
+          next.add(tagId);
+        }
+        saveTagSelection(next);
+        return next;
+      });
+    },
+    [saveTagSelection]
+  );
+
+  const removeTag = useCallback(
+    (tagId: string) => {
+      setSelectedTagIds((prev) => {
+        const next = new Set(prev);
+        next.delete(tagId);
+        saveTagSelection(next);
+        return next;
+      });
+    },
+    [saveTagSelection]
+  );
+
+  const createTag = useCallback(
+    async (name: string, color: string) => {
+      setIsCreating(true);
+      try {
+        const res = await fetch("/api/tags", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, color }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          const newTag = data.tag as TagData;
+          setAllTags((prev) => [...prev, newTag]);
+          setSelectedTagIds((prev) => {
+            if (prev.size >= MAX_TAGS_PER_INTERVIEW) return prev;
+            const next = new Set(prev);
+            next.add(newTag.id);
+            saveTagSelection(next);
+            return next;
+          });
+          setNewTagName("");
+          setShowCreateForm(false);
+        } else if (res.status === 409) {
+          const existing = allTags.find((t) => t.name === name.trim());
+          if (existing) toggleTag(existing.id);
+        }
+      } catch {
+        /* ignore */
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [allTags, saveTagSelection, toggleTag]
+  );
+
+  const addPresetTag = useCallback(
+    (presetName: string) => {
+      const existing = allTags.find((t) => t.name === presetName);
+      if (existing) {
+        if (!selectedTagIds.has(existing.id)) toggleTag(existing.id);
+      } else {
+        const ci = Math.floor(Math.random() * TAG_COLORS.length);
+        createTag(presetName, TAG_COLORS[ci].value);
+      }
+    },
+    [allTags, selectedTagIds, toggleTag, createTag]
+  );
+
+  const selectedTags = allTags.filter((t) => selectedTagIds.has(t.id));
+  const unselectedTags = allTags.filter((t) => !selectedTagIds.has(t.id));
+  const unusedPresets = PRESET_TAGS.filter(
+    (p) => !allTags.some((t) => t.name === p)
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Tag className="h-4 w-4 text-muted-foreground shrink-0" />
+        <span className="text-sm font-medium text-muted-foreground shrink-0">
+          タグ
+        </span>
+        {isSaving && (
+          <span className="text-xs text-muted-foreground">保存中...</span>
+        )}
+      </div>
+
+      {selectedTags.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {selectedTags.map((tag) => (
+            <TagBadge
+              key={tag.id}
+              name={tag.name}
+              color={tag.color}
+              removable
+              onRemove={() => removeTag(tag.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          タグが設定されていません
+        </p>
+      )}
+
+      {unselectedTags.length > 0 &&
+        selectedTagIds.size < MAX_TAGS_PER_INTERVIEW && (
+          <div className="space-y-1.5">
+            <p className="text-xs text-muted-foreground">
+              既存タグから追加:
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {unselectedTags.map((tag) => (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggleTag(tag.id)}
+                  className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium border border-dashed border-muted-foreground/30 hover:border-muted-foreground/60 transition-colors ${getTagColorConfig(tag.color).bg} ${getTagColorConfig(tag.color).text} opacity-60 hover:opacity-100`}
+                >
+                  <Plus className="h-3 w-3" />
+                  {tag.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+      {unusedPresets.length > 0 &&
+        selectedTagIds.size < MAX_TAGS_PER_INTERVIEW && (
+          <div className="space-y-1.5">
+            <p className="text-xs text-muted-foreground">プリセット:</p>
+            <div className="flex flex-wrap gap-1.5">
+              {unusedPresets.map((preset) => (
+                <button
+                  key={preset}
+                  type="button"
+                  onClick={() => addPresetTag(preset)}
+                  className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium border border-dashed border-muted-foreground/30 hover:border-muted-foreground/60 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <Plus className="h-3 w-3" />
+                  {preset}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+      {selectedTagIds.size < MAX_TAGS_PER_INTERVIEW && (
+        <>
+          {!showCreateForm ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowCreateForm(true)}
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" />
+              カスタムタグを作成
+            </Button>
+          ) : (
+            <div className="flex flex-col gap-2 rounded-lg border p-3">
+              <Input
+                placeholder="タグ名を入力..."
+                value={newTagName}
+                onChange={(e) => setNewTagName(e.target.value)}
+                maxLength={50}
+                className="h-8 text-sm"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && newTagName.trim())
+                    createTag(newTagName.trim(), newTagColor);
+                }}
+              />
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground mr-1">色:</span>
+                {TAG_COLORS.map((c) => (
+                  <button
+                    key={c.value}
+                    type="button"
+                    onClick={() => setNewTagColor(c.value)}
+                    className={`h-5 w-5 rounded-full ${c.dot} transition-all ${
+                      newTagColor === c.value
+                        ? "ring-2 ring-offset-2 ring-offset-background ring-foreground scale-110"
+                        : "opacity-50 hover:opacity-100"
+                    }`}
+                    aria-label={c.label}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  disabled={!newTagName.trim() || isCreating}
+                  onClick={() => createTag(newTagName.trim(), newTagColor)}
+                >
+                  {isCreating ? "作成中..." : "作成"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowCreateForm(false);
+                    setNewTagName("");
+                  }}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {selectedTagIds.size >= MAX_TAGS_PER_INTERVIEW && (
+        <p className="text-xs text-muted-foreground">
+          タグは最大{MAX_TAGS_PER_INTERVIEW}個まで追加できます
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,5 @@
 /**
- * analyze API が返す4カテゴリに対応するラベル定義。
- * result-content.tsx / growth/page.tsx で共通利用する。
+ * analyze API labels
  */
 export const CATEGORY_LABELS: Record<string, string> = {
   communication: "コミュニケーション",
@@ -8,3 +7,25 @@ export const CATEGORY_LABELS: Record<string, string> = {
   manner: "マナー",
   logic: "論理性",
 };
+
+export const TAG_COLORS = [
+  { value: "blue", label: "ブルー", bg: "bg-blue-100 dark:bg-blue-900/40", text: "text-blue-800 dark:text-blue-200", dot: "bg-blue-500" },
+  { value: "green", label: "グリーン", bg: "bg-green-100 dark:bg-green-900/40", text: "text-green-800 dark:text-green-200", dot: "bg-green-500" },
+  { value: "purple", label: "パープル", bg: "bg-purple-100 dark:bg-purple-900/40", text: "text-purple-800 dark:text-purple-200", dot: "bg-purple-500" },
+  { value: "orange", label: "オレンジ", bg: "bg-orange-100 dark:bg-orange-900/40", text: "text-orange-800 dark:text-orange-200", dot: "bg-orange-500" },
+  { value: "pink", label: "ピンク", bg: "bg-pink-100 dark:bg-pink-900/40", text: "text-pink-800 dark:text-pink-200", dot: "bg-pink-500" },
+  { value: "cyan", label: "シアン", bg: "bg-cyan-100 dark:bg-cyan-900/40", text: "text-cyan-800 dark:text-cyan-200", dot: "bg-cyan-500" },
+] as const;
+
+export type TagColor = (typeof TAG_COLORS)[number]["value"];
+
+export function getTagColorConfig(color: string) {
+  return TAG_COLORS.find((c) => c.value === color) ?? TAG_COLORS[0];
+}
+
+export const PRESET_TAGS = [
+  "1次面接", "2次面接", "最終面接", "GD", "ケース面接", "オンライン", "対面",
+] as const;
+
+export const MAX_TAGS_PER_INTERVIEW = 10;
+export const MAX_NOTES_LENGTH = 1000;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -185,6 +185,7 @@ export interface Database {
           interview_date: string | null;
           transcript: string | null;
           transcript_char_count: number;
+          notes: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -202,6 +203,7 @@ export interface Database {
           interview_date?: string | null;
           transcript?: string | null;
           transcript_char_count?: number;
+          notes?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -219,6 +221,7 @@ export interface Database {
           interview_date?: string | null;
           transcript?: string | null;
           transcript_char_count?: number;
+          notes?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -305,6 +308,45 @@ export interface Database {
           raw_response?: Json | null;
           model_version?: string | null;
           created_at?: string;
+        };
+      };
+
+      tags: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          color: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          color?: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          color?: string;
+          created_at?: string;
+        };
+      };
+
+      interview_tags: {
+        Row: {
+          interview_id: string;
+          tag_id: string;
+        };
+        Insert: {
+          interview_id: string;
+          tag_id: string;
+        };
+        Update: {
+          interview_id?: string;
+          tag_id?: string;
         };
       };
 

--- a/supabase/migrations/00005_tags_and_notes.sql
+++ b/supabase/migrations/00005_tags_and_notes.sql
@@ -1,0 +1,32 @@
+-- Issue #79: tags and notes
+ALTER TABLE interviews ADD COLUMN IF NOT EXISTS notes TEXT;
+
+CREATE TABLE IF NOT EXISTS tags (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  color TEXT NOT NULL DEFAULT 'blue',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS interview_tags (
+  interview_id UUID NOT NULL REFERENCES interviews(id) ON DELETE CASCADE,
+  tag_id UUID NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (interview_id, tag_id)
+);
+
+ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tags_select_own" ON tags FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "tags_insert_own" ON tags FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "tags_update_own" ON tags FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "tags_delete_own" ON tags FOR DELETE USING (auth.uid() = user_id);
+
+ALTER TABLE interview_tags ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "interview_tags_select_own" ON interview_tags FOR SELECT USING (EXISTS (SELECT 1 FROM interviews WHERE interviews.id = interview_tags.interview_id AND interviews.user_id = auth.uid()));
+CREATE POLICY "interview_tags_insert_own" ON interview_tags FOR INSERT WITH CHECK (EXISTS (SELECT 1 FROM interviews WHERE interviews.id = interview_tags.interview_id AND interviews.user_id = auth.uid()));
+CREATE POLICY "interview_tags_delete_own" ON interview_tags FOR DELETE USING (EXISTS (SELECT 1 FROM interviews WHERE interviews.id = interview_tags.interview_id AND interviews.user_id = auth.uid()));
+
+CREATE INDEX IF NOT EXISTS idx_tags_user_id ON tags(user_id);
+CREATE INDEX IF NOT EXISTS idx_interview_tags_interview_id ON interview_tags(interview_id);
+CREATE INDEX IF NOT EXISTS idx_interview_tags_tag_id ON interview_tags(tag_id);


### PR DESCRIPTION
## Summary
- 面接にタグとメモを付与できる機能を追加
- DBマイグレーション（notes カラム、tags テーブル、interview_tags テーブル + RLS）
- タグのCRUD API、面接タグ割り当て API、メモ保存 API
- タグバッジ、タグセレクター（プリセット・カラーピッカー付き）、メモエディター（1秒デバウンスの自動保存）
- ダッシュボードでのタグフィルタリング、面接カードでのタグ表示

## Changes
- **DB**: `supabase/migrations/00005_tags_and_notes.sql` - notes カラム追加、tags/interview_tags テーブル作成、RLSポリシー
- **Types**: `src/types/database.ts` - notes フィールド、tags/interview_tags テーブル型追加
- **API**: 
  - `GET/POST /api/tags` - ユーザーのタグ一覧取得・作成
  - `GET/PUT /api/interviews/[id]/tags` - 面接タグ取得・更新
  - `PUT /api/interviews/[id]/notes` - メモ保存
- **Components**: `tag-badge.tsx`, `tag-selector.tsx`, `notes-editor.tsx`
- **Integration**: 結果ページ、ダッシュボード、面接カードに統合

## Test plan
- [ ] タグの作成・選択・削除が正常に動作する
- [ ] プリセットタグからの追加が動作する
- [ ] カスタムタグ作成でカラーピッカーが動作する
- [ ] メモの自動保存（1秒デバウンス）が動作する
- [ ] ダッシュボードでタグフィルタリングが動作する
- [ ] 面接カードにタグバッジが表示される
- [ ] タグ最大10個の制限が動作する
- [ ] `npm run build` が成功する

closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)