### PR TITLE
feat: #70 OGP画像 + #73 日付範囲フィルタ

### DIFF
--- a/src/app/api/export/csv/route.ts
+++ b/src/app/api/export/csv/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/types/database";
 
@@ -46,10 +46,15 @@ function escapeCsvValue(value: string): string {
   return escaped;
 }
 
+/** ISO 8601 日付形式の検証（YYYY-MM-DD） */
+function isValidDateString(dateStr: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(dateStr) && !isNaN(Date.parse(dateStr));
+}
+
 /** 最大エクスポート件数 */
 const MAX_EXPORT_ROWS = 100;
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
 
@@ -65,11 +70,46 @@ export async function GET() {
       );
     }
 
+    // 日付範囲パラメータの取得・バリデーション
+    const { searchParams } = new URL(request.url);
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+
+    if (from && !isValidDateString(from)) {
+      return NextResponse.json(
+        { error: "開始日の形式が不正です（YYYY-MM-DD）" },
+        { status: 400 }
+      );
+    }
+
+    if (to && !isValidDateString(to)) {
+      return NextResponse.json(
+        { error: "終了日の形式が不正です（YYYY-MM-DD）" },
+        { status: 400 }
+      );
+    }
+
+    if (from && to && from > to) {
+      return NextResponse.json(
+        { error: "開始日は終了日より前に設定してください" },
+        { status: 400 }
+      );
+    }
+
     // 面接データ取得（user_id でフィルタ、最大100件）
-    const { data: interviewsData, error: interviewsError } = await supabase
+    let query = supabase
       .from("interviews")
       .select("*")
-      .eq("user_id", user.id)
+      .eq("user_id", user.id);
+
+    if (from) {
+      query = query.gte("interview_date", from);
+    }
+    if (to) {
+      query = query.lte("interview_date", to);
+    }
+
+    const { data: interviewsData, error: interviewsError } = await query
       .order("interview_date", { ascending: false, nullsFirst: false })
       .limit(MAX_EXPORT_ROWS);
 

--- a/src/app/api/export/pdf/route.ts
+++ b/src/app/api/export/pdf/route.ts
@@ -25,6 +25,11 @@ const ROUND_MAP: Record<string, string> = {
   other: "その他",
 };
 
+/** ISO 8601 日付形式の検証（YYYY-MM-DD） */
+function isValidDateString(dateStr: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(dateStr) && !isNaN(Date.parse(dateStr));
+}
+
 /** 最大エクスポート件数 */
 const MAX_EXPORT_ROWS = 100;
 
@@ -203,9 +208,33 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // クエリパラメータ: 特定の面接 ID（任意）
+    // クエリパラメータ: 特定の面接 ID（任意）、日付範囲（任意）
     const { searchParams } = new URL(request.url);
     const interviewId = searchParams.get("id");
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+
+    // 日付バリデーション
+    if (from && !isValidDateString(from)) {
+      return NextResponse.json(
+        { error: "開始日の形式が不正です（YYYY-MM-DD）" },
+        { status: 400 }
+      );
+    }
+
+    if (to && !isValidDateString(to)) {
+      return NextResponse.json(
+        { error: "終了日の形式が不正です（YYYY-MM-DD）" },
+        { status: 400 }
+      );
+    }
+
+    if (from && to && from > to) {
+      return NextResponse.json(
+        { error: "開始日は終了日より前に設定してください" },
+        { status: 400 }
+      );
+    }
 
     let interviews: Interview[] = [];
     const feedbackMap = new Map<string, Feedback>();
@@ -228,11 +257,20 @@ export async function GET(request: NextRequest) {
 
       interviews = [interviewData as Interview];
     } else {
-      // 全件取得（最大100件）
-      const { data: interviewsData, error: interviewsError } = await supabase
+      // 全件取得（最大100件）、日付範囲フィルタ対応
+      let query = supabase
         .from("interviews")
         .select("*")
-        .eq("user_id", user.id)
+        .eq("user_id", user.id);
+
+      if (from) {
+        query = query.gte("interview_date", from);
+      }
+      if (to) {
+        query = query.lte("interview_date", to);
+      }
+
+      const { data: interviewsData, error: interviewsError } = await query
         .order("interview_date", { ascending: false, nullsFirst: false })
         .limit(MAX_EXPORT_ROWS);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,11 +33,20 @@ export const metadata: Metadata = {
     locale: "ja_JP",
     url: siteUrl,
     siteName,
+    images: [
+      {
+        url: "/opengraph-image.png",
+        width: 1200,
+        height: 630,
+        alt: "InterviewCoach - AI面接フィードバック",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: siteName,
     description: defaultDescription,
+    images: ["/opengraph-image.png"],
   },
   robots: {
     index: true,

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,150 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "InterviewCoach - AI面接フィードバック";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #1e3a5f 0%, #0f172a 50%, #1e293b 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* 背景装飾 */}
+        <div
+          style={{
+            position: "absolute",
+            top: "-100px",
+            right: "-100px",
+            width: "400px",
+            height: "400px",
+            borderRadius: "50%",
+            background: "radial-gradient(circle, rgba(59,130,246,0.3) 0%, transparent 70%)",
+            display: "flex",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: "-80px",
+            left: "-80px",
+            width: "300px",
+            height: "300px",
+            borderRadius: "50%",
+            background: "radial-gradient(circle, rgba(139,92,246,0.2) 0%, transparent 70%)",
+            display: "flex",
+          }}
+        />
+
+        {/* ロゴ・サービス名 */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            marginBottom: "24px",
+          }}
+        >
+          <div
+            style={{
+              width: "64px",
+              height: "64px",
+              borderRadius: "16px",
+              background: "linear-gradient(135deg, #3b82f6, #8b5cf6)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "32px",
+              color: "#fff",
+              fontWeight: 700,
+            }}
+          >
+            IC
+          </div>
+          <span
+            style={{
+              fontSize: "48px",
+              fontWeight: 700,
+              color: "#ffffff",
+              letterSpacing: "-1px",
+            }}
+          >
+            InterviewCoach
+          </span>
+        </div>
+
+        {/* キャッチコピー */}
+        <div
+          style={{
+            fontSize: "28px",
+            color: "#94a3b8",
+            textAlign: "center",
+            maxWidth: "800px",
+            lineHeight: 1.6,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <span style={{ marginBottom: "8px" }}>
+            AI面接フィードバックで、就活を成功に導く
+          </span>
+        </div>
+
+        {/* 特徴タグ */}
+        <div
+          style={{
+            display: "flex",
+            gap: "16px",
+            marginTop: "40px",
+          }}
+        >
+          {["AI分析", "成長トラッキング", "パーソナライズ"].map((tag) => (
+            <div
+              key={tag}
+              style={{
+                padding: "10px 24px",
+                borderRadius: "999px",
+                border: "1px solid rgba(148,163,184,0.3)",
+                color: "#cbd5e1",
+                fontSize: "18px",
+                background: "rgba(255,255,255,0.05)",
+                display: "flex",
+              }}
+            >
+              {tag}
+            </div>
+          ))}
+        </div>
+
+        {/* フッター */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: "24px",
+            fontSize: "16px",
+            color: "#64748b",
+            display: "flex",
+          }}
+        >
+          interviewcoach.jp
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,6 +31,14 @@ export const metadata: Metadata = {
     description:
       "面接練習の録音をAIが分析し、回答内容・話し方の両面からフィードバックを自動生成。新卒就活を成功に導くAI面接コーチ。",
     url: "https://interviewcoach.jp",
+    images: [
+      {
+        url: "/opengraph-image.png",
+        width: 1200,
+        height: 630,
+        alt: "InterviewCoach - AI面接フィードバック",
+      },
+    ],
   },
 };
 

--- a/src/components/export-buttons.tsx
+++ b/src/components/export-buttons.tsx
@@ -1,20 +1,36 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Download, Printer, FileDown, Loader2 } from "lucide-react";
+import { Download, Printer, FileDown, Loader2, CalendarDays } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 interface ExportButtonsProps {
   /** 特定の面接IDを指定（個別レポートの場合） */
   interviewId?: string;
   /** ドロップダウン形式で表示するか（ダッシュボード用） */
   variant?: "dropdown" | "inline";
+}
+
+/** 日付パラメータをクエリ文字列に変換 */
+function buildDateParams(from: string, to: string): string {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
 }
 
 export function ExportButtons({
@@ -24,14 +40,24 @@ export function ExportButtons({
   const [csvLoading, setCsvLoading] = useState(false);
   const [pdfLoading, setPdfLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
 
   /** CSV ダウンロード */
   const handleCsvExport = async () => {
     setCsvLoading(true);
     setError(null);
 
+    // 日付バリデーション
+    if (dateFrom && dateTo && dateFrom > dateTo) {
+      setError("開始日は終了日より前に設定してください");
+      setCsvLoading(false);
+      return;
+    }
+
     try {
-      const response = await fetch("/api/export/csv");
+      const dateParams = buildDateParams(dateFrom, dateTo);
+      const response = await fetch(`/api/export/csv${dateParams}`);
 
       if (!response.ok) {
         const data = await response.json().catch(() => null);
@@ -66,10 +92,24 @@ export function ExportButtons({
     setPdfLoading(true);
     setError(null);
 
+    // 日付バリデーション
+    if (dateFrom && dateTo && dateFrom > dateTo) {
+      setError("開始日は終了日より前に設定してください");
+      setPdfLoading(false);
+      return;
+    }
+
     try {
-      const url = interviewId
+      const dateParams = buildDateParams(dateFrom, dateTo);
+      const baseUrl = interviewId
         ? `/api/export/pdf?id=${encodeURIComponent(interviewId)}`
-        : "/api/export/pdf";
+        : `/api/export/pdf${dateParams}`;
+
+      // interviewId がある場合は日付パラメータを追加
+      const url =
+        interviewId && dateParams
+          ? `${baseUrl}&${dateParams.slice(1)}`
+          : baseUrl;
 
       window.open(url, "_blank");
     } catch {
@@ -115,40 +155,105 @@ export function ExportButtons({
     );
   }
 
+  /** 日付範囲ピッカー */
+  const dateRangePicker = (
+    <div className="flex items-center gap-2">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm">
+            <CalendarDays className="mr-2 h-4 w-4" />
+            {dateFrom || dateTo
+              ? `${dateFrom || "..."} ~ ${dateTo || "..."}`
+              : "期間指定"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-4" align="end">
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="export-date-from" className="text-xs text-muted-foreground">
+                開始日
+              </Label>
+              <Input
+                id="export-date-from"
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="export-date-to" className="text-xs text-muted-foreground">
+                終了日
+              </Label>
+              <Input
+                id="export-date-to"
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            {dateFrom && dateTo && dateFrom > dateTo && (
+              <p className="text-xs text-red-500">
+                開始日は終了日より前に設定してください
+              </p>
+            )}
+            {(dateFrom || dateTo) && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 w-full text-xs"
+                onClick={() => {
+                  setDateFrom("");
+                  setDateTo("");
+                }}
+              >
+                期間をクリア
+              </Button>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+
   return (
     <div className="relative">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm">
-            <FileDown className="mr-2 h-4 w-4" />
-            エクスポート
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onClick={handleCsvExport}
-            disabled={csvLoading}
-          >
-            {csvLoading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Download className="mr-2 h-4 w-4" />
-            )}
-            CSV ダウンロード
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={handlePdfExport}
-            disabled={pdfLoading}
-          >
-            {pdfLoading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Printer className="mr-2 h-4 w-4" />
-            )}
-            PDF 印刷
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className="flex items-center gap-2">
+        {dateRangePicker}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm">
+              <FileDown className="mr-2 h-4 w-4" />
+              エクスポート
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={handleCsvExport}
+              disabled={csvLoading}
+            >
+              {csvLoading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="mr-2 h-4 w-4" />
+              )}
+              CSV ダウンロード
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={handlePdfExport}
+              disabled={pdfLoading}
+            >
+              {pdfLoading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Printer className="mr-2 h-4 w-4" />
+              )}
+              PDF 印刷
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
       {error && (
         <div className="absolute top-full right-0 z-50 mt-2 w-max max-w-xs rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400">
           {error}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}


### PR DESCRIPTION
## Summary

- **#70 OGP画像未設定**: `next/og` の `ImageResponse` を使ってOGP画像(1200x630)をプログラム生成。`layout.tsx` / `page.tsx` に `openGraph.images` と `twitter.images` を追加
- **#73 日付範囲フィルタ**: CSV/PDF エクスポートAPIに `from` / `to` クエリパラメータを追加。UI側に日付範囲ピッカー(Popover)を実装

## Changes

### #70 OGP画像
- `src/app/opengraph-image.tsx` — OGP画像をEdge Runtimeで動的生成
- `src/app/layout.tsx` — openGraph.images / twitter.images を追加
- `src/app/page.tsx` — openGraph.images を追加

### #73 日付範囲フィルタ
- `src/app/api/export/csv/route.ts` — from/to パラメータ対応、バリデーション追加
- `src/app/api/export/pdf/route.ts` — from/to パラメータ対応、バリデーション追加
- `src/components/export-buttons.tsx` — 日付範囲ピッカーUI追加
- `src/components/ui/popover.tsx` — shadcn/ui Popover コンポーネント追加

## Test plan
- [ ] `npm run build` 成功を確認済み
- [ ] OGP画像: `/opengraph-image` にアクセスして画像が表示されること
- [ ] Twitter Card Validator / Facebook Debugger で確認
- [ ] エクスポート: 日付範囲未指定で全件エクスポートされること（後方互換）
- [ ] エクスポート: from/to 指定で期間内データのみ取得されること
- [ ] 不正な日付範囲（from > to）でバリデーションエラーが返ること

closes #70, closes #73