### PR TITLE
feat: #84 パフォーマンス最適化（Core Web Vitals 改善）

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,10 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // 画像最適化: WebP/AVIF フォーマットに対応
+  images: {
+    formats: ["image/avif", "image/webp"],
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/src/app/api/subscription/route.ts
+++ b/src/app/api/subscription/route.ts
@@ -15,7 +15,14 @@ export async function GET() {
     const subscription = await getUserSubscription(user.id);
     const usage = await getRemainingUsage(user.id);
 
-    return NextResponse.json({ subscription, usage });
+    return NextResponse.json(
+      { subscription, usage },
+      {
+        headers: {
+          "Cache-Control": "private, max-age=60, stale-while-revalidate=120",
+        },
+      }
+    );
   } catch (error) {
     console.error("[subscription] Error:", error);
     return NextResponse.json(

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -26,7 +26,14 @@ export async function GET() {
         { status: 500 }
       );
 
-    return NextResponse.json({ tags: data ?? [] });
+    return NextResponse.json(
+      { tags: data ?? [] },
+      {
+        headers: {
+          "Cache-Control": "private, max-age=30, stale-while-revalidate=60",
+        },
+      }
+    );
   } catch {
     return NextResponse.json(
       { error: "予期しないエラーが発生しました" },

--- a/src/app/dashboard/growth/loading.tsx
+++ b/src/app/dashboard/growth/loading.tsx
@@ -1,0 +1,62 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function GrowthLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8 animate-pulse">
+      {/* ナビゲーション */}
+      <div className="mb-6">
+        <div className="h-4 w-40 rounded bg-muted" />
+      </div>
+
+      <div className="h-8 w-32 rounded bg-muted" />
+      <div className="mt-1 h-4 w-64 rounded bg-muted" />
+
+      {/* 統計サマリ */}
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i} className="py-4">
+            <CardContent className="flex flex-col gap-1">
+              <div className="h-4 w-20 rounded bg-muted" />
+              <div className="h-8 w-16 rounded bg-muted" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* スコア推移 */}
+      <Card className="mt-8">
+        <CardHeader>
+          <div className="h-6 w-48 rounded bg-muted" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <div className="h-4 w-16 rounded bg-muted" />
+                <div className="h-7 flex-1 rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* カテゴリ別・企業別 */}
+      <div className="mt-8 grid gap-8 lg:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <div className="h-6 w-40 rounded bg-muted" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, j) => (
+                  <div key={j} className="h-6 w-full rounded bg-muted" />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function DashboardLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between">
+        <div className="h-8 w-32 animate-pulse rounded bg-muted" />
+        <div className="flex items-center gap-2">
+          <div className="h-9 w-[180px] animate-pulse rounded-md bg-muted" />
+          <div className="h-9 w-[160px] animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+
+      {/* フィルタ */}
+      <div className="mt-6 space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-8 w-20 animate-pulse rounded-md bg-muted"
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* カード一覧 */}
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="animate-pulse">
+            <CardHeader className="pb-2">
+              <div className="h-5 w-3/4 rounded bg-muted" />
+              <div className="mt-2 flex gap-1.5">
+                <div className="h-5 w-16 rounded-full bg-muted" />
+                <div className="h-5 w-12 rounded-full bg-muted" />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="h-4 w-1/2 rounded bg-muted" />
+              <div className="space-y-1.5">
+                <div className="flex justify-between">
+                  <div className="h-3 w-16 rounded bg-muted" />
+                  <div className="h-3 w-10 rounded bg-muted" />
+                </div>
+                <div className="h-1.5 w-full rounded-full bg-muted" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Suspense } from "react";
 import { Plus, ClipboardList } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
@@ -62,7 +63,8 @@ export default async function DashboardPage({
     : "date_desc";
 
   // --- データ取得 ---
-  let interviewQuery = supabase.from("interviews").select("*").eq("user_id", user.id);
+  // 必要なカラムのみ取得してレスポンスサイズを削減
+  let interviewQuery = supabase.from("interviews").select("id, title, company_name_snapshot, interview_category, interview_round, interview_date, status").eq("user_id", user.id);
 
   if (currentCategory !== "all") {
     interviewQuery = interviewQuery.eq("interview_category", currentCategory);
@@ -168,7 +170,9 @@ export default async function DashboardPage({
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">面接履歴</h1>
         <div className="flex items-center gap-2">
-          <ExportButtons variant="dropdown" />
+          <Suspense fallback={<div className="h-9 w-[180px] animate-pulse rounded-md bg-muted" />}>
+            <ExportButtons variant="dropdown" />
+          </Suspense>
           <Button asChild>
             <Link href="/interview/new">
               <Plus className="mr-2 h-4 w-4" />

--- a/src/app/interview/[id]/result/loading.tsx
+++ b/src/app/interview/[id]/result/loading.tsx
@@ -1,0 +1,79 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function ResultLoading() {
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-8 animate-pulse">
+      {/* ヘッダー */}
+      <div className="mb-6 flex items-center gap-4">
+        <div className="h-9 w-48 rounded-md bg-muted" />
+        <div className="h-8 flex-1 rounded bg-muted" />
+        <div className="h-9 w-[140px] rounded-md bg-muted" />
+      </div>
+
+      {/* タグ・メモセクション */}
+      <Card className="mb-6">
+        <CardContent className="space-y-6 pt-6">
+          <div className="space-y-2">
+            <div className="h-4 w-16 rounded bg-muted" />
+            <div className="h-8 w-full rounded bg-muted" />
+          </div>
+          <div className="border-t pt-4">
+            <div className="space-y-2">
+              <div className="h-4 w-16 rounded bg-muted" />
+              <div className="h-24 w-full rounded bg-muted" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* スコア & カテゴリ別スコア */}
+      <div className="mb-6 grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardContent className="flex flex-col items-center py-6">
+            <div className="flex flex-col items-center gap-3 rounded-xl p-8">
+              <div className="h-4 w-20 rounded bg-muted" />
+              <div className="h-20 w-24 rounded bg-muted" />
+              <div className="h-3 w-12 rounded bg-muted" />
+              <div className="h-2 w-48 rounded-full bg-muted" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="h-6 w-40 rounded bg-muted" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="space-y-1">
+                <div className="flex justify-between">
+                  <div className="h-4 w-24 rounded bg-muted" />
+                  <div className="h-4 w-10 rounded bg-muted" />
+                </div>
+                <div className="h-3 w-full rounded-full bg-muted" />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 良い点 & 改善点 */}
+      <div className="mb-6 grid gap-4 sm:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <div className="h-6 w-24 rounded bg-muted" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {Array.from({ length: 3 }).map((_, j) => (
+                  <div key={j} className="h-4 w-full rounded bg-muted" />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { ArrowLeft, CheckCircle2, AlertTriangle, Lightbulb } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -16,9 +17,43 @@ import type { Database } from "@/types/supabase";
 import type { Json } from "@/types/supabase";
 import type { CategoryScores } from "@/types/database";
 import { CATEGORY_LABELS } from "@/lib/constants";
-import { ExportButtons } from "@/components/export-buttons";
-import { TagSelector } from "@/components/tag-selector";
-import { NotesEditor } from "@/components/notes-editor";
+
+// 動的インポート: 初期表示に不要なインタラクティブコンポーネントを遅延ロード
+const ExportButtons = dynamic(
+  () => import("@/components/export-buttons").then((mod) => mod.ExportButtons),
+  {
+    loading: () => (
+      <div className="h-9 w-[140px] animate-pulse rounded-md bg-muted" />
+    ),
+    ssr: false,
+  }
+);
+
+const TagSelector = dynamic(
+  () => import("@/components/tag-selector").then((mod) => mod.TagSelector),
+  {
+    loading: () => (
+      <div className="space-y-2">
+        <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+        <div className="h-8 w-full animate-pulse rounded bg-muted" />
+      </div>
+    ),
+    ssr: false,
+  }
+);
+
+const NotesEditor = dynamic(
+  () => import("@/components/notes-editor").then((mod) => mod.NotesEditor),
+  {
+    loading: () => (
+      <div className="space-y-2">
+        <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+        <div className="h-24 w-full animate-pulse rounded bg-muted" />
+      </div>
+    ),
+    ssr: false,
+  }
+);
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Transcript = Database["public"]["Tables"]["transcripts"]["Row"];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,11 +7,13 @@ import { Footer } from "@/components/footer";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const siteUrl = "https://interviewcoach.jp";
@@ -61,6 +63,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
+      <head>
+        {/* Supabase への接続を事前確立して LCP を改善 */}
+        <link
+          rel="dns-prefetch"
+          href={`https://${process.env.NEXT_PUBLIC_SUPABASE_URL?.replace("https://", "") ?? ""}`}
+        />
+        <link
+          rel="preconnect"
+          href={`https://${process.env.NEXT_PUBLIC_SUPABASE_URL?.replace("https://", "") ?? ""}`}
+          crossOrigin="anonymous"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
## Summary
- **画像最適化**: `next.config.ts` に AVIF/WebP フォーマット設定を追加
- **フォント最適化**: `display: "swap"` を追加し FOIT を防止、外部接続の `dns-prefetch`/`preconnect` を設定
- **動的インポート**: `ExportButtons`、`TagSelector`、`NotesEditor` を `next/dynamic` で遅延ロードし初期バンドルサイズを削減
- **Supabase クエリ最適化**: ダッシュボードで必要カラムのみ `select()` してレスポンスサイズを削減
- **ストリーミング SSR**: `loading.tsx` を主要3ページに追加しスケルトン UI を表示
- **API キャッシュ**: `tags` / `subscription` API に `Cache-Control` ヘッダーを追加

closes #84

## Test plan
- [ ] `npm run build` がエラーなく成功すること
- [ ] ダッシュボード、成長記録、面接結果ページが正常に表示されること
- [ ] ExportButtons、TagSelector、NotesEditor が遅延ロード後に正常動作すること
- [ ] loading.tsx のスケルトン UI がページ読み込み中に表示されること
- [ ] Lighthouse Performance スコアの改善を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)