### PR TITLE
fix: #99 #100 Sprint 5 バグ修正

### DIFF
--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -10,6 +10,10 @@ import { createClient } from "@/lib/supabase/server";
 /** デフォルトの有効期限: 7日間 */
 const DEFAULT_EXPIRY_DAYS = 7;
 
+/** expiryDays の許容範囲 */
+const MIN_EXPIRY_DAYS = 1;
+const MAX_EXPIRY_DAYS = 90;
+
 /** 既存共有リンクの型 */
 interface ExistingShare {
   id: string;
@@ -103,8 +107,14 @@ export async function POST(request: Request) {
     // 共有トークン生成（crypto.randomUUID は URL-safe）
     const shareToken = crypto.randomUUID();
 
-    // 有効期限を計算
-    const days = expiryDays ?? DEFAULT_EXPIRY_DAYS;
+    // 有効期限を計算（型チェック・範囲チェック付き）
+    const days =
+      typeof expiryDays === "number" &&
+      Number.isFinite(expiryDays) &&
+      expiryDays >= MIN_EXPIRY_DAYS &&
+      expiryDays <= MAX_EXPIRY_DAYS
+        ? Math.floor(expiryDays)
+        : DEFAULT_EXPIRY_DAYS;
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + days);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
         <link
           rel="preconnect"
           href={`https://${process.env.NEXT_PUBLIC_SUPABASE_URL?.replace("https://", "") ?? ""}`}
-          crossOrigin="anonymous"
+          crossOrigin="use-credentials"
         />
       </head>
       <body


### PR DESCRIPTION
## Summary

- **#99 共有API expiryDays バリデーション追加**: `POST /api/share` の `expiryDays` パラメータに型チェック (`typeof`, `Number.isFinite`)、範囲チェック (1-90日)、整数化 (`Math.floor`) を追加。不正値はデフォルト値 (7日) にフォールバック
- **#100 preconnect crossOrigin 修正**: `src/app/layout.tsx` の `<link rel="preconnect">` の `crossOrigin` を `anonymous` から `use-credentials` に変更。Supabase API は認証トークン (Cookie) を含むため適切な設定に修正

closes #99, closes #100

## Test plan

- [ ] `POST /api/share` に `expiryDays: -1` を送信 → デフォルト値 (7日) が適用されることを確認
- [ ] `POST /api/share` に `expiryDays: 999` を送信 → デフォルト値 (7日) が適用されることを確認
- [ ] `POST /api/share` に `expiryDays: "abc"` を送信 → デフォルト値 (7日) が適用されることを確認
- [ ] `POST /api/share` に `expiryDays: 30` を送信 → 30日が適用されることを確認
- [ ] `POST /api/share` に `expiryDays` なしで送信 → デフォルト値 (7日) が適用されることを確認
- [ ] ブラウザ DevTools で preconnect ヘッダーの crossOrigin が `use-credentials` になっていることを確認
- [ ] `npm run build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)