### PR TITLE
feat: #81 分析完了通知（ブラウザ通知・アプリ内トースト）

### DIFF
--- a/src/app/interview/[id]/processing/page.tsx
+++ b/src/app/interview/[id]/processing/page.tsx
@@ -12,10 +12,13 @@ import {
   FileText,
   Brain,
   PartyPopper,
+  CheckCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { createClient } from "@/lib/supabase/client";
+import { NotificationPrompt } from "@/components/notification-prompt";
+import { sendAnalysisCompleteNotification } from "@/lib/notifications";
 import type { Database } from "@/types/supabase";
 
 type InterviewStatus =
@@ -82,7 +85,9 @@ export default function ProcessingPage({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const analyzeCalledRef = useRef(false);
+  const notifiedRef = useRef(false);
 
   // AI分析 API を呼び出す関数
   const triggerAnalysis = useCallback(async () => {
@@ -160,9 +165,20 @@ export default function ProcessingPage({
         }
 
         if (status === "completed") {
+          // ブラウザ通知を送信（1回のみ）
+          if (!notifiedRef.current) {
+            notifiedRef.current = true;
+            const sent = sendAnalysisCompleteNotification(id, (url) => {
+              router.push(url);
+            });
+            // ブラウザ通知が送信できなかった場合、アプリ内トーストでフォールバック
+            if (!sent) {
+              setToastMessage("分析が完了しました！結果ページに移動します...");
+            }
+          }
           setTimeout(() => {
             router.push(`/interview/${id}/result`);
-          }, 1000);
+          }, 2000);
           return;
         }
 
@@ -228,6 +244,17 @@ export default function ProcessingPage({
   return (
     <div className="container mx-auto max-w-2xl px-4 py-8">
       <h1 className="mb-8 text-2xl font-bold text-center">処理ステータス</h1>
+
+      {/* アプリ内トースト通知（ブラウザ通知のフォールバック） */}
+      {toastMessage && (
+        <div
+          className="mb-6 flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800"
+          role="alert"
+        >
+          <CheckCircle className="h-5 w-5 shrink-0" />
+          <span className="text-sm font-medium">{toastMessage}</span>
+        </div>
+      )}
 
       <Card>
         <CardHeader>
@@ -347,6 +374,11 @@ export default function ProcessingPage({
       <p className="mt-4 text-center text-xs text-muted-foreground">
         5秒ごとに自動更新されます。このページを閉じても処理は続行されます。
       </p>
+
+      {/* 通知許可リクエスト（処理中のみ表示） */}
+      {!isError && !isLoading && currentStatus !== "completed" && (
+        <NotificationPrompt />
+      )}
     </div>
   );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -14,7 +14,14 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, Save, X, CheckCircle, AlertCircle } from "lucide-react";
+import { Loader2, Save, X, CheckCircle, AlertCircle, Bell, BellOff } from "lucide-react";
+import {
+  isNotificationSupported,
+  getNotificationPermission,
+  requestNotificationPermission,
+  isNotificationEnabled,
+  setNotificationEnabled as setNotificationEnabledStorage,
+} from "@/lib/notifications";
 import type { Database } from "@/types/database";
 
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
@@ -107,6 +114,22 @@ export default function ProfilePage() {
   const [preferredWorkLocation, setPreferredWorkLocation] = useState<string[]>(
     []
   );
+
+  // 通知設定
+  const [notificationSupported, setNotificationSupported] = useState(false);
+  const [notificationPermission, setNotificationPermission] =
+    useState<NotificationPermission | null>(null);
+  const [notificationEnabled, setNotificationEnabledState] = useState(true);
+
+  // 通知状態の初期化
+  useEffect(() => {
+    const supported = isNotificationSupported();
+    setNotificationSupported(supported);
+    if (supported) {
+      setNotificationPermission(getNotificationPermission());
+      setNotificationEnabledState(isNotificationEnabled());
+    }
+  }, []);
 
   // トースト自動非表示
   useEffect(() => {
@@ -563,6 +586,108 @@ export default function ProfilePage() {
                   )}
                 </div>
               </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* 通知設定 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>通知設定</CardTitle>
+            <CardDescription>
+              分析完了時の通知方法を設定してください
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {notificationSupported ? (
+              <>
+                {/* ブラウザ通知の許可状態 */}
+                <div className="flex items-center justify-between rounded-lg border p-4">
+                  <div className="flex items-center gap-3">
+                    {notificationEnabled && notificationPermission === "granted" ? (
+                      <Bell className="h-5 w-5 text-primary" />
+                    ) : (
+                      <BellOff className="h-5 w-5 text-muted-foreground" />
+                    )}
+                    <div>
+                      <p className="text-sm font-medium">ブラウザ通知</p>
+                      <p className="text-xs text-muted-foreground">
+                        {notificationPermission === "granted"
+                          ? "分析完了時にブラウザ通知を送信します"
+                          : notificationPermission === "denied"
+                            ? "ブラウザの設定で通知がブロックされています"
+                            : "通知許可が必要です"}
+                      </p>
+                    </div>
+                  </div>
+                  <div>
+                    {notificationPermission === "granted" ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const next = !notificationEnabled;
+                          setNotificationEnabledState(next);
+                          setNotificationEnabledStorage(next);
+                        }}
+                        role="switch"
+                        aria-checked={notificationEnabled}
+                        aria-label="ブラウザ通知の切り替え"
+                        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                          notificationEnabled ? "bg-primary" : "bg-muted"
+                        }`}
+                      >
+                        <span
+                          className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                            notificationEnabled
+                              ? "translate-x-5"
+                              : "translate-x-0"
+                          }`}
+                        />
+                      </button>
+                    ) : notificationPermission === "denied" ? (
+                      <span className="text-xs text-muted-foreground">
+                        ブロック中
+                      </span>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={async () => {
+                          const perm = await requestNotificationPermission();
+                          setNotificationPermission(perm);
+                          if (perm === "granted") {
+                            setNotificationEnabledState(true);
+                            setNotificationEnabledStorage(true);
+                          }
+                        }}
+                      >
+                        許可する
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                {/* アプリ内通知（常に有効） */}
+                <div className="flex items-center justify-between rounded-lg border p-4">
+                  <div className="flex items-center gap-3">
+                    <Bell className="h-5 w-5 text-primary" />
+                    <div>
+                      <p className="text-sm font-medium">アプリ内通知</p>
+                      <p className="text-xs text-muted-foreground">
+                        ブラウザ通知が利用できない場合のフォールバック
+                      </p>
+                    </div>
+                  </div>
+                  <span className="text-xs font-medium text-primary">
+                    常にON
+                  </span>
+                </div>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                お使いのブラウザはブラウザ通知に対応していません。分析完了時はアプリ内で通知されます。
+              </p>
             )}
           </CardContent>
         </Card>

--- a/src/components/notification-prompt.tsx
+++ b/src/components/notification-prompt.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Bell, BellOff, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  isNotificationSupported,
+  getNotificationPermission,
+  requestNotificationPermission,
+  isNotificationEnabled,
+  setNotificationEnabled,
+} from "@/lib/notifications";
+
+type PromptState = "idle" | "granted" | "denied" | "unsupported";
+
+/**
+ * 通知許可リクエストコンポーネント
+ *
+ * 分析処理待ちページで表示。
+ * - ブラウザが通知非対応の場合は非表示
+ * - 既に許可済みの場合は「通知ON」状態を表示
+ * - 拒否済みの場合はブラウザ設定への案内を表示
+ */
+export function NotificationPrompt() {
+  const [state, setState] = useState<PromptState>("idle");
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    if (!isNotificationSupported()) {
+      setState("unsupported");
+      return;
+    }
+
+    const permission = getNotificationPermission();
+    if (permission === "granted") {
+      setState("granted");
+    } else if (permission === "denied") {
+      setState("denied");
+    }
+
+    setEnabled(isNotificationEnabled());
+  }, []);
+
+  const handleRequestPermission = useCallback(async () => {
+    const permission = await requestNotificationPermission();
+    if (permission === "granted") {
+      setState("granted");
+      setNotificationEnabled(true);
+      setEnabled(true);
+    } else if (permission === "denied") {
+      setState("denied");
+    }
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    const next = !enabled;
+    setEnabled(next);
+    setNotificationEnabled(next);
+  }, [enabled]);
+
+  // 非対応ブラウザでは何も表示しない
+  if (state === "unsupported") return null;
+
+  // 許可済み: トグルボタンを表示
+  if (state === "granted") {
+    return (
+      <div className="mt-4 flex items-center justify-center gap-2">
+        {enabled ? (
+          <button
+            onClick={handleToggle}
+            className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+            aria-label="通知を無効にする"
+          >
+            <Bell className="h-3.5 w-3.5" />
+            完了時に通知
+            <Check className="h-3.5 w-3.5" />
+          </button>
+        ) : (
+          <button
+            onClick={handleToggle}
+            className="inline-flex items-center gap-1.5 rounded-full border border-muted-foreground/20 bg-muted/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
+            aria-label="通知を有効にする"
+          >
+            <BellOff className="h-3.5 w-3.5" />
+            通知OFF
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // 拒否済み: ブラウザ設定への案内
+  if (state === "denied") {
+    return (
+      <div className="mt-4 text-center">
+        <p className="text-xs text-muted-foreground">
+          通知がブロックされています。ブラウザの設定から通知を許可してください。
+        </p>
+      </div>
+    );
+  }
+
+  // 未許可: リクエストボタン
+  return (
+    <div className="mt-4 flex justify-center">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleRequestPermission}
+        className="gap-2"
+      >
+        <Bell className="h-4 w-4" />
+        分析完了時に通知を受け取る
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,91 @@
+/**
+ * ブラウザ通知ユーティリティ
+ *
+ * Web Notifications API のラッパー。
+ * Service Worker 不要（ページがアクティブな間のみ通知を送信）。
+ */
+
+// localStorage キー
+const NOTIFICATION_ENABLED_KEY = "notification_enabled";
+
+/** ブラウザが Web Notifications API に対応しているか */
+export function isNotificationSupported(): boolean {
+  return typeof window !== "undefined" && "Notification" in window;
+}
+
+/** 現在の通知許可状態を取得 */
+export function getNotificationPermission(): NotificationPermission | null {
+  if (!isNotificationSupported()) return null;
+  return Notification.permission;
+}
+
+/** 通知許可をリクエスト */
+export async function requestNotificationPermission(): Promise<NotificationPermission | null> {
+  if (!isNotificationSupported()) return null;
+  const permission = await Notification.requestPermission();
+  return permission;
+}
+
+/** ユーザーが通知を有効にしているか（localStorage ベース） */
+export function isNotificationEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  const stored = localStorage.getItem(NOTIFICATION_ENABLED_KEY);
+  // デフォルトは true（初回は有効）
+  return stored === null ? true : stored === "true";
+}
+
+/** 通知の有効/無効を設定 */
+export function setNotificationEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(NOTIFICATION_ENABLED_KEY, String(enabled));
+}
+
+/** ブラウザ通知を送信 */
+export function sendBrowserNotification(
+  title: string,
+  options?: {
+    body?: string;
+    icon?: string;
+    tag?: string;
+    onClick?: () => void;
+  }
+): Notification | null {
+  if (!isNotificationSupported()) return null;
+  if (Notification.permission !== "granted") return null;
+  if (!isNotificationEnabled()) return null;
+
+  const notification = new Notification(title, {
+    body: options?.body,
+    icon: options?.icon ?? "/icon-192x192.png",
+    tag: options?.tag,
+  });
+
+  if (options?.onClick) {
+    notification.onclick = () => {
+      window.focus();
+      options.onClick!();
+      notification.close();
+    };
+  }
+
+  return notification;
+}
+
+/**
+ * 分析完了通知を送信するヘルパー
+ * ブラウザ通知が利用できない場合は false を返す（フォールバックの判定に使用）
+ */
+export function sendAnalysisCompleteNotification(
+  interviewId: string,
+  onNavigate: (url: string) => void
+): boolean {
+  const notification = sendBrowserNotification("分析が完了しました", {
+    body: "面接フィードバックの準備ができました。クリックして結果を確認しましょう。",
+    tag: `analysis-complete-${interviewId}`,
+    onClick: () => {
+      onNavigate(`/interview/${interviewId}/result`);
+    },
+  });
+
+  return notification !== null;
+}


### PR DESCRIPTION
## Summary
- Web Notifications API を使用したブラウザ通知機能を実装（Phase 1）
- ブラウザ通知が利用できない場合のアプリ内トースト通知フォールバック
- プロフィール設定ページに通知 ON/OFF トグルを追加

## 変更内容
### 新規ファイル
- `src/lib/notifications.ts` — 通知ユーティリティ（権限管理・通知送信・localStorage 管理）
- `src/components/notification-prompt.tsx` — 通知許可リクエスト UI コンポーネント

### 変更ファイル
- `src/app/interview/[id]/processing/page.tsx` — 分析完了時にブラウザ通知送信 + トーストフォールバック + NotificationPrompt 表示
- `src/app/profile/page.tsx` — 通知設定カード追加（ブラウザ通知トグル・アプリ内通知表示）

## 技術詳細
- Service Worker 不要（ページアクティブ時のみ通知）
- `Notification.requestPermission()` + `new Notification()` で実装
- `localStorage` の `notification_enabled` キーで有効/無効を管理
- 通知クリックでフォーカス遷移 + 結果ページへナビゲーション
- メール通知は Phase 2（本 PR のスコープ外）

## Test plan
- [ ] processing ページで「分析完了時に通知を受け取る」ボタンが表示される
- [ ] 通知許可後、分析完了時にブラウザ通知が表示される
- [ ] 通知クリックで結果ページに遷移する
- [ ] ブラウザ通知が使えない場合、アプリ内トーストが表示される
- [ ] プロフィール設定ページで通知トグルが動作する
- [ ] `npm run build` が成功する

closes #81

Generated with [Claude Code](https://claude.com/claude-code)