### PR TITLE
feat: #98 Cookie 同意バナーの実装

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,12 +1,28 @@
 import * as Sentry from "@sentry/nextjs";
 
+/**
+ * Cookie 同意状態を localStorage から取得する。
+ * sentry.client.config.ts はモジュールスコープで実行されるため、
+ * ここでは初期値のみ読み取り、同意変更後はイベントリスナーで対応する。
+ */
+function getConsentLevel(): "essential" | "all" | null {
+  if (typeof window === "undefined") return null;
+  const value = localStorage.getItem("cookie_consent");
+  if (value === "essential" || value === "all") return value;
+  return null;
+}
+
+const consentLevel = getConsentLevel();
+const hasFullConsent = consentLevel === "all";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
   enabled: process.env.NODE_ENV === "production",
   sendDefaultPii: false,
+  // セッションリプレイは「すべて許可」の場合のみ有効
   replaysSessionSampleRate: 0,
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: hasFullConsent ? 1.0 : 0,
   environment: process.env.NODE_ENV,
   beforeSend(event) {
     if (event.user) {
@@ -15,10 +31,34 @@ Sentry.init({
     }
     return event;
   },
-  integrations: [
-    Sentry.replayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
-    }),
-  ],
+  integrations: hasFullConsent
+    ? [
+        Sentry.replayIntegration({
+          maskAllText: true,
+          blockAllMedia: true,
+        }),
+      ]
+    : [],
 });
+
+/**
+ * Cookie 同意変更イベントを監視し、
+ * 「すべて許可」が選択された場合にリプレイ統合を動的に追加する。
+ */
+if (typeof window !== "undefined") {
+  window.addEventListener("cookie-consent-change", ((
+    event: CustomEvent<{ level: string }>
+  ) => {
+    if (event.detail.level === "all") {
+      const client = Sentry.getClient();
+      if (client) {
+        client.addIntegration(
+          Sentry.replayIntegration({
+            maskAllText: true,
+            blockAllMedia: true,
+          })
+        );
+      }
+    }
+  }) as EventListener);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
+import { CookieConsent } from "@/components/cookie-consent";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -83,6 +84,7 @@ export default function RootLayout({
           <main className="flex-1">{children}</main>
           <Footer />
         </div>
+        <CookieConsent />
       </body>
     </html>
   );

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+/** localStorage に保存する同意状態のキー */
+const CONSENT_KEY = "cookie_consent";
+
+/** ユーザーの Cookie 同意レベル */
+export type ConsentLevel = "essential" | "all";
+
+/**
+ * 現在の Cookie 同意状態を取得する。
+ * 同意未取得の場合は null を返す。
+ */
+export function getConsentLevel(): ConsentLevel | null {
+  if (typeof window === "undefined") return null;
+  const value = localStorage.getItem(CONSENT_KEY);
+  if (value === "essential" || value === "all") return value;
+  return null;
+}
+
+/**
+ * Cookie 同意バナー。
+ * 初回訪問時に画面下部に固定表示し、同意後は非表示にする。
+ */
+export function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // localStorage から同意状態を確認
+    const consent = getConsentLevel();
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  function handleConsent(level: ConsentLevel) {
+    localStorage.setItem(CONSENT_KEY, level);
+    setVisible(false);
+
+    // カスタムイベントを発火して Sentry など他のスクリプトに通知
+    window.dispatchEvent(
+      new CustomEvent("cookie-consent-change", { detail: { level } })
+    );
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Cookie の使用について"
+      className="fixed inset-x-0 bottom-0 z-50 border-t bg-background p-4 shadow-lg sm:p-6"
+    >
+      <div className="mx-auto flex max-w-4xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        {/* 説明テキスト */}
+        <div className="text-sm text-muted-foreground">
+          <p>
+            当サイトでは、サービスの提供・改善のために Cookie
+            を使用しています。詳しくは{" "}
+            <Link
+              href="/legal/cookies"
+              className="font-medium text-primary underline underline-offset-4 hover:no-underline"
+            >
+              Cookie ポリシー
+            </Link>{" "}
+            をご覧ください。
+          </p>
+        </div>
+
+        {/* ボタン群 */}
+        <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={() => handleConsent("essential")}
+            className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+          >
+            必須 Cookie のみ
+          </button>
+          <button
+            type="button"
+            onClick={() => handleConsent("all")}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            すべて許可
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Cookie 同意バナーコンポーネント (`CookieConsent`) を新規作成
- 画面下部に固定表示し、「必須 Cookie のみ」と「すべて許可」の2択を提供
- `localStorage` で同意状態を永続化し、同意済みの場合は非表示
- Cookie ポリシーページ (`/legal/cookies`) へのリンクを含む
- `layout.tsx` に統合して全ページ（法的ページ含む）で表示
- Sentry クライアント設定を条件付きに変更: 「すべて許可」の場合のみセッションリプレイを有効化

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `src/components/cookie-consent.tsx` | 新規 - Cookie 同意バナー Client Component |
| `src/app/layout.tsx` | `<CookieConsent />` を追加 |
| `sentry.client.config.ts` | 同意状態に応じた条件付きリプレイ統合 |

## Test plan
- [ ] 初回訪問時にバナーが画面下部に表示されること
- [ ] 「必須 Cookie のみ」をクリック → バナー非表示、`localStorage` に `essential` が保存
- [ ] 「すべて許可」をクリック → バナー非表示、`localStorage` に `all` が保存
- [ ] ページリロード後、同意済みの場合はバナーが表示されないこと
- [ ] Cookie ポリシーリンクが `/legal/cookies` に遷移すること
- [ ] モバイル表示でレスポンシブに対応していること
- [ ] 「すべて許可」選択時のみ Sentry セッションリプレイが有効化されること

closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)