### PR TITLE
feat: #102 パスワードリセット機能

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const type = searchParams.get("type");
+
+  if (code) {
+    const cookieStore = await cookies();
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return NextResponse.redirect(`${origin}/login?error=config`);
+    }
+
+    const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // Server Component からの呼び出し時は無視
+          }
+        },
+      },
+    });
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      // パスワードリカバリーの場合はパスワード更新ページにリダイレクト
+      if (type === "recovery") {
+        return NextResponse.redirect(`${origin}/update-password`);
+      }
+      // 通常のログイン/サインアップの場合はダッシュボードへ
+      return NextResponse.redirect(`${origin}/dashboard`);
+    }
+  }
+
+  // エラーの場合はログインページにリダイレクト
+  return NextResponse.redirect(`${origin}/login?error=auth`);
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -77,7 +77,15 @@ export default function LoginPage() {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password">パスワード</Label>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="password">パスワード</Label>
+                <Link
+                  href="/reset-password"
+                  className="text-xs text-muted-foreground hover:text-primary hover:underline"
+                >
+                  パスワードを忘れた方
+                </Link>
+              </div>
               <Input
                 id="password"
                 type="password"

--- a/src/app/reset-password/layout.tsx
+++ b/src/app/reset-password/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "パスワードリセット | InterviewCoach",
+  robots: { index: false, follow: false },
+};
+
+export default function ResetPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function ResetPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
+      });
+
+      if (error) {
+        setError("リセットメールの送信中にエラーが発生しました。しばらくしてから再度お試しください。");
+        return;
+      }
+
+      // セキュリティ上、メール未登録でも同じメッセージを表示
+      setSent(true);
+    } catch {
+      setError("リセットメールの送信中にエラーが発生しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (sent) {
+    return (
+      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">メールを確認してください</CardTitle>
+            <CardDescription>
+              パスワードリセット用のリンクを送信しました
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-center text-sm text-muted-foreground">
+              <strong>{email}</strong>{" "}
+              宛にパスワードリセット用のメールを送信しました。
+              メール内のリンクをクリックして、新しいパスワードを設定してください。
+            </p>
+            <p className="text-center text-xs text-muted-foreground">
+              メールが届かない場合は、迷惑メールフォルダもご確認ください。
+            </p>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-4">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                setSent(false);
+                setEmail("");
+              }}
+            >
+              別のメールアドレスで再送信
+            </Button>
+            <Link
+              href="/login"
+              className="text-sm text-muted-foreground hover:text-primary hover:underline"
+            >
+              ログインページに戻る
+            </Link>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">パスワードリセット</CardTitle>
+          <CardDescription>
+            登録済みのメールアドレスを入力してください
+          </CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            {error && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="email">メールアドレス</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="example@email.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-4">
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "送信中..." : "リセットメールを送信"}
+            </Button>
+            <Link
+              href="/login"
+              className="text-sm text-muted-foreground hover:text-primary hover:underline"
+            >
+              ログインページに戻る
+            </Link>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/update-password/layout.tsx
+++ b/src/app/update-password/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "パスワード更新 | InterviewCoach",
+  robots: { index: false, follow: false },
+};
+
+export default function UpdatePasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function UpdatePasswordPage() {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (password.length < 8) {
+      setError("パスワードは8文字以上で入力してください");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError("パスワードが一致しません");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.updateUser({ password });
+
+      if (error) {
+        if (error.message.includes("same password")) {
+          setError("現在と同じパスワードは使用できません。別のパスワードを入力してください。");
+        } else {
+          setError("パスワードの更新中にエラーが発生しました。もう一度お試しください。");
+        }
+        return;
+      }
+
+      router.push("/dashboard");
+      router.refresh();
+    } catch {
+      setError("パスワードの更新中にエラーが発生しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">新しいパスワードを設定</CardTitle>
+          <CardDescription>
+            新しいパスワードを入力してください
+          </CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            {error && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="password">新しいパスワード</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="8文字以上"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">新しいパスワード（確認）</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                placeholder="もう一度入力"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                minLength={8}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              パスワードは8文字以上で設定してください。
+            </p>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-4">
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "更新中..." : "パスワードを更新"}
+            </Button>
+            <Link
+              href="/login"
+              className="text-sm text-muted-foreground hover:text-primary hover:underline"
+            >
+              ログインページに戻る
+            </Link>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -82,6 +82,8 @@ const ONBOARDING_BYPASS_PREFIXES = [
   "/_next/",
   "/login",
   "/signup",
+  "/reset-password",
+  "/update-password",
 ];
 
 const ONBOARDING_REQUIRED_PREFIXES = [


### PR DESCRIPTION
## Summary
- ログインページに「パスワードを忘れた方」リンクを追加
- パスワードリセットリクエストページ (`/reset-password`) を新規作成
  - メールアドレス入力 → Supabase `resetPasswordForEmail` でリセットメール送信
  - セキュリティ対策: メール未登録でも同一メッセージ表示（情報漏洩防止）
  - 送信後「メールを確認してください」の案内画面を表示
- パスワード更新ページ (`/update-password`) を新規作成
  - 新しいパスワード入力（2回、一致確認、8文字以上）
  - `supabase.auth.updateUser({ password })` で更新
  - 成功後 `/dashboard` にリダイレクト
- Auth Callback (`/auth/callback`) を新規作成
  - `type=recovery` パラメータで `/update-password` にリダイレクト
  - 通常のコールバックは `/dashboard` にリダイレクト
- Middleware に `/reset-password` と `/update-password` のオンボーディングバイパスを追加
- noindex メタデータ設定済み

## Test plan
- [ ] ログインページに「パスワードを忘れた方」リンクが表示されること
- [ ] リンクから `/reset-password` に遷移できること
- [ ] メールアドレス入力後「メールを確認してください」画面に遷移すること
- [ ] リセットメール内のリンクから `/update-password` に遷移できること
- [ ] パスワード更新後 `/dashboard` にリダイレクトされること
- [ ] パスワード不一致時にエラーメッセージが表示されること
- [ ] 8文字未満のパスワードでエラーが表示されること
- [ ] `npm run build` が成功すること

closes #102