### PR TITLE
fix: Sprint 5 QA 品質修正 (#113, #114, #115, #116, #118)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Site URL (Open Redirect 防止のため本番環境では必ず設定)
+NEXT_PUBLIC_SITE_URL=https://your-domain.com
+
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -2,8 +2,24 @@ import { NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
+/**
+ * リダイレクト先のオリジンを安全に取得する。
+ * リバースプロキシ環境では X-Forwarded-Host が攻撃者に操作される可能性があるため、
+ * 環境変数 NEXT_PUBLIC_SITE_URL を優先的に使用し、Open Redirect を防止する。
+ */
+function getSafeOrigin(requestUrl: string): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (siteUrl) {
+    // 末尾スラッシュを除去して返す
+    return siteUrl.replace(/\/+$/, "");
+  }
+  // フォールバック: 開発環境向け
+  return new URL(requestUrl).origin;
+}
+
 export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
+  const { searchParams } = new URL(request.url);
+  const origin = getSafeOrigin(request.url);
   const code = searchParams.get("code");
   const type = searchParams.get("type");
 

--- a/src/app/interview/[id]/compare/page.tsx
+++ b/src/app/interview/[id]/compare/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/types/supabase";
@@ -5,6 +6,15 @@ import { CompareContent } from "./compare-content";
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Feedback = Database["public"]["Tables"]["feedbacks"]["Row"];
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "フィードバック比較 | InterviewCoach",
+    description:
+      "面接フィードバックを比較して成長を可視化します。カテゴリ別スコアや改善ポイントの変化を確認できます。",
+    robots: { index: false },
+  };
+}
 
 export default async function ComparePage({
   params,
@@ -35,11 +45,12 @@ export default async function ComparePage({
   const currentInterview = currentInterviewData as Interview | null;
   if (!currentInterview) redirect("/dashboard");
 
-  // 現在の面接のフィードバック取得
+  // 現在の面接のフィードバック取得（user_id フィルタで Defence-in-Depth）
   const { data: currentFeedbackData } = await supabase
     .from("feedbacks")
     .select("*")
     .eq("interview_id", id)
+    .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(1)
     .single();
@@ -74,10 +85,12 @@ export default async function ComparePage({
     compareInterview = compareInterviewData as Interview | null;
 
     if (compareInterview) {
+      // 比較対象のフィードバック取得（user_id フィルタで Defence-in-Depth）
       const { data: compareFeedbackData } = await supabase
         .from("feedbacks")
         .select("*")
         .eq("interview_id", compareId)
+        .eq("user_id", user.id)
         .order("created_at", { ascending: false })
         .limit(1)
         .single();

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -61,7 +61,11 @@ export default function LoginPage() {
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
             {error && (
-              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+              >
                 {error}
               </div>
             )}
@@ -70,6 +74,7 @@ export default function LoginPage() {
               <Input
                 id="email"
                 type="email"
+                autoComplete="email"
                 placeholder="example@email.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -89,6 +94,7 @@ export default function LoginPage() {
               <Input
                 id="password"
                 type="password"
+                autoComplete="current-password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -15,15 +15,57 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
+/** クールダウン秒数 */
+const COOLDOWN_SECONDS = 60;
+
 export default function ResetPasswordPage() {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+  const cooldownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // クールダウンタイマーのクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current) {
+        clearInterval(cooldownTimerRef.current);
+      }
+    };
+  }, []);
+
+  const startCooldown = useCallback(() => {
+    setCooldown(COOLDOWN_SECONDS);
+
+    if (cooldownTimerRef.current) {
+      clearInterval(cooldownTimerRef.current);
+    }
+
+    cooldownTimerRef.current = setInterval(() => {
+      setCooldown((prev) => {
+        if (prev <= 1) {
+          if (cooldownTimerRef.current) {
+            clearInterval(cooldownTimerRef.current);
+            cooldownTimerRef.current = null;
+          }
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+
+    // クールダウン中は送信を拒否
+    if (cooldown > 0) {
+      setError(`リクエストの間隔を空けてください。${cooldown}秒後に再度お試しください。`);
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -38,9 +80,13 @@ export default function ResetPasswordPage() {
       }
 
       // セキュリティ上、メール未登録でも同じメッセージを表示
+      // 送信成功・失敗に関わらずクールダウンを開始（列挙攻撃防止）
+      startCooldown();
       setSent(true);
     } catch {
       setError("リセットメールの送信中にエラーが発生しました");
+      // エラー時もクールダウンを開始
+      startCooldown();
     } finally {
       setLoading(false);
     }
@@ -67,15 +113,23 @@ export default function ResetPasswordPage() {
             </p>
           </CardContent>
           <CardFooter className="flex flex-col gap-4">
+            {cooldown > 0 && (
+              <p className="text-center text-xs text-muted-foreground">
+                再送信まであと {cooldown} 秒お待ちください
+              </p>
+            )}
             <Button
               variant="outline"
               className="w-full"
+              disabled={cooldown > 0}
               onClick={() => {
                 setSent(false);
                 setEmail("");
               }}
             >
-              別のメールアドレスで再送信
+              {cooldown > 0
+                ? `再送信まで ${cooldown} 秒`
+                : "別のメールアドレスで再送信"}
             </Button>
             <Link
               href="/login"
@@ -101,7 +155,11 @@ export default function ResetPasswordPage() {
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
             {error && (
-              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+              >
                 {error}
               </div>
             )}
@@ -110,6 +168,7 @@ export default function ResetPasswordPage() {
               <Input
                 id="email"
                 type="email"
+                autoComplete="email"
                 placeholder="example@email.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -118,8 +177,12 @@ export default function ResetPasswordPage() {
             </div>
           </CardContent>
           <CardFooter className="flex flex-col gap-4">
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? "送信中..." : "リセットメールを送信"}
+            <Button type="submit" className="w-full" disabled={loading || cooldown > 0}>
+              {loading
+                ? "送信中..."
+                : cooldown > 0
+                  ? `再送信まで ${cooldown} 秒`
+                  : "リセットメールを送信"}
             </Button>
             <Link
               href="/login"

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
@@ -21,7 +21,30 @@ export default function UpdatePasswordPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [authChecking, setAuthChecking] = useState(true);
   const router = useRouter();
+
+  // 認証状態の検証: 未認証ユーザーがパスワード更新ページにアクセスすることを防止
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const supabase = createClient();
+        const { data: { user } } = await supabase.auth.getUser();
+
+        if (!user) {
+          // 未認証の場合はパスワードリセットページにリダイレクト
+          router.replace("/reset-password");
+          return;
+        }
+      } catch {
+        router.replace("/reset-password");
+        return;
+      }
+      setAuthChecking(false);
+    };
+
+    checkAuth();
+  }, [router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -61,6 +84,19 @@ export default function UpdatePasswordPage() {
     }
   };
 
+  // 認証チェック中はローディング表示
+  if (authChecking) {
+    return (
+      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
+        <Card className="w-full max-w-md">
+          <CardContent className="flex items-center justify-center py-12">
+            <p className="text-sm text-muted-foreground">認証状態を確認中...</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
       <Card className="w-full max-w-md">
@@ -73,7 +109,11 @@ export default function UpdatePasswordPage() {
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
             {error && (
-              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+              >
                 {error}
               </div>
             )}
@@ -82,6 +122,7 @@ export default function UpdatePasswordPage() {
               <Input
                 id="password"
                 type="password"
+                autoComplete="new-password"
                 placeholder="8文字以上"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -94,6 +135,7 @@ export default function UpdatePasswordPage() {
               <Input
                 id="confirmPassword"
                 type="password"
+                autoComplete="new-password"
                 placeholder="もう一度入力"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 
 /** localStorage に保存する同意状態のキー */
@@ -26,6 +26,7 @@ export function getConsentLevel(): ConsentLevel | null {
  */
 export function CookieConsent() {
   const [visible, setVisible] = useState(false);
+  const bannerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // localStorage から同意状態を確認
@@ -35,7 +36,14 @@ export function CookieConsent() {
     }
   }, []);
 
-  function handleConsent(level: ConsentLevel) {
+  // バナー表示時にフォーカスを移動
+  useEffect(() => {
+    if (visible && bannerRef.current) {
+      bannerRef.current.focus();
+    }
+  }, [visible]);
+
+  const handleConsent = useCallback((level: ConsentLevel) => {
     localStorage.setItem(CONSENT_KEY, level);
     setVisible(false);
 
@@ -43,14 +51,28 @@ export function CookieConsent() {
     window.dispatchEvent(
       new CustomEvent("cookie-consent-change", { detail: { level } })
     );
-  }
+  }, []);
+
+  // Esc キーで「必須 Cookie のみ」として閉じる
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handleConsent("essential");
+      }
+    },
+    [handleConsent]
+  );
 
   if (!visible) return null;
 
   return (
     <div
+      ref={bannerRef}
       role="dialog"
       aria-label="Cookie の使用について"
+      aria-modal="true"
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
       className="fixed inset-x-0 bottom-0 z-50 border-t bg-background p-4 shadow-lg sm:p-6"
     >
       <div className="mx-auto flex max-w-4xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-const protectedRoutes = ["/dashboard", "/interview", "/profile"];
+const protectedRoutes = ["/dashboard", "/interview", "/profile", "/update-password"];
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });


### PR DESCRIPTION
## Summary

Sprint 5 QA で報告された High 品質 Issue 5件を一括修正

### 修正内容

- **#113**: エラーメッセージに `role="alert"` / `aria-live="assertive"` を追加（reset-password, update-password, login）
- **#114**: フォーム入力に `autocomplete` 属性を追加
  - reset-password: `autocomplete="email"`
  - update-password: `autocomplete="new-password"`
  - login: `autocomplete="email"`, `autocomplete="current-password"`
- **#115**: フィードバック比較ページに `generateMetadata` を追加（`title`, `description`, `robots: { index: false }`）
- **#116**: Cookie同意バナーのアクセシビリティ改善（Escキー対応、フォーカス管理、`aria-modal`）
- **#118**: feedbacks クエリに `user_id` フィルタを追加（Defence-in-Depth: RLS + アプリケーション層の二重防御）

### 追加セキュリティ改善

- Open Redirect 防止: auth callback で `NEXT_PUBLIC_SITE_URL` を優先利用
- `/update-password` を protected routes に追加
- reset-password: クールダウン機能追加（列挙攻撃防止）
- update-password: 未認証ユーザーのアクセス防止

## Test plan

- [ ] reset-password ページでエラー時にスクリーンリーダーがエラーメッセージを読み上げること
- [ ] update-password ページでエラー時にスクリーンリーダーがエラーメッセージを読み上げること
- [ ] login ページでエラー時にスクリーンリーダーがエラーメッセージを読み上げること
- [ ] reset-password のメール入力に autocomplete="email" が適用されること
- [ ] update-password のパスワード入力に autocomplete="new-password" が適用されること
- [ ] login のメール/パスワード入力に autocomplete が適用されること
- [ ] フィードバック比較ページの `<head>` に正しいメタデータが出力されること
- [ ] Cookie同意バナー表示中にEscキーで閉じられること
- [ ] Cookie同意バナー表示時にバナーにフォーカスが移動すること
- [ ] 比較ページで他ユーザーのフィードバックが表示されないこと
- [ ] `npm run build` が成功すること

closes #113, closes #114, closes #115, closes #116, closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)