### PR TITLE
feat: #105 フィラー表現分析の強化

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -29,7 +29,12 @@ interface AIFeedbackResponse {
   advice: string;
   summary: string;
   suggestions: { original: string; improved: string; reason: string }[];
-  filler_words: { word: string; count: number }[];
+  filler_words: {
+    total_count: number;
+    filler_rate: number;
+    details: { word: string; count: number }[];
+    assessment: string;
+  };
   strengths: string[];
   improvements: string[];
 }
@@ -213,12 +218,17 @@ ${transcriptText}
       "reason": "改善理由"
     }
   ],
-  "filler_words": [
-    {
-      "word": "検出されたフィラーワード（えー、あの、えっと等）",
-      "count": <出現回数>
-    }
-  ],
+  "filler_words": {
+    "total_count": <検出されたフィラー表現の総出現回数>,
+    "filler_rate": <全体の発話に占めるフィラー率（%）。小数点第1位まで。計算方法: (フィラー総数 / 候補者の総発話単語数) * 100>,
+    "details": [
+      {
+        "word": "検出されたフィラー表現（えーと、あのー、えー、まあ、なんか、その、あの、ええと、うーん 等）",
+        "count": <出現回数>
+      }
+    ],
+    "assessment": "フィラー使用に関する評価コメント（例: 少なめで好印象です / やや多め。意識的に間を置くことで改善できます）"
+  },
   "strengths": ["強み1", "強み2"],
   "improvements": ["改善点1", "改善点2"]
 }`;
@@ -443,7 +453,7 @@ export async function POST(request: Request) {
       improvement_points: feedback.improvement_points,
       overall_comment: feedback.detailed_feedback,
       category_scores: feedback.category_scores,
-      filler_words: feedback.filler_words || [],
+      filler_words: feedback.filler_words || { total_count: 0, filler_rate: 0, details: [], assessment: "" },
       suggestions: feedback.suggestions || [],
       strengths: feedback.strengths || [],
       improvements: feedback.improvements || [],

--- a/src/app/dashboard/growth/page.tsx
+++ b/src/app/dashboard/growth/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { StatsCard } from "@/components/stats-card";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { CategoryScores } from "@/types/database";
+import type { Json } from "@/types/database";
 
 import { CATEGORY_LABELS } from "@/lib/constants";
 
@@ -54,7 +55,7 @@ export default async function GrowthPage() {
   const { data: feedbacks } = interviewIds.length > 0
     ? await supabase
         .from("feedbacks")
-        .select("interview_id, overall_score, category_scores, created_at")
+        .select("interview_id, overall_score, category_scores, filler_words, created_at")
         .in("interview_id", interviewIds)
     : { data: null };
 
@@ -62,6 +63,7 @@ export default async function GrowthPage() {
     interview_id: string;
     overall_score: number;
     category_scores: CategoryScores | null;
+    filler_words: Json;
     created_at: string;
   }[];
 
@@ -177,6 +179,60 @@ export default async function GrowthPage() {
       title: interview?.title ?? "",
     };
   });
+
+  // ---------- フィラー率推移（直近10件） ----------
+
+  /** filler_words カラムからフィラー率を安全に取得する */
+  function extractFillerRate(fw: Json): number | null {
+    if (fw && typeof fw === "object" && !Array.isArray(fw)) {
+      const obj = fw as Record<string, Json | undefined>;
+      if (typeof obj.filler_rate === "number") return obj.filler_rate;
+    }
+    // 旧形式（配列）の場合はフィラー率が不明なので null
+    return null;
+  }
+
+  function extractFillerTotalCount(fw: Json): number {
+    if (fw && typeof fw === "object" && !Array.isArray(fw)) {
+      const obj = fw as Record<string, Json | undefined>;
+      if (typeof obj.total_count === "number") return obj.total_count;
+    }
+    if (Array.isArray(fw)) {
+      let total = 0;
+      for (const item of fw) {
+        if (item && typeof item === "object" && !Array.isArray(item)) {
+          const d = item as Record<string, Json | undefined>;
+          if (typeof d.count === "number") total += d.count;
+        }
+      }
+      return total;
+    }
+    return 0;
+  }
+
+  const recentFillerData = recentFeedbacks.map((f) => {
+    const interview = interviewList.find((i) => i.id === f.interview_id);
+    return {
+      fillerRate: extractFillerRate(f.filler_words),
+      fillerCount: extractFillerTotalCount(f.filler_words),
+      date: new Date(f.created_at).toLocaleDateString("ja-JP", {
+        month: "short",
+        day: "numeric",
+      }),
+      title: interview?.title ?? "",
+    };
+  });
+
+  // フィラー率の平均
+  const fillerRatesWithData = feedbackList
+    .map((f) => extractFillerRate(f.filler_words))
+    .filter((r): r is number => r !== null);
+  const avgFillerRate =
+    fillerRatesWithData.length > 0
+      ? Math.round(
+          (fillerRatesWithData.reduce((a, b) => a + b, 0) / fillerRatesWithData.length) * 10
+        ) / 10
+      : null;
 
   const barMaxScore = 100;
 
@@ -391,6 +447,68 @@ export default async function GrowthPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* フィラー率推移 */}
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle>フィラー率の推移（直近10件）</CardTitle>
+          {avgFillerRate !== null && (
+            <p className="text-sm text-muted-foreground">
+              平均フィラー率: {avgFillerRate}%
+              {avgFillerRate <= 2
+                ? " — 少なめで好印象です"
+                : avgFillerRate <= 5
+                  ? " — 標準的な範囲です"
+                  : " — やや多め。意識的に間を置きましょう"}
+            </p>
+          )}
+        </CardHeader>
+        <CardContent>
+          {recentFillerData.every((d) => d.fillerRate === null) ? (
+            <p className="text-sm text-muted-foreground">
+              フィラー分析データが蓄積されると、ここにフィラー率の推移が表示されます。
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {recentFillerData.map((item, i) => {
+                const rate = item.fillerRate ?? 0;
+                // フィラー率のバー表示（最大10%で100%幅）
+                const barWidth = Math.min(Math.max((rate / 10) * 100, 2), 100);
+                const barColor =
+                  rate <= 2
+                    ? "bg-green-400 dark:bg-green-500"
+                    : rate <= 5
+                      ? "bg-yellow-400 dark:bg-yellow-500"
+                      : "bg-red-400 dark:bg-red-500";
+                return (
+                  <div key={i} className="flex items-center gap-3">
+                    <span className="w-16 shrink-0 text-xs text-muted-foreground text-right">
+                      {item.date}
+                    </span>
+                    <div className="relative flex-1 h-7 rounded bg-muted overflow-hidden">
+                      <div
+                        className={`absolute inset-y-0 left-0 rounded ${barColor} transition-all`}
+                        style={{ width: `${barWidth}%` }}
+                      />
+                      <span className="relative z-10 flex h-full items-center px-2 text-xs font-medium">
+                        {item.fillerRate !== null ? `${item.fillerRate}%` : "—"}
+                        <span className="ml-1 text-muted-foreground">
+                          ({item.fillerCount}回)
+                        </span>
+                        {item.title && (
+                          <span className="ml-2 truncate text-muted-foreground">
+                            {item.title}
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* 面接カテゴリ別の件数内訳 */}
       <Card className="mt-8">

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -77,6 +77,61 @@ interface FillerWord {
   count: number;
 }
 
+/** 拡張フィラー分析構造 */
+interface FillerAnalysis {
+  total_count: number;
+  filler_rate: number;
+  details: FillerWord[];
+  assessment: string;
+}
+
+/**
+ * filler_words カラムのデータをパースする。
+ * 新形式（オブジェクト）と旧形式（配列）の両方に対応。
+ */
+function parseFillerAnalysis(data: Json): FillerAnalysis {
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const obj = data as Record<string, Json | undefined>;
+    return {
+      total_count: typeof obj.total_count === "number" ? obj.total_count : 0,
+      filler_rate: typeof obj.filler_rate === "number" ? obj.filler_rate : 0,
+      details: Array.isArray(obj.details)
+        ? obj.details
+            .filter((item): item is { [key: string]: Json | undefined } =>
+              item !== null && typeof item === "object" && !Array.isArray(item)
+            )
+            .map((item) => ({
+              word: typeof item.word === "string" ? item.word : "",
+              count: typeof item.count === "number" ? item.count : 0,
+            }))
+        : [],
+      assessment: typeof obj.assessment === "string" ? obj.assessment : "",
+    };
+  }
+  // 旧形式（配列）の場合: details として扱い、total_count を算出
+  if (Array.isArray(data)) {
+    const details: FillerWord[] = data
+      .filter((item): item is { [key: string]: Json | undefined } =>
+        item !== null && typeof item === "object" && !Array.isArray(item)
+      )
+      .map((item) => ({
+        word: typeof item.word === "string" ? item.word : "",
+        count: typeof item.count === "number" ? item.count : 0,
+      }));
+    let totalCount = 0;
+    for (const d of details) {
+      totalCount += d.count;
+    }
+    return {
+      total_count: totalCount,
+      filler_rate: 0,
+      details,
+      assessment: "",
+    };
+  }
+  return { total_count: 0, filler_rate: 0, details: [], assessment: "" };
+}
+
 function parseJsonArray<T>(data: Json): T[] {
   if (!Array.isArray(data)) return [];
   // null/undefined を除外してキャスト
@@ -196,9 +251,9 @@ export function ResultContent({
   const suggestions = feedback
     ? parseJsonArray<Suggestion>(feedback.suggestions)
     : [];
-  const fillerWords = feedback
-    ? parseJsonArray<FillerWord>(feedback.filler_words)
-    : [];
+  const fillerAnalysis = feedback
+    ? parseFillerAnalysis(feedback.filler_words)
+    : { total_count: 0, filler_rate: 0, details: [], assessment: "" };
   const goodPoints = feedback
     ? parseStringArray(feedback.good_points)
     : [];
@@ -506,32 +561,97 @@ export function ResultContent({
           </div>
         </TabsContent>
 
-        {/* フィラーワード */}
+        {/* フィラーワード分析 */}
         <TabsContent value="filler">
-          <Card>
-            <CardHeader>
-              <CardTitle>フィラーワード検出</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {fillerWords.length === 0 ? (
-                <p className="text-muted-foreground">
-                  フィラーワードは検出されませんでした
-                </p>
-              ) : (
-                <div className="flex flex-wrap gap-3">
-                  {fillerWords.map((fw, i) => (
-                    <div
-                      key={i}
-                      className="flex items-center gap-2 rounded-lg border px-4 py-2"
-                    >
-                      <span className="font-medium">{fw.word}</span>
-                      <Badge variant="destructive">{fw.count}回</Badge>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <div className="space-y-4">
+            {/* サマリーカード */}
+            <div className="grid gap-4 sm:grid-cols-3">
+              <Card>
+                <CardContent className="flex flex-col items-center py-6">
+                  <p className="text-sm font-medium text-muted-foreground">総フィラー数</p>
+                  <span className="mt-1 text-4xl font-bold">{fillerAnalysis.total_count}</span>
+                  <span className="text-xs text-muted-foreground">回</span>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="flex flex-col items-center py-6">
+                  <p className="text-sm font-medium text-muted-foreground">フィラー率</p>
+                  <span className={`mt-1 text-4xl font-bold ${
+                    fillerAnalysis.filler_rate <= 2
+                      ? "text-green-600"
+                      : fillerAnalysis.filler_rate <= 5
+                        ? "text-yellow-600"
+                        : "text-red-600"
+                  }`}>
+                    {fillerAnalysis.filler_rate}
+                  </span>
+                  <span className="text-xs text-muted-foreground">%</span>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="flex flex-col items-center py-6">
+                  <p className="text-sm font-medium text-muted-foreground">種類数</p>
+                  <span className="mt-1 text-4xl font-bold">{fillerAnalysis.details.length}</span>
+                  <span className="text-xs text-muted-foreground">種類</span>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* 評価コメント */}
+            {fillerAnalysis.assessment && (
+              <Card className="border-blue-200 bg-blue-50/50 dark:border-blue-900 dark:bg-blue-950/20">
+                <CardContent className="py-4">
+                  <div className="flex items-start gap-2">
+                    <Lightbulb className="mt-0.5 h-5 w-5 shrink-0 text-blue-600" />
+                    <p className="text-sm leading-relaxed">{fillerAnalysis.assessment}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* フィラー種類別の出現回数（横棒グラフ） */}
+            <Card>
+              <CardHeader>
+                <CardTitle>フィラー表現の内訳</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {fillerAnalysis.details.length === 0 ? (
+                  <p className="text-muted-foreground">
+                    フィラー表現は検出されませんでした
+                  </p>
+                ) : (
+                  <div className="space-y-3">
+                    {[...fillerAnalysis.details]
+                      .sort((a, b) => b.count - a.count)
+                      .map((fw, i) => {
+                        const maxCount = Math.max(
+                          ...fillerAnalysis.details.map((d) => d.count)
+                        );
+                        const barWidth = maxCount > 0
+                          ? Math.max((fw.count / maxCount) * 100, 4)
+                          : 0;
+                        return (
+                          <div key={i} className="flex items-center gap-3">
+                            <span className="w-16 shrink-0 text-sm font-medium text-right">
+                              {fw.word}
+                            </span>
+                            <div className="relative flex-1 h-7 rounded bg-muted overflow-hidden">
+                              <div
+                                className="absolute inset-y-0 left-0 rounded bg-orange-400 dark:bg-orange-500 transition-all"
+                                style={{ width: `${barWidth}%` }}
+                              />
+                              <span className="relative z-10 flex h-full items-center px-2 text-xs font-medium">
+                                {fw.count}回
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
         </TabsContent>
       </Tabs>
 


### PR DESCRIPTION
## Summary
- AIプロンプトにフィラー表現の拡張検出指示を追加（`total_count`, `filler_rate`, `details`, `assessment` の構造化出力）
- 結果ページのフィラータブを大幅強化（サマリーカード3枚、評価コメント、横棒グラフでの内訳表示）
- 成長ダッシュボードにフィラー率推移チャート（直近10件）と平均フィラー率の表示を追加
- 旧形式（配列）と新形式（オブジェクト）の両方に後方互換性を持たせ、既存データが壊れない設計

## Changes
- `src/app/api/analyze/route.ts`: AIFeedbackResponse の filler_words 型を拡張構造に変更、プロンプトにフィラー率・評価コメントの生成指示を追加
- `src/app/interview/[id]/result/result-content.tsx`: フィラータブに総フィラー数・フィラー率・種類数のサマリーカード、評価コメント表示、種類別横棒グラフを追加
- `src/app/dashboard/growth/page.tsx`: feedbacks クエリに filler_words を追加、フィラー率推移チャートと平均フィラー率の表示を追加

## Test plan
- [ ] 新しい面接を分析し、フィラー分析が拡張構造（total_count, filler_rate, details, assessment）で保存されることを確認
- [ ] 結果ページのフィラータブでサマリーカード、評価コメント、横棒グラフが表示されることを確認
- [ ] 旧形式（配列）のフィラーデータがある面接で結果ページが正しく表示されることを確認
- [ ] 成長ダッシュボードでフィラー率推移チャートが表示されることを確認
- [ ] `npm run build` が成功すること ✅

closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)