### PR TITLE
feat: #106 原文スクリプト表示 + インラインハイライト

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -14,6 +14,16 @@ interface AnalyzeRequest {
   interview_id: string;
 }
 
+/** テキストアノテーション（ハイライト情報） */
+interface Annotation {
+  start: number;
+  end: number;
+  type: "error" | "warning" | "good";
+  text: string;
+  reason: string;
+  suggestion?: string;
+}
+
 /** Claude API が返す構造化フィードバック */
 interface AIFeedbackResponse {
   overall_score: number;
@@ -37,6 +47,7 @@ interface AIFeedbackResponse {
   };
   strengths: string[];
   improvements: string[];
+  annotations: Annotation[];
 }
 
 // ============================================================
@@ -230,8 +241,31 @@ ${transcriptText}
     "assessment": "フィラー使用に関する評価コメント（例: 少なめで好印象です / やや多め。意識的に間を置くことで改善できます）"
   },
   "strengths": ["強み1", "強み2"],
-  "improvements": ["改善点1", "改善点2"]
-}`;
+  "improvements": ["改善点1", "改善点2"],
+  "annotations": [
+    {
+      "start": <原文テキスト内の問題箇所の開始位置（0-indexed の文字数オフセット）>,
+      "end": <原文テキスト内の問題箇所の終了位置（0-indexed の文字数オフセット）>,
+      "type": "<'error' | 'warning' | 'good' のいずれか>",
+      "text": "該当するテキストの原文（start-end の範囲と完全一致すること）",
+      "reason": "ハイライトの理由（なぜこの部分が良い/悪いか）",
+      "suggestion": "改善提案（type が good の場合は省略可）"
+    }
+  ]
+}
+
+【annotations の type 分類基準】
+- "error"（赤色ハイライト）: 重大な問題 — 論理の破綻、事実と矛盾する発言、不適切な表現、志望動機の欠如
+- "warning"（黄色ハイライト）: 改善推奨 — 冗長な表現、フィラー表現（えーと、あのー等）、曖昧な回答、具体性不足
+- "good"（緑色ハイライト）: 良い表現 — 効果的なエピソード、具体的な数字、論理的な構成、適切な敬語
+
+【annotations の重要ルール】
+- <user_transcript> タグ内のテキスト全体を対象に、start/end の文字数オフセットを正確に計算すること
+- start/end はタグ内テキストの先頭を 0 とする文字インデックス
+- "[面接官]" や "[候補者]" などの話者ラベルも文字数に含めること
+- 最低 3 個、最大 15 個程度のアノテーションを付与すること
+- 重複する範囲のアノテーションは作成しないこと
+- text フィールドは原文テキストの該当範囲と完全一致させること`;
 }
 
 // ============================================================
@@ -457,6 +491,7 @@ export async function POST(request: Request) {
       suggestions: feedback.suggestions || [],
       strengths: feedback.strengths || [],
       improvements: feedback.improvements || [],
+      annotations: Array.isArray(feedback.annotations) ? feedback.annotations : [],
       raw_response: feedback as unknown,
       model_version: MODEL_NAME,
     } as never);

--- a/src/app/interview/[id]/result/page.tsx
+++ b/src/app/interview/[id]/result/page.tsx
@@ -76,6 +76,19 @@ export default async function ResultPage({
 
   const hasOtherInterviews = (otherCompletedCount ?? 0) > 0;
 
+  // 原文テキストを取得（transcripts → interview.transcript の優先順）
+  let rawTranscript: string | null = null;
+  if (transcripts.length > 0) {
+    rawTranscript = transcripts
+      .map((t) => {
+        const speaker = t.speaker === "interviewer" ? "面接官" : "候補者";
+        return `[${speaker}] ${t.content}`;
+      })
+      .join("\n");
+  } else if (interview.transcript) {
+    rawTranscript = interview.transcript;
+  }
+
   return (
     <ResultContent
       interview={interview}
@@ -83,6 +96,7 @@ export default async function ResultPage({
       feedback={feedback}
       interviewTags={interviewTags}
       hasOtherInterviews={hasOtherInterviews}
+      rawTranscript={rawTranscript}
     />
   );
 }

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -17,8 +17,22 @@ import type { Database } from "@/types/supabase";
 import type { Json } from "@/types/supabase";
 import type { CategoryScores } from "@/types/database";
 import { CATEGORY_LABELS } from "@/lib/constants";
+import { parseAnnotations } from "@/components/annotated-transcript";
 
 // 動的インポート: 初期表示に不要なインタラクティブコンポーネントを遅延ロード
+const AnnotatedTranscript = dynamic(
+  () =>
+    import("@/components/annotated-transcript").then(
+      (mod) => mod.AnnotatedTranscript
+    ),
+  {
+    loading: () => (
+      <div className="h-48 w-full animate-pulse rounded-lg bg-muted" />
+    ),
+    ssr: false,
+  }
+);
+
 const ExportButtons = dynamic(
   () => import("@/components/export-buttons").then((mod) => mod.ExportButtons),
   {
@@ -241,12 +255,14 @@ export function ResultContent({
   feedback,
   interviewTags = [],
   hasOtherInterviews = false,
+  rawTranscript = null,
 }: {
   interview: Interview;
   transcripts: Transcript[];
   feedback: Feedback | null;
   interviewTags?: TagData[];
   hasOtherInterviews?: boolean;
+  rawTranscript?: string | null;
 }) {
   const suggestions = feedback
     ? parseJsonArray<Suggestion>(feedback.suggestions)
@@ -265,6 +281,11 @@ export function ResultContent({
     : [];
   const improvements = feedback
     ? parseStringArray(feedback.improvements)
+    : [];
+
+  // annotations をパース
+  const annotations = feedback
+    ? parseAnnotations(feedback.annotations)
     : [];
 
   // good_points が空の場合は strengths にフォールバック
@@ -442,6 +463,16 @@ export function ResultContent({
                 </CardContent>
               </Card>
             )}
+        </div>
+      )}
+
+      {/* 原文スクリプト（ハイライト付き） */}
+      {rawTranscript && (
+        <div className="mb-6">
+          <AnnotatedTranscript
+            transcript={rawTranscript}
+            annotations={annotations}
+          />
         </div>
       )}
 

--- a/src/components/annotated-transcript.tsx
+++ b/src/components/annotated-transcript.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { Eye, EyeOff, ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Json } from "@/types/database";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/** アノテーション */
+export interface Annotation {
+  start: number;
+  end: number;
+  type: "error" | "warning" | "good";
+  text: string;
+  reason: string;
+  suggestion?: string;
+}
+
+/** テキストセグメント（通常テキスト or ハイライト付き） */
+interface TextSegment {
+  text: string;
+  annotation: Annotation | null;
+}
+
+// ============================================================
+// ユーティリティ
+// ============================================================
+
+/** Json 型からAnnotation配列をパースする */
+export function parseAnnotations(data: Json): Annotation[] {
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter((item): item is Record<string, Json | undefined> =>
+      item !== null && typeof item === "object" && !Array.isArray(item)
+    )
+    .filter((item) => {
+      return (
+        typeof item.start === "number" &&
+        typeof item.end === "number" &&
+        typeof item.type === "string" &&
+        typeof item.text === "string" &&
+        typeof item.reason === "string" &&
+        ["error", "warning", "good"].includes(item.type as string)
+      );
+    })
+    .map((item) => ({
+      start: item.start as number,
+      end: item.end as number,
+      type: item.type as "error" | "warning" | "good",
+      text: item.text as string,
+      reason: item.reason as string,
+      suggestion: typeof item.suggestion === "string" ? item.suggestion : undefined,
+    }));
+}
+
+/**
+ * テキストをアノテーションに基づいてセグメントに分割する。
+ * 重複範囲を処理し、start 順にソートしたアノテーションで分割。
+ */
+function splitTextByAnnotations(
+  text: string,
+  annotations: Annotation[]
+): TextSegment[] {
+  if (annotations.length === 0) {
+    return [{ text, annotation: null }];
+  }
+
+  // start 順にソート（同じ start なら end が大きい方が先）
+  const sorted = [...annotations]
+    .filter((a) => a.start >= 0 && a.end <= text.length && a.start < a.end)
+    .sort((a, b) => a.start - b.start || b.end - a.end);
+
+  // 重複範囲を除外（先に来たアノテーションを優先）
+  const resolved: Annotation[] = [];
+  let lastEnd = 0;
+  for (const ann of sorted) {
+    if (ann.start >= lastEnd) {
+      resolved.push(ann);
+      lastEnd = ann.end;
+    }
+  }
+
+  const segments: TextSegment[] = [];
+  let currentPos = 0;
+
+  for (const ann of resolved) {
+    // アノテーション前の通常テキスト
+    if (ann.start > currentPos) {
+      segments.push({
+        text: text.slice(currentPos, ann.start),
+        annotation: null,
+      });
+    }
+    // ハイライトテキスト
+    segments.push({
+      text: text.slice(ann.start, ann.end),
+      annotation: ann,
+    });
+    currentPos = ann.end;
+  }
+
+  // 残りのテキスト
+  if (currentPos < text.length) {
+    segments.push({
+      text: text.slice(currentPos),
+      annotation: null,
+    });
+  }
+
+  return segments;
+}
+
+// ============================================================
+// ツールチップコンポーネント
+// ============================================================
+
+function AnnotationTooltip({
+  annotation,
+  position,
+  onClose,
+}: {
+  annotation: Annotation;
+  position: { top: number; left: number };
+  onClose: () => void;
+}) {
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        tooltipRef.current &&
+        !tooltipRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  const typeConfig = {
+    error: {
+      label: "重大な問題",
+      borderColor: "border-red-300 dark:border-red-700",
+      bgColor: "bg-red-50 dark:bg-red-950/50",
+      labelColor: "text-red-700 dark:text-red-300",
+    },
+    warning: {
+      label: "改善推奨",
+      borderColor: "border-yellow-300 dark:border-yellow-700",
+      bgColor: "bg-yellow-50 dark:bg-yellow-950/50",
+      labelColor: "text-yellow-700 dark:text-yellow-300",
+    },
+    good: {
+      label: "良い表現",
+      borderColor: "border-green-300 dark:border-green-700",
+      bgColor: "bg-green-50 dark:bg-green-950/50",
+      labelColor: "text-green-700 dark:text-green-300",
+    },
+  };
+
+  const config = typeConfig[annotation.type];
+
+  return (
+    <div
+      ref={tooltipRef}
+      role="tooltip"
+      className={`absolute z-50 max-w-sm rounded-lg border-2 ${config.borderColor} ${config.bgColor} p-3 shadow-lg`}
+      style={{
+        top: `${position.top}px`,
+        left: `${position.left}px`,
+      }}
+    >
+      <div className="space-y-2">
+        <span
+          className={`inline-block rounded px-2 py-0.5 text-xs font-semibold ${config.labelColor} ${config.bgColor}`}
+        >
+          {config.label}
+        </span>
+        <p className="text-sm font-medium">{annotation.reason}</p>
+        {annotation.suggestion && (
+          <div className="border-t border-current/10 pt-2">
+            <p className="text-xs font-medium text-muted-foreground">改善提案:</p>
+            <p className="text-sm">{annotation.suggestion}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// ハイライト付きテキストコンポーネント
+// ============================================================
+
+function HighlightedSpan({
+  segment,
+  highlightEnabled,
+}: {
+  segment: TextSegment;
+  highlightEnabled: boolean;
+}) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
+  const spanRef = useRef<HTMLSpanElement>(null);
+
+  const handleInteraction = useCallback(() => {
+    if (!segment.annotation || !highlightEnabled || !spanRef.current) return;
+    const rect = spanRef.current.getBoundingClientRect();
+    const containerRect = spanRef.current.closest("[data-transcript-container]")?.getBoundingClientRect();
+    if (!containerRect) return;
+
+    setTooltipPosition({
+      top: rect.bottom - containerRect.top + 4,
+      left: Math.max(0, rect.left - containerRect.left),
+    });
+    setShowTooltip((prev) => !prev);
+  }, [segment.annotation, highlightEnabled]);
+
+  const handleClose = useCallback(() => {
+    setShowTooltip(false);
+  }, []);
+
+  if (!segment.annotation || !highlightEnabled) {
+    return <span>{segment.text}</span>;
+  }
+
+  const highlightClasses = {
+    error:
+      "bg-red-100 dark:bg-red-900/40 border-b-2 border-red-400 dark:border-red-600 cursor-pointer hover:bg-red-200 dark:hover:bg-red-900/60",
+    warning:
+      "bg-yellow-100 dark:bg-yellow-900/40 border-b-2 border-yellow-400 dark:border-yellow-600 cursor-pointer hover:bg-yellow-200 dark:hover:bg-yellow-900/60",
+    good:
+      "bg-green-100 dark:bg-green-900/40 border-b-2 border-green-400 dark:border-green-600 cursor-pointer hover:bg-green-200 dark:hover:bg-green-900/60",
+  };
+
+  return (
+    <>
+      <span
+        ref={spanRef}
+        className={`rounded-sm px-0.5 transition-colors ${highlightClasses[segment.annotation.type]}`}
+        onClick={handleInteraction}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleInteraction();
+          }
+        }}
+        tabIndex={0}
+        role="button"
+        aria-label={`${segment.annotation.type === "error" ? "重大な問題" : segment.annotation.type === "warning" ? "改善推奨" : "良い表現"}: ${segment.annotation.reason}`}
+        aria-expanded={showTooltip}
+      >
+        {segment.text}
+      </span>
+      {showTooltip && (
+        <AnnotationTooltip
+          annotation={segment.annotation}
+          position={tooltipPosition}
+          onClose={handleClose}
+        />
+      )}
+    </>
+  );
+}
+
+// ============================================================
+// 凡例コンポーネント
+// ============================================================
+
+function AnnotationLegend() {
+  return (
+    <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block h-3 w-3 rounded-sm bg-red-100 border border-red-400 dark:bg-red-900/40 dark:border-red-600" />
+        重大な問題
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block h-3 w-3 rounded-sm bg-yellow-100 border border-yellow-400 dark:bg-yellow-900/40 dark:border-yellow-600" />
+        改善推奨
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block h-3 w-3 rounded-sm bg-green-100 border border-green-400 dark:bg-green-900/40 dark:border-green-600" />
+        良い表現
+      </span>
+      <span className="text-muted-foreground/60">
+        ハイライト箇所をクリック/タップで詳細表示
+      </span>
+    </div>
+  );
+}
+
+// ============================================================
+// メインコンポーネント
+// ============================================================
+
+export function AnnotatedTranscript({
+  transcript,
+  annotations,
+}: {
+  transcript: string;
+  annotations: Annotation[];
+}) {
+  const [highlightEnabled, setHighlightEnabled] = useState(true);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const segments = splitTextByAnnotations(transcript, annotations);
+
+  // アノテーション数の集計
+  const errorCount = annotations.filter((a) => a.type === "error").length;
+  const warningCount = annotations.filter((a) => a.type === "warning").length;
+  const goodCount = annotations.filter((a) => a.type === "good").length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            原文スクリプト
+            {annotations.length > 0 && (
+              <span className="flex items-center gap-1.5 text-sm font-normal text-muted-foreground">
+                {errorCount > 0 && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-red-100 dark:bg-red-900/40 px-2 py-0.5 text-xs text-red-700 dark:text-red-300">
+                    {errorCount}
+                  </span>
+                )}
+                {warningCount > 0 && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 dark:bg-yellow-900/40 px-2 py-0.5 text-xs text-yellow-700 dark:text-yellow-300">
+                    {warningCount}
+                  </span>
+                )}
+                {goodCount > 0 && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-green-100 dark:bg-green-900/40 px-2 py-0.5 text-xs text-green-700 dark:text-green-300">
+                    {goodCount}
+                  </span>
+                )}
+              </span>
+            )}
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            {annotations.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setHighlightEnabled(!highlightEnabled)}
+                aria-label={highlightEnabled ? "ハイライトを非表示" : "ハイライトを表示"}
+              >
+                {highlightEnabled ? (
+                  <>
+                    <EyeOff className="mr-1.5 h-4 w-4" />
+                    ハイライトOFF
+                  </>
+                ) : (
+                  <>
+                    <Eye className="mr-1.5 h-4 w-4" />
+                    ハイライトON
+                  </>
+                )}
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsCollapsed(!isCollapsed)}
+              aria-label={isCollapsed ? "原文スクリプトを展開" : "原文スクリプトを折りたたむ"}
+              aria-expanded={!isCollapsed}
+            >
+              {isCollapsed ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronUp className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      {!isCollapsed && (
+        <CardContent className="space-y-4">
+          {/* 凡例 */}
+          {annotations.length > 0 && highlightEnabled && <AnnotationLegend />}
+
+          {/* 原文テキスト（ハイライト付き） */}
+          <div
+            data-transcript-container=""
+            className="relative rounded-lg bg-muted/50 p-4 text-sm leading-relaxed whitespace-pre-wrap"
+          >
+            {segments.map((segment, i) => (
+              <HighlightedSpan
+                key={i}
+                segment={segment}
+                highlightEnabled={highlightEnabled}
+              />
+            ))}
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -269,6 +269,7 @@ export interface Database {
           improvement_points: Json;
           overall_comment: string | null;
           category_scores: CategoryScores;
+          annotations: Json;
           raw_response: Json | null;
           model_version: string | null;
           created_at: string;
@@ -287,6 +288,7 @@ export interface Database {
           improvement_points?: Json;
           overall_comment?: string | null;
           category_scores?: CategoryScores;
+          annotations?: Json;
           raw_response?: Json | null;
           model_version?: string | null;
           created_at?: string;
@@ -305,6 +307,7 @@ export interface Database {
           improvement_points?: Json;
           overall_comment?: string | null;
           category_scores?: CategoryScores;
+          annotations?: Json;
           raw_response?: Json | null;
           model_version?: string | null;
           created_at?: string;

--- a/supabase/migrations/00007_annotations.sql
+++ b/supabase/migrations/00007_annotations.sql
@@ -1,0 +1,8 @@
+-- Issue #106: 原文スクリプト表示 + インラインフィードバック（ハイライト）
+-- feedbacks テーブルに annotations JSONB カラムを追加
+
+ALTER TABLE feedbacks
+  ADD COLUMN IF NOT EXISTS annotations JSONB DEFAULT '[]'::jsonb;
+
+-- annotations カラムにコメント追加
+COMMENT ON COLUMN feedbacks.annotations IS 'AI分析によるテキストアノテーション（ハイライト情報）。各要素: {start, end, type, text, reason, suggestion}';


### PR DESCRIPTION
## Summary
closes #106

- feedbacks テーブルに `annotations JSONB` カラムを追加（マイグレーション 00007）
- AI プロンプトを拡張し、原文テキストに対する annotations（error/warning/good の3分類）を出力するよう指示
- `AnnotatedTranscript` コンポーネント新規作成：テキスト分割 → ハイライト表示 → ツールチップ
- 結果ページに「原文スクリプト」セクションを追加（折りたたみ可能・デフォルト展開）

## 変更内容

### DB マイグレーション
- `supabase/migrations/00007_annotations.sql`: feedbacks テーブルに `annotations JSONB DEFAULT '[]'` カラム追加

### AI プロンプト拡張
- `src/app/api/analyze/route.ts`:
  - `Annotation` 型定義追加
  - `AIFeedbackResponse` に `annotations` フィールド追加
  - プロンプトに annotations 出力指示を追加（type 分類基準・ルール記載）
  - annotations を feedbacks テーブルに保存

### 新規コンポーネント
- `src/components/annotated-transcript.tsx`:
  - `parseAnnotations()`: JSON → Annotation[] のパーサー
  - `splitTextByAnnotations()`: テキストをセグメント分割（重複範囲処理あり）
  - ハイライト色: 赤 (error)、黄 (warning)、緑 (good)
  - ツールチップ: クリック/タップで reason + suggestion 表示
  - ハイライト ON/OFF トグル
  - 折りたたみ UI（デフォルト展開）
  - 凡例表示
  - アクセシビリティ: role="button", aria-label, aria-expanded, role="tooltip"

### 結果ページ更新
- `src/app/interview/[id]/result/page.tsx`: rawTranscript を ResultContent に渡す
- `src/app/interview/[id]/result/result-content.tsx`:
  - AnnotatedTranscript を dynamic import
  - annotations パース & 原文スクリプトセクション追加

### 型定義
- `src/types/database.ts`: feedbacks の Row/Insert/Update に `annotations: Json` 追加

## Test plan
- [ ] 新規面接を分析し、feedbacks テーブルに annotations が保存されることを確認
- [ ] 結果ページに「原文スクリプト」セクションが表示されることを確認
- [ ] 赤・黄・緑のハイライトが正しく色分けされていることを確認
- [ ] ハイライト箇所クリック/タップでツールチップが表示されることを確認
- [ ] ハイライト ON/OFF トグルが動作することを確認
- [ ] 折りたたみボタンでセクションの開閉ができることを確認
- [ ] annotations がない既存データでもエラーなく表示されることを確認
- [ ] ダークモードでの表示を確認
- [ ] Supabase マイグレーション `00007_annotations.sql` を適用

🤖 Generated with [Claude Code](https://claude.com/claude-code)