### PR TITLE
fix: Sprint 6 QA 修正 (#124, #125, #126)

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -491,7 +491,7 @@ export async function POST(request: Request) {
       suggestions: feedback.suggestions || [],
       strengths: feedback.strengths || [],
       improvements: feedback.improvements || [],
-      annotations: Array.isArray(feedback.annotations) ? feedback.annotations : [],
+      annotations: Array.isArray(feedback.annotations) ? feedback.annotations.slice(0, 30) : [],
       raw_response: feedback as unknown,
       model_version: MODEL_NAME,
     } as never);

--- a/src/app/dashboard/growth/page.tsx
+++ b/src/app/dashboard/growth/page.tsx
@@ -52,11 +52,13 @@ export default async function GrowthPage() {
 
   // フィードバックを一括取得
   // 面接IDが0件の場合はクエリをスキップし、空配列として扱う
+  // Defence-in-Depth: RLS に加えアプリケーション層でも user_id フィルタ
   const { data: feedbacks } = interviewIds.length > 0
     ? await supabase
         .from("feedbacks")
         .select("interview_id, overall_score, category_scores, filler_words, created_at")
         .in("interview_id", interviewIds)
+        .eq("user_id", user.id)
     : { data: null };
 
   const feedbackList = (feedbacks ?? []) as {

--- a/src/app/interview/[id]/result/page.tsx
+++ b/src/app/interview/[id]/result/page.tsx
@@ -1,7 +1,15 @@
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/types/supabase";
 import { ResultContent } from "./result-content";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "面接結果 | InterviewCoach",
+    robots: { index: false },
+  };
+}
 
 type Interview = Database["public"]["Tables"]["interviews"]["Row"];
 type Transcript = Database["public"]["Tables"]["transcripts"]["Row"];
@@ -46,10 +54,12 @@ export default async function ResultPage({
   const transcripts = (transcriptsData ?? []) as Transcript[];
 
   // 最新のフィードバックを取得（履歴として複数保持されるため）
+  // Defence-in-Depth: RLS に加えアプリケーション層でも user_id フィルタ
   const { data: feedbackData } = await supabase
     .from("feedbacks")
     .select("*")
     .eq("interview_id", id)
+    .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(1)
     .single();

--- a/src/components/annotated-transcript.tsx
+++ b/src/components/annotated-transcript.tsx
@@ -40,7 +40,9 @@ export function parseAnnotations(data: Json): Annotation[] {
     .filter((item) => {
       return (
         typeof item.start === "number" &&
+        Number.isFinite(item.start) &&
         typeof item.end === "number" &&
+        Number.isFinite(item.end) &&
         typeof item.type === "string" &&
         typeof item.text === "string" &&
         typeof item.reason === "string" &&
@@ -138,8 +140,17 @@ function AnnotationTooltip({
         onClose();
       }
     }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
   }, [onClose]);
 
   const typeConfig = {


### PR DESCRIPTION
## Summary
- **#124 (Medium)**: AnnotationTooltip に Escape キーでの閉じ処理を追加
- **#125 (Medium)**: feedbacks クエリに `user_id` フィルタを追加 (Defence-in-Depth)
  - `src/app/interview/[id]/result/page.tsx`
  - `src/app/dashboard/growth/page.tsx`
- **#126 (Low)**: `result/page.tsx` に `generateMetadata` を追加 (`title: "面接結果 | InterviewCoach"`, `robots: { index: false }`)
- **Hacker Medium-1**: annotations 配列の上限チェック (`.slice(0, 30)`) を `route.ts` に追加
- **Hacker Low-1**: `parseAnnotations` に `Number.isFinite` チェックを追加

closes #124, closes #125, closes #126

## Test plan
- [ ] AnnotationTooltip 表示中に Esc キーを押して閉じることを確認
- [ ] result/page.tsx でフィードバック取得時に user_id フィルタが効いていることを確認
- [ ] growth/page.tsx でフィードバック取得時に user_id フィルタが効いていることを確認
- [ ] result ページの HTML head に `<meta name="robots" content="noindex">` と `<title>面接結果 | InterviewCoach</title>` が含まれることを確認
- [ ] annotations が 30 件を超える場合に切り捨てられることを確認
- [ ] NaN/Infinity の start/end を持つ annotation がフィルタされることを確認
- [ ] `npm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)