### PR TITLE
feat: #131 料金プラン改定（上限追加・Premium追加・Haiku対応）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,13 @@ ASSEMBLYAI_API_KEY=your_assemblyai_api_key
 # Anthropic (Claude API)
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
+# Stripe
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+STRIPE_PRO_PRICE_ID=price_xxx
+STRIPE_PREMIUM_PRICE_ID=price_xxx
+
 # Sentry
 NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn
 SENTRY_DSN=your_sentry_dsn

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { createClient } from "@/lib/supabase/server";
 import Anthropic from "@anthropic-ai/sdk";
-import type { InterviewCategory, InterviewRound } from "@/types/database";
-import { checkUsageLimit } from "@/lib/subscription";
-import { FREE_MONTHLY_LIMIT } from "@/lib/stripe/config";
+import type { InterviewCategory, InterviewRound, SubscriptionPlan } from "@/types/database";
+import { checkUsageLimit, getModelForPlan } from "@/lib/subscription";
+import { PLANS } from "@/lib/stripe/config";
 
 // ============================================================
 // 型定義
@@ -273,19 +273,19 @@ ${transcriptText}
 // ============================================================
 
 const MAX_RETRIES = 3;
-const MODEL_NAME = "claude-sonnet-4-6";
 
 async function callClaudeWithRetry(
   anthropic: Anthropic,
   systemPrompt: string,
-  userPrompt: string
+  userPrompt: string,
+  modelName: string
 ): Promise<AIFeedbackResponse> {
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       const message = await anthropic.messages.create({
-        model: MODEL_NAME,
+        model: modelName,
         max_tokens: 4096,
         messages: [
           {
@@ -392,17 +392,22 @@ export async function POST(request: Request) {
     const interview = interviewData as Record<string, unknown>;
 
     // サブスクリプション利用制限チェック
-    const canUse = await checkUsageLimit(user.id);
-    if (!canUse) {
+    const usageResult = await checkUsageLimit(user.id);
+    if (!usageResult.allowed) {
+      const planName = usageResult.plan === "free" ? "無料" : PLANS[usageResult.plan as Exclude<SubscriptionPlan, "enterprise">]?.name ?? usageResult.plan;
+      const limitCount = usageResult.limit ?? 0;
       return NextResponse.json(
         {
-          error: `無料プランの月間利用上限（${FREE_MONTHLY_LIMIT}回）に達しました。Pro プランにアップグレードすると無制限でご利用いただけます。`,
+          error: `${planName}プランの月間利用上限（${limitCount}回）に達しました。上位プランにアップグレードすると、より多くの分析をご利用いただけます。`,
           code: "USAGE_LIMIT_EXCEEDED",
           upgrade_url: "/pricing",
         },
         { status: 403 }
       );
     }
+
+    // プランに応じた AI モデルを決定
+    const modelName = getModelForPlan(usageResult.plan);
 
     // ステータスを analyzing に更新
     // as never: Supabase 生成型が未定義のため型アサーションが必要。supabase gen types 実行後に除去可能。
@@ -472,9 +477,9 @@ export async function POST(request: Request) {
       profile
     );
 
-    // Claude API 呼び出し（リトライ付き）
+    // Claude API 呼び出し（リトライ付き・プラン別モデル）
     const anthropic = new Anthropic({ apiKey });
-    const feedback = await callClaudeWithRetry(anthropic, systemPrompt, userPrompt);
+    const feedback = await callClaudeWithRetry(anthropic, systemPrompt, userPrompt, modelName);
 
     // feedbacks テーブルに保存（履歴として追加、上書きしない）
     // as never: Supabase 生成型が未定義のため型アサーションが必要。supabase gen types 実行後に除去可能。
@@ -493,7 +498,7 @@ export async function POST(request: Request) {
       improvements: feedback.improvements || [],
       annotations: Array.isArray(feedback.annotations) ? feedback.annotations.slice(0, 30) : [],
       raw_response: feedback as unknown,
-      model_version: MODEL_NAME,
+      model_version: modelName,
     } as never);
 
     if (insertError) {

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getStripe } from "@/lib/stripe/server";
-import { PLANS, getBaseUrl } from "@/lib/stripe/config";
+import { PLANS, getBaseUrl, PAID_PLAN_KEYS } from "@/lib/stripe/config";
+import type { PaidPlanKey } from "@/lib/stripe/config";
 import { getUserSubscription } from "@/lib/subscription";
 
-export async function POST() {
+interface CheckoutRequest {
+  plan?: string;
+}
+
+export async function POST(request: Request) {
   try {
     const supabase = await createClient();
     const {
@@ -14,17 +19,32 @@ export async function POST() {
       return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
     }
 
-    // 既に Pro 以上のプランの場合はエラー
+    // リクエストボディからプランを取得（デフォルトは pro）
+    let targetPlan: PaidPlanKey = "pro";
+    try {
+      const body = (await request.json()) as CheckoutRequest;
+      if (body.plan && PAID_PLAN_KEYS.includes(body.plan as PaidPlanKey)) {
+        targetPlan = body.plan as PaidPlanKey;
+      }
+    } catch {
+      // body が空の場合はデフォルトの pro を使用
+    }
+
+    // 既に同一以上のプランの場合はエラー
     const subscription = await getUserSubscription(user.id);
-    if (subscription.plan !== "free") {
+    const planOrder = ["free", "pro", "premium", "enterprise"] as const;
+    const currentIndex = planOrder.indexOf(subscription.plan as (typeof planOrder)[number]);
+    const targetIndex = planOrder.indexOf(targetPlan);
+
+    if (currentIndex >= targetIndex) {
       return NextResponse.json(
-        { error: "既に有料プランに加入済みです" },
+        { error: "既に同等以上のプランに加入済みです。プラン変更は設定画面の「支払い・プラン管理」からお手続きください。" },
         { status: 400 }
       );
     }
 
     const stripe = getStripe();
-    const priceId = PLANS.pro.stripePriceId;
+    const priceId = PLANS[targetPlan].stripePriceId;
     if (!priceId) {
       return NextResponse.json(
         { error: "Stripe Price ID が設定されていません" },
@@ -54,9 +74,9 @@ export async function POST() {
       success_url: `${baseUrl}/pricing/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${baseUrl}/pricing/cancel`,
       subscription_data: {
-        metadata: { supabase_user_id: user.id },
+        metadata: { supabase_user_id: user.id, plan: targetPlan },
       },
-      metadata: { supabase_user_id: user.id },
+      metadata: { supabase_user_id: user.id, plan: targetPlan },
     });
 
     return NextResponse.json({ url: session.url });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { headers } from "next/headers";
 import { getStripe } from "@/lib/stripe/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { PLANS } from "@/lib/stripe/config";
 import type { SubscriptionPlan, SubscriptionStatus } from "@/types/database";
 import type Stripe from "stripe";
 
@@ -17,6 +18,30 @@ function getWebhookSecret(): string {
   const secret = process.env.STRIPE_WEBHOOK_SECRET;
   if (!secret) throw new Error("STRIPE_WEBHOOK_SECRET が設定されていません");
   return secret;
+}
+
+/**
+ * Stripe の Price ID からプランを判定する。
+ * メタデータ -> Price ID の順でフォールバック。
+ */
+function resolvePlan(metadata: Record<string, string> | undefined, priceId?: string): SubscriptionPlan {
+  // 1. メタデータに plan が明示されていればそれを使う
+  if (metadata?.plan === "premium" || metadata?.plan === "pro") {
+    return metadata.plan;
+  }
+
+  // 2. Price ID からプランをマッチング
+  if (priceId) {
+    if (PLANS.premium.stripePriceId && priceId === PLANS.premium.stripePriceId) {
+      return "premium";
+    }
+    if (PLANS.pro.stripePriceId && priceId === PLANS.pro.stripePriceId) {
+      return "pro";
+    }
+  }
+
+  // 3. デフォルトは pro（後方互換）
+  return "pro";
 }
 
 /** Stripe の subscription status を DB の enum にマッピング */
@@ -52,12 +77,20 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   const periodStart = subData.current_period_start as number | undefined;
   const periodEnd = subData.current_period_end as number | undefined;
 
+  // Price ID またはメタデータからプランを判定
+  const items = subscription.items?.data;
+  const priceId = items?.[0]?.price?.id;
+  const plan = resolvePlan(
+    subscription.metadata as Record<string, string> | undefined,
+    priceId
+  );
+
   await supabase.from("subscriptions").upsert(
     {
       user_id: userId,
       stripe_customer_id: typeof session.customer === "string" ? session.customer : session.customer?.id ?? null,
       stripe_subscription_id: subscription.id,
-      plan: "pro" as SubscriptionPlan,
+      plan: plan as SubscriptionPlan,
       status: mapStripeStatus(subscription.status),
       current_period_start: periodStart ? new Date(periodStart * 1000).toISOString() : null,
       current_period_end: periodEnd ? new Date(periodEnd * 1000).toISOString() : null,
@@ -80,7 +113,12 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
   const periodStart = subData.current_period_start as number | undefined;
   const periodEnd = subData.current_period_end as number | undefined;
 
-  const plan: SubscriptionPlan = subscription.status === "canceled" ? "free" : "pro";
+  // キャンセル時は free、それ以外は Price ID / メタデータからプランを判定
+  const items = subscription.items?.data;
+  const priceId = items?.[0]?.price?.id;
+  const plan: SubscriptionPlan = subscription.status === "canceled"
+    ? "free"
+    : resolvePlan(subscription.metadata as Record<string, string> | undefined, priceId);
 
   await supabase
     .from("subscriptions")

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Check, X } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
@@ -15,8 +14,23 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { UpgradeButton } from "./upgrade-button";
+import type { SubscriptionPlan } from "@/types/database";
 
 export const metadata = { title: "料金プラン | InterviewCoach" };
+
+/** Free プランで利用不可の機能一覧 */
+const FREE_EXCLUDED_FEATURES = [
+  "成長トラッキング",
+  "パーソナライズ分析",
+  "AI 模擬面接",
+  "優先処理",
+];
+
+/** Pro プランで利用不可の機能一覧 */
+const PRO_EXCLUDED_FEATURES = [
+  "AI 模擬面接（無制限）",
+  "優先処理",
+];
 
 export default async function PricingPage() {
   const supabase = await createClient();
@@ -25,28 +39,44 @@ export default async function PricingPage() {
   } = await supabase.auth.getUser();
 
   // 未ログインでも料金ページは閲覧可能
-  let currentPlan: string | null = null;
+  let currentPlan: SubscriptionPlan | null = null;
   if (user) {
     const sub = await getUserSubscription(user.id);
     currentPlan = sub.plan;
   }
 
-  const isPro = currentPlan === "pro" || currentPlan === "enterprise";
+  /** 指定プランが現在のプランか */
+  function isCurrentPlan(plan: string): boolean {
+    return currentPlan === plan;
+  }
+
+  /** 指定プラン以上か（アップグレード不要か） */
+  function isAtLeast(plan: SubscriptionPlan): boolean {
+    const order: SubscriptionPlan[] = ["free", "pro", "premium", "enterprise"];
+    if (!currentPlan) return false;
+    return order.indexOf(currentPlan) >= order.indexOf(plan);
+  }
 
   return (
     <div className="px-4 py-16">
-      <div className="mx-auto max-w-4xl">
+      <div className="mx-auto max-w-6xl">
         <div className="text-center">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">料金プラン</h1>
-          <p className="mt-4 text-lg text-muted-foreground">まずは無料プランでお試しください</p>
+          <p className="mt-4 text-lg text-muted-foreground">
+            まずは無料プランでお試しください
+          </p>
         </div>
 
-        <div className="mt-16 grid gap-8 sm:grid-cols-2">
+        <div className="mt-16 grid gap-8 md:grid-cols-3">
+          {/* ============================================================ */}
           {/* 無料プラン */}
+          {/* ============================================================ */}
           <Card className="flex flex-col border-2">
             <CardHeader>
               <CardTitle className="text-2xl">{PLANS.free.name}</CardTitle>
-              <CardDescription className="text-base">まずは気軽に試したい方へ</CardDescription>
+              <CardDescription className="text-base">
+                {PLANS.free.description}
+              </CardDescription>
               <div className="mt-4">
                 <span className="text-4xl font-bold">¥0</span>
                 <span className="text-muted-foreground">/月</span>
@@ -60,18 +90,16 @@ export default async function PricingPage() {
                     <span className="text-sm">{f}</span>
                   </li>
                 ))}
-                <li className="flex items-center gap-3">
-                  <X className="size-5 shrink-0 text-muted-foreground/40" />
-                  <span className="text-sm text-muted-foreground">成長トラッキング</span>
-                </li>
-                <li className="flex items-center gap-3">
-                  <X className="size-5 shrink-0 text-muted-foreground/40" />
-                  <span className="text-sm text-muted-foreground">パーソナライズ分析</span>
-                </li>
+                {FREE_EXCLUDED_FEATURES.map((f) => (
+                  <li key={f} className="flex items-center gap-3">
+                    <X className="size-5 shrink-0 text-muted-foreground/40" />
+                    <span className="text-sm text-muted-foreground">{f}</span>
+                  </li>
+                ))}
               </ul>
             </CardContent>
             <CardFooter>
-              {currentPlan === "free" ? (
+              {isCurrentPlan("free") ? (
                 <Badge variant="secondary" className="w-full justify-center py-2 text-sm">
                   現在のプラン
                 </Badge>
@@ -83,16 +111,22 @@ export default async function PricingPage() {
             </CardFooter>
           </Card>
 
+          {/* ============================================================ */}
           {/* Pro プラン */}
+          {/* ============================================================ */}
           <Card className="relative flex flex-col border-2 border-primary shadow-lg">
             <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-              <Badge className="px-4 py-1 text-sm">おすすめ</Badge>
+              <Badge className="px-4 py-1 text-sm">{PLANS.pro.badge}</Badge>
             </div>
             <CardHeader>
               <CardTitle className="text-2xl">{PLANS.pro.name}</CardTitle>
-              <CardDescription className="text-base">本気で面接対策したい方へ</CardDescription>
+              <CardDescription className="text-base">
+                {PLANS.pro.description}
+              </CardDescription>
               <div className="mt-4">
-                <span className="text-4xl font-bold">¥{PLANS.pro.priceMonthly.toLocaleString()}</span>
+                <span className="text-4xl font-bold">
+                  ¥{PLANS.pro.priceMonthly.toLocaleString()}
+                </span>
                 <span className="text-muted-foreground">/月</span>
               </div>
             </CardHeader>
@@ -104,18 +138,70 @@ export default async function PricingPage() {
                     <span className="text-sm">{f}</span>
                   </li>
                 ))}
+                {PRO_EXCLUDED_FEATURES.map((f) => (
+                  <li key={f} className="flex items-center gap-3">
+                    <X className="size-5 shrink-0 text-muted-foreground/40" />
+                    <span className="text-sm text-muted-foreground">{f}</span>
+                  </li>
+                ))}
               </ul>
             </CardContent>
             <CardFooter>
-              {isPro ? (
+              {isCurrentPlan("pro") ? (
+                <Badge variant="secondary" className="w-full justify-center py-2 text-sm">
+                  現在のプラン
+                </Badge>
+              ) : isAtLeast("pro") ? null : user ? (
+                <UpgradeButton planKey="pro" label="Pro にアップグレード" />
+              ) : (
+                <Button className="w-full" size="lg" asChild>
+                  <Link href="/signup">Pro で始める</Link>
+                </Button>
+              )}
+            </CardFooter>
+          </Card>
+
+          {/* ============================================================ */}
+          {/* Premium プラン */}
+          {/* ============================================================ */}
+          <Card className="relative flex flex-col border-2 border-violet-500/50 shadow-md">
+            <div className="absolute -top-3 left-1/2 -translate-x-1/2">
+              <Badge variant="secondary" className="bg-violet-100 px-4 py-1 text-sm text-violet-700">
+                {PLANS.premium.badge}
+              </Badge>
+            </div>
+            <CardHeader>
+              <CardTitle className="text-2xl">{PLANS.premium.name}</CardTitle>
+              <CardDescription className="text-base">
+                {PLANS.premium.description}
+              </CardDescription>
+              <div className="mt-4">
+                <span className="text-4xl font-bold">
+                  ¥{PLANS.premium.priceMonthly.toLocaleString()}
+                </span>
+                <span className="text-muted-foreground">/月</span>
+              </div>
+            </CardHeader>
+            <CardContent className="flex-1">
+              <ul className="space-y-3">
+                {PLANS.premium.features.map((f) => (
+                  <li key={f} className="flex items-center gap-3">
+                    <Check className="size-5 shrink-0 text-violet-600" />
+                    <span className="text-sm">{f}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+            <CardFooter>
+              {isCurrentPlan("premium") || isCurrentPlan("enterprise") ? (
                 <Badge variant="secondary" className="w-full justify-center py-2 text-sm">
                   現在のプラン
                 </Badge>
               ) : user ? (
-                <UpgradeButton />
+                <UpgradeButton planKey="premium" label="Premium にアップグレード" variant="violet" />
               ) : (
-                <Button className="w-full" size="lg" asChild>
-                  <Link href="/signup">Pro で始める</Link>
+                <Button className="w-full bg-violet-600 hover:bg-violet-700" size="lg" asChild>
+                  <Link href="/signup">Premium で始める</Link>
                 </Button>
               )}
             </CardFooter>

--- a/src/app/pricing/upgrade-button.tsx
+++ b/src/app/pricing/upgrade-button.tsx
@@ -2,12 +2,30 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
-export function UpgradeButton() {
+interface UpgradeButtonProps {
+  /** checkout API に送るプランキー */
+  planKey?: "pro" | "premium";
+  /** ボタンのラベル */
+  label?: string;
+  /** カラーバリアント */
+  variant?: "default" | "violet";
+}
+
+export function UpgradeButton({
+  planKey = "pro",
+  label = "Pro にアップグレード",
+  variant = "default",
+}: UpgradeButtonProps) {
   const [loading, setLoading] = useState(false);
+
   const handleUpgrade = async () => {
     try {
       setLoading(true);
-      const response = await fetch("/api/stripe/checkout", { method: "POST", headers: { "Content-Type": "application/json" } });
+      const response = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan: planKey }),
+      });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || "チェックアウトに失敗しました");
       if (data.url) window.location.href = data.url;
@@ -17,9 +35,20 @@ export function UpgradeButton() {
       setLoading(false);
     }
   };
+
+  const buttonClassName =
+    variant === "violet"
+      ? "w-full bg-violet-600 hover:bg-violet-700"
+      : "w-full";
+
   return (
-    <Button className="w-full" size="lg" onClick={handleUpgrade} disabled={loading}>
-      {loading ? "処理中..." : "Pro にアップグレード"}
+    <Button
+      className={buttonClassName}
+      size="lg"
+      onClick={handleUpgrade}
+      disabled={loading}
+    >
+      {loading ? "処理中..." : label}
     </Button>
   );
 }

--- a/src/app/settings/billing/billing-client.tsx
+++ b/src/app/settings/billing/billing-client.tsx
@@ -29,6 +29,17 @@ function getStatusBadge(status: SubscriptionStatus) {
   return <Badge variant={config.variant}>{config.label}</Badge>;
 }
 
+/** アップグレードの案内文を返す */
+function getUpgradeMessage(plan: SubscriptionPlan): string {
+  if (plan === "free") {
+    return "上位プランにアップグレードすると、より多くの分析をご利用いただけます。";
+  }
+  if (plan === "pro") {
+    return "Premium プランにアップグレードすると無制限でご利用いただけます。";
+  }
+  return "";
+}
+
 export function BillingClient({ plan, status, planName, priceMonthly, currentPeriodEnd, cancelAt, canceledAt, hasStripeCustomer, usageUsed, usageLimit, usageRemaining }: BillingClientProps) {
   const [portalLoading, setPortalLoading] = useState(false);
   const handleOpenPortal = async () => {
@@ -47,6 +58,7 @@ export function BillingClient({ plan, status, planName, priceMonthly, currentPer
 
   const isCanceled = !!canceledAt || !!cancelAt;
   const usagePercent = usageLimit !== null ? Math.min(100, (usageUsed / usageLimit) * 100) : 0;
+  const canUpgrade = plan === "free" || plan === "pro";
 
   return (
     <div className="mt-8 space-y-6">
@@ -72,9 +84,10 @@ export function BillingClient({ plan, status, planName, priceMonthly, currentPer
           )}
         </CardContent>
         <CardFooter className="flex gap-3">
-          {plan === "free" ? (
-            <Button asChild><Link href="/pricing">Pro にアップグレード</Link></Button>
-          ) : hasStripeCustomer ? (
+          {canUpgrade ? (
+            <Button asChild><Link href="/pricing">アップグレード</Link></Button>
+          ) : null}
+          {hasStripeCustomer ? (
             <Button variant="outline" onClick={handleOpenPortal} disabled={portalLoading}>
               <CreditCard className="mr-2 size-4" />
               {portalLoading ? "読み込み中..." : "支払い・プラン管理"}
@@ -97,10 +110,11 @@ export function BillingClient({ plan, status, planName, priceMonthly, currentPer
               </div>
               <Progress value={usagePercent} className="h-2" />
               {usageRemaining === 0 && (
-                <p className="text-sm text-destructive">
-                  今月の利用上限に達しました。
-                  <Link href="/pricing" className="ml-1 font-medium underline underline-offset-4">Pro プランにアップグレード</Link>
-                  すると無制限でご利用いただけます。
+                <p className="text-sm text-destructive" role="alert" aria-live="assertive">
+                  今月の利用回数に達しました。
+                  <Link href="/pricing" className="ml-1 font-medium underline underline-offset-4">
+                    {getUpgradeMessage(plan) ? "上位プランにアップグレード" : "プランを確認"}
+                  </Link>
                 </p>
               )}
             </div>

--- a/src/app/settings/billing/page.tsx
+++ b/src/app/settings/billing/page.tsx
@@ -13,7 +13,7 @@ export default async function BillingPage() {
 
   const subscription = await getUserSubscription(user.id);
   const usage = await getRemainingUsage(user.id);
-  const planConfig = PLANS[subscription.plan === "enterprise" ? "pro" : subscription.plan];
+  const planConfig = PLANS[subscription.plan === "enterprise" ? "premium" : subscription.plan];
 
   return (
     <div className="px-4 py-16">

--- a/src/lib/stripe/config.ts
+++ b/src/lib/stripe/config.ts
@@ -1,35 +1,95 @@
 import type { SubscriptionPlan } from "@/types/database";
 
-/** 無料プランの月間利用上限 */
-export const FREE_MONTHLY_LIMIT = 3;
+// ============================================================
+// プラン別の月間利用上限
+// ============================================================
+
+/** プラン別の月間利用上限（null = 無制限） */
+export const PLAN_MONTHLY_LIMITS: Record<Exclude<SubscriptionPlan, "enterprise">, number | null> = {
+  free: 3,
+  pro: 30,
+  premium: null,
+};
+
+/** 無料プランの月間利用上限（後方互換用） */
+export const FREE_MONTHLY_LIMIT = PLAN_MONTHLY_LIMITS.free as number;
+
+// ============================================================
+// プラン別の AI モデル
+// ============================================================
+
+/** プラン別に使用する Claude モデル */
+export const PLAN_MODELS: Record<Exclude<SubscriptionPlan, "enterprise">, string> = {
+  free: "claude-haiku-4-5-20251001",
+  pro: "claude-sonnet-4-6",
+  premium: "claude-sonnet-4-6",
+};
+
+// ============================================================
+// プラン設定
+// ============================================================
 
 export interface PlanConfig {
   name: string;
+  description: string;
   priceMonthly: number;
   stripePriceId: string | null;
   features: string[];
+  badge: string | null;
+  monthlyLimit: number | null;
 }
 
 export const PLANS: Record<Exclude<SubscriptionPlan, "enterprise">, PlanConfig> = {
   free: {
     name: "無料プラン",
+    description: "まずは気軽に試したい方へ",
     priceMonthly: 0,
     stripePriceId: null,
-    features: ["月3回まで面接分析", "基本的なAIフィードバック", "スコア表示"],
+    features: [
+      "月3回まで面接分析",
+      "基本的なAIフィードバック",
+      "スコア表示",
+    ],
+    badge: null,
+    monthlyLimit: PLAN_MONTHLY_LIMITS.free,
   },
   pro: {
     name: "Pro プラン",
+    description: "本気で面接対策したい方へ",
     priceMonthly: 980,
     stripePriceId: process.env.STRIPE_PRO_PRICE_ID ?? null,
+    features: [
+      "月30回まで面接分析",
+      "詳細なAIフィードバック",
+      "スコア表示",
+      "成長トラッキング",
+      "パーソナライズ分析",
+    ],
+    badge: "おすすめ",
+    monthlyLimit: PLAN_MONTHLY_LIMITS.pro,
+  },
+  premium: {
+    name: "Premium プラン",
+    description: "すべての機能を制限なく使いたい方へ",
+    priceMonthly: 1980,
+    stripePriceId: process.env.STRIPE_PREMIUM_PRICE_ID ?? null,
     features: [
       "無制限の面接分析",
       "詳細なAIフィードバック",
       "スコア表示",
       "成長トラッキング",
       "パーソナライズ分析",
+      "AI 模擬面接（無制限）",
+      "優先処理",
     ],
+    badge: "すべての機能",
+    monthlyLimit: PLAN_MONTHLY_LIMITS.premium,
   },
 };
+
+/** 有料プランのキー一覧 */
+export const PAID_PLAN_KEYS = ["pro", "premium"] as const;
+export type PaidPlanKey = (typeof PAID_PLAN_KEYS)[number];
 
 export function getBaseUrl(): string {
   if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL;

--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { FREE_MONTHLY_LIMIT } from "@/lib/stripe/config";
+import { PLAN_MONTHLY_LIMITS, PLAN_MODELS } from "@/lib/stripe/config";
 import type { Row, SubscriptionPlan, SubscriptionStatus } from "@/types/database";
 
 export interface UserSubscription {
@@ -67,35 +67,71 @@ async function getMonthlyUsageCount(userId: string): Promise<number> {
 }
 
 /**
- * ユーザーが分析を実行可能か判定する。
- * Pro プラン以上は常に true、無料プランは月間利用上限をチェックする。
+ * プラン別の月間利用上限を取得する。
+ * enterprise は無制限として扱う。
  */
-export async function checkUsageLimit(userId: string): Promise<boolean> {
-  const sub = await getUserSubscription(userId);
-  if (sub.plan !== "free") return true;
+function getPlanLimit(plan: SubscriptionPlan): number | null {
+  if (plan === "enterprise") return null;
+  return PLAN_MONTHLY_LIMITS[plan];
+}
 
+/**
+ * プラン別の AI モデルを取得する。
+ * enterprise は premium と同じモデルを使う。
+ */
+export function getModelForPlan(plan: SubscriptionPlan): string {
+  if (plan === "enterprise") return PLAN_MODELS.premium;
+  return PLAN_MODELS[plan];
+}
+
+/**
+ * ユーザーが分析を実行可能か判定する。
+ * 各プランの月間利用上限をチェックする（null = 無制限）。
+ */
+export async function checkUsageLimit(userId: string): Promise<{
+  allowed: boolean;
+  plan: SubscriptionPlan;
+  used: number;
+  limit: number | null;
+}> {
+  const sub = await getUserSubscription(userId);
+  const limit = getPlanLimit(sub.plan);
   const used = await getMonthlyUsageCount(userId);
-  return used < FREE_MONTHLY_LIMIT;
+
+  // 上限が null のプランは無制限
+  if (limit === null) {
+    return { allowed: true, plan: sub.plan, used, limit };
+  }
+
+  return {
+    allowed: used < limit,
+    plan: sub.plan,
+    used,
+    limit,
+  };
 }
 
 /**
  * 残り利用回数の情報を返す
  */
 export async function getRemainingUsage(userId: string): Promise<{
+  plan: SubscriptionPlan;
   used: number;
   limit: number | null;
   remaining: number | null;
 }> {
   const sub = await getUserSubscription(userId);
   const used = await getMonthlyUsageCount(userId);
+  const limit = getPlanLimit(sub.plan);
 
-  if (sub.plan !== "free") {
-    return { used, limit: null, remaining: null };
+  if (limit === null) {
+    return { plan: sub.plan, used, limit: null, remaining: null };
   }
 
   return {
+    plan: sub.plan,
     used,
-    limit: FREE_MONTHLY_LIMIT,
-    remaining: Math.max(0, FREE_MONTHLY_LIMIT - used),
+    limit,
+    remaining: Math.max(0, limit - used),
   };
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -32,7 +32,7 @@ export type InterviewRound =
   | "other";
 
 /** サブスクリプションプラン */
-export type SubscriptionPlan = "free" | "pro" | "enterprise";
+export type SubscriptionPlan = "free" | "pro" | "premium" | "enterprise";
 
 /** サブスクリプションステータス */
 export type SubscriptionStatus =
@@ -64,6 +64,33 @@ export type InterviewStatus =
 
 /** 話者 */
 export type Speaker = "interviewer" | "interviewee";
+
+/** 模擬面接カテゴリ */
+export type MockInterviewCategory =
+  | "general"
+  | "technical"
+  | "behavioral"
+  | "case";
+
+/** 模擬面接ラウンド */
+export type MockInterviewRound =
+  | "first"
+  | "second"
+  | "third"
+  | "final";
+
+/** 模擬面接難易度 */
+export type MockInterviewDifficulty = "easy" | "normal" | "hard";
+
+/** 模擬面接ステータス */
+export type MockInterviewStatus = "in_progress" | "completed";
+
+/** 模擬面接メッセージ */
+export interface MockInterviewMessage {
+  role: "interviewer" | "user";
+  content: string;
+  timestamp: string;
+}
 
 // ============================================================
 // カテゴリ別スコアの型
@@ -144,6 +171,7 @@ export interface Database {
           created_at?: string;
           updated_at?: string;
         };
+        Relationships: [];
       };
 
       companies: {
@@ -168,6 +196,7 @@ export interface Database {
           normalized_name?: string;
           created_at?: string;
         };
+        Relationships: [];
       };
 
       interviews: {
@@ -225,6 +254,7 @@ export interface Database {
           created_at?: string;
           updated_at?: string;
         };
+        Relationships: [];
       };
 
       transcripts: {
@@ -252,6 +282,7 @@ export interface Database {
           start_time?: number;
           end_time?: number;
         };
+        Relationships: [];
       };
 
       feedbacks: {
@@ -312,6 +343,7 @@ export interface Database {
           model_version?: string | null;
           created_at?: string;
         };
+        Relationships: [];
       };
 
       tags: {
@@ -336,6 +368,7 @@ export interface Database {
           color?: string;
           created_at?: string;
         };
+        Relationships: [];
       };
 
       interview_tags: {
@@ -351,6 +384,7 @@ export interface Database {
           interview_id?: string;
           tag_id?: string;
         };
+        Relationships: [];
       };
 
       subscriptions: {
@@ -396,6 +430,63 @@ export interface Database {
           created_at?: string;
           updated_at?: string;
         };
+        Relationships: [];
+      };
+
+      /** Issue #129: AI模擬面接 */
+      mock_interviews: {
+        Row: {
+          id: string;
+          user_id: string;
+          company_name: string | null;
+          industry: string | null;
+          category: string;
+          round: string;
+          duration_minutes: number;
+          difficulty: string;
+          messages: Json;
+          status: string;
+          total_questions: number;
+          started_at: string;
+          completed_at: string | null;
+          feedback_id: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          company_name?: string | null;
+          industry?: string | null;
+          category?: string;
+          round?: string;
+          duration_minutes?: number;
+          difficulty?: string;
+          messages?: Json;
+          status?: string;
+          total_questions?: number;
+          started_at?: string;
+          completed_at?: string | null;
+          feedback_id?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          company_name?: string | null;
+          industry?: string | null;
+          category?: string;
+          round?: string;
+          duration_minutes?: number;
+          difficulty?: string;
+          messages?: Json;
+          status?: string;
+          total_questions?: number;
+          started_at?: string;
+          completed_at?: string | null;
+          feedback_id?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
       };
 
       /** Issue #78: 面接結果の共有リンク */
@@ -427,6 +518,7 @@ export interface Database {
           expires_at?: string | null;
           created_at?: string;
         };
+        Relationships: [];
       };
     };
 
@@ -444,6 +536,10 @@ export interface Database {
       subscription_plan: SubscriptionPlan;
       subscription_status: SubscriptionStatus;
       job_hunting_status: JobHuntingStatus;
+      mock_interview_category: MockInterviewCategory;
+      mock_interview_round: MockInterviewRound;
+      mock_interview_difficulty: MockInterviewDifficulty;
+      mock_interview_status: MockInterviewStatus;
     };
   };
 }


### PR DESCRIPTION
## Summary
closes #131

- **Proプラン**: 月30回の利用上限を追加（以前は無制限）
- **Premiumプラン新設**: ¥1,980/月 — 無制限分析・AI模擬面接（無制限）・優先処理
- **Freeプラン**: 分析に `claude-haiku-4-5-20251001` を使用（コスト75%削減）
- **pricingページ**: 3カラム表示（Free / Pro / Premium）
- **checkUsageLimit**: プラン別の月間上限チェックに対応
- **analyze API**: プランに応じたモデル切り替え（Free=Haiku, Pro/Premium=Sonnet）
- **checkout API**: リクエストボディでプラン指定に対応
- **webhook**: Price ID / メタデータベースのプラン判定
- **billing画面**: Premium対応のアップグレード導線
- **.env.example**: `STRIPE_PREMIUM_PRICE_ID` 追加

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `src/lib/stripe/config.ts` | `PLAN_MONTHLY_LIMITS`, `PLAN_MODELS`, Premium プラン定義追加 |
| `src/lib/subscription.ts` | `checkUsageLimit` をプラン別上限対応に、`getModelForPlan` 追加 |
| `src/app/api/analyze/route.ts` | プラン別モデル選択、上限エラーメッセージ更新 |
| `src/app/pricing/page.tsx` | 3カラムレイアウト（Free/Pro/Premium） |
| `src/app/pricing/upgrade-button.tsx` | `planKey` props でプラン指定対応 |
| `src/app/api/stripe/checkout/route.ts` | `plan` パラメータ対応 |
| `src/app/api/stripe/webhook/route.ts` | `resolvePlan()` で Price ID/メタデータからプラン判定 |
| `src/app/settings/billing/billing-client.tsx` | Premium対応のアップグレード導線 |
| `src/types/database.ts` | `SubscriptionPlan` に `"premium"` 追加 |
| `.env.example` | Stripe関連環境変数追加 |

## Test plan
- [ ] pricingページで3プラン（Free/Pro/Premium）が表示されること
- [ ] Free/Pro/Premiumそれぞれのアップグレードボタンが正しいplanをcheckout APIに送ること
- [ ] analyze APIでFreeプランの場合Haikuモデルが使用されること
- [ ] Proプランで月30回の上限に達した場合、エラーメッセージが表示されること
- [ ] Premiumプランでは無制限に分析が実行できること
- [ ] billing画面でプランに応じた利用状況が表示されること
- [ ] webhook経由でPremiumプランのサブスクリプションが正しく処理されること
- [ ] モバイルで3カラムが縦並びにレスポンシブ表示されること

---
Generated with [Claude Code](https://claude.com/claude-code)