### PR TITLE
fix: #142 mock-interview textarea autocomplete属性追加

### DIFF
--- a/src/app/mock-interview/[id]/chat/chat-interface.tsx
+++ b/src/app/mock-interview/[id]/chat/chat-interface.tsx
@@ -511,6 +511,7 @@ export function ChatInterface({
               <div className="relative flex-1">
                 <textarea
                   ref={textareaRef}
+                  autoComplete="off"
                   value={currentAnswer}
                   onChange={(e) => {
                     setCurrentAnswer(e.target.value);


### PR DESCRIPTION
## Summary
- chat-interface.tsx の textarea に `autoComplete="off"` を追加（Sprint Reflect ルール準拠）

## Test plan
- [x] ビルド通過確認済み

closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)