### PR TITLE
feat: #138 Part2 - 診断機能 + プロフィール統合

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/types/database";
+import { PERSONALITY_TYPES } from "@/lib/personality/types";
 
 type ProfileInsert = Database["public"]["Tables"]["profiles"]["Insert"];
 
@@ -57,6 +58,17 @@ const VALID_JOB_HUNTING_STATUSES = [
   "decided",
   "other",
 ] as const;
+
+/** バリデーション: パーソナリティタイプ (16タイプのみ or null) */
+function validatePersonalityType(value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") return null;
+  const upper = value.toUpperCase();
+  if (PERSONALITY_TYPES.includes(upper as (typeof PERSONALITY_TYPES)[number])) {
+    return upper;
+  }
+  return null;
+}
 
 /** バリデーション: 就活ステータス */
 function validateJobHuntingStatus(
@@ -151,6 +163,11 @@ export async function PUT(request: Request) {
       11
     );
 
+    // personality_type が送られてきた場合のみバリデーション＆セット
+    const personalityType = body.personality_type !== undefined
+      ? validatePersonalityType(body.personality_type)
+      : undefined;
+
     const profileData: ProfileInsert = {
       user_id: user.id,
       display_name: displayName,
@@ -162,6 +179,7 @@ export async function PUT(request: Request) {
       target_job_type: targetJobType,
       job_hunting_status: jobHuntingStatus,
       preferred_work_location: preferredWorkLocation,
+      ...(body.personality_type !== undefined && { personality_type: personalityType }),
       updated_at: new Date().toISOString(),
     };
 

--- a/src/app/personality/diagnosis/diagnosis-client.tsx
+++ b/src/app/personality/diagnosis/diagnosis-client.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  DIAGNOSIS_QUESTIONS,
+  calculatePersonalityType,
+} from "@/lib/personality/diagnosis";
+import {
+  PERSONALITY_DATA,
+  getGroupForType,
+} from "@/lib/personality/types";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Loader2, ArrowRight, ArrowLeft, CheckCircle, RotateCcw } from "lucide-react";
+
+type Phase = "intro" | "questions" | "result";
+
+export function DiagnosisClient() {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>("intro");
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const totalQuestions = DIAGNOSIS_QUESTIONS.length;
+  const currentQuestion = DIAGNOSIS_QUESTIONS[currentIndex];
+  const progress = phase === "questions"
+    ? Math.round(((currentIndex) / totalQuestions) * 100)
+    : phase === "result"
+      ? 100
+      : 0;
+
+  const result =
+    phase === "result" ? calculatePersonalityType(answers) : null;
+  const personalityInfo =
+    result ? PERSONALITY_DATA[result.type] : null;
+  const groupInfo =
+    result ? getGroupForType(result.type) : null;
+
+  // 回答を選択
+  const handleAnswer = useCallback(
+    (value: string) => {
+      const questionId = currentQuestion.id;
+      setAnswers((prev) => ({ ...prev, [questionId]: value }));
+
+      // 最後の質問なら結果表示へ
+      if (currentIndex === totalQuestions - 1) {
+        setPhase("result");
+      } else {
+        setCurrentIndex((prev) => prev + 1);
+      }
+    },
+    [currentIndex, currentQuestion, totalQuestions]
+  );
+
+  // 前の質問に戻る
+  const handleBack = useCallback(() => {
+    if (currentIndex > 0) {
+      setCurrentIndex((prev) => prev - 1);
+    }
+  }, [currentIndex]);
+
+  // 結果を保存
+  const handleSave = useCallback(async () => {
+    if (!result || saving) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ personality_type: result.type }),
+      });
+      if (res.ok) {
+        setSaved(true);
+      }
+    } catch {
+      // 静かに失敗
+    } finally {
+      setSaving(false);
+    }
+  }, [result, saving]);
+
+  // やり直し
+  const handleRetry = useCallback(() => {
+    setPhase("intro");
+    setCurrentIndex(0);
+    setAnswers({});
+    setSaved(false);
+  }, []);
+
+  // ── イントロ画面 ──
+  if (phase === "intro") {
+    return (
+      <div className="space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">パーソナリティ診断テスト</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            10問の簡単な質問であなたの性格タイプを診断します
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="space-y-4 pt-6">
+            <div className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                この診断テストでは、4つの軸をもとにあなたの性格タイプを判定します。
+              </p>
+              <ul className="ml-4 list-disc space-y-1">
+                <li><strong>E/I</strong> - 外向型 / 内向型</li>
+                <li><strong>S/N</strong> - 感覚型 / 直感型</li>
+                <li><strong>T/F</strong> - 思考型 / 感情型</li>
+                <li><strong>J/P</strong> - 判断型 / 知覚型</li>
+              </ul>
+              <p>
+                直感で回答してください。正解・不正解はありません。
+              </p>
+              <p className="text-xs">
+                所要時間: 約2分 / 全{totalQuestions}問
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex justify-center">
+          <Button
+            size="lg"
+            onClick={() => setPhase("questions")}
+          >
+            診断を始める
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── 質問画面 ──
+  if (phase === "questions" && currentQuestion) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold">パーソナリティ診断テスト</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Q{currentIndex + 1} / {totalQuestions}
+          </p>
+        </div>
+
+        {/* プログレスバー */}
+        <div className="h-2 w-full rounded-full bg-muted">
+          <div
+            className="h-2 rounded-full bg-primary transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg leading-relaxed">
+              {currentQuestion.question}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <button
+              type="button"
+              onClick={() => handleAnswer(currentQuestion.optionA.value)}
+              className="w-full rounded-lg border-2 border-border p-4 text-left text-sm transition-colors hover:border-primary hover:bg-primary/5"
+            >
+              <span className="mr-2 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+                A
+              </span>
+              {currentQuestion.optionA.label}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleAnswer(currentQuestion.optionB.value)}
+              className="w-full rounded-lg border-2 border-border p-4 text-left text-sm transition-colors hover:border-primary hover:bg-primary/5"
+            >
+              <span className="mr-2 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+                B
+              </span>
+              {currentQuestion.optionB.label}
+            </button>
+          </CardContent>
+        </Card>
+
+        {currentIndex > 0 && (
+          <div className="flex justify-start">
+            <Button variant="ghost" size="sm" onClick={handleBack}>
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              前の質問に戻る
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ── 結果画面 ──
+  if (phase === "result" && result && personalityInfo && groupInfo) {
+    return (
+      <div className="space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">診断結果</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            あなたのパーソナリティタイプが判明しました
+          </p>
+        </div>
+
+        {/* プログレスバー (100%) */}
+        <div className="h-2 w-full rounded-full bg-muted">
+          <div className="h-2 w-full rounded-full bg-primary" />
+        </div>
+
+        {/* 結果カード */}
+        <Card
+          className="overflow-hidden"
+          style={{ borderColor: `${personalityInfo.color}40` }}
+        >
+          <div
+            className="p-6 text-center"
+            style={{ backgroundColor: personalityInfo.colorLight }}
+          >
+            <div className="mb-3 text-5xl">
+              {personalityInfo.animalEmoji}
+            </div>
+            <span
+              className="inline-block rounded-full px-4 py-1 text-sm font-bold text-white"
+              style={{ backgroundColor: personalityInfo.color }}
+            >
+              {personalityInfo.type}
+            </span>
+            <h2 className="mt-2 text-xl font-bold">
+              {personalityInfo.name}
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {personalityInfo.nameEn}
+              </span>
+            </h2>
+            <p className="mt-1 text-sm" style={{ color: groupInfo.color }}>
+              {groupInfo.name}グループ
+            </p>
+          </div>
+
+          <CardContent className="space-y-4 pt-6">
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {personalityInfo.tagline}
+            </p>
+            <p className="text-sm leading-relaxed">
+              {personalityInfo.description}
+            </p>
+
+            {/* 面接での強み */}
+            <div>
+              <h3 className="mb-2 text-sm font-bold text-green-700 dark:text-green-400">
+                面接での強み
+              </h3>
+              <ul className="ml-4 list-disc space-y-1 text-sm text-muted-foreground">
+                {personalityInfo.interviewStrengths.map((s) => (
+                  <li key={s}>{s}</li>
+                ))}
+              </ul>
+            </div>
+
+            {/* 面接での課題 */}
+            <div>
+              <h3 className="mb-2 text-sm font-bold text-orange-700 dark:text-orange-400">
+                面接での課題
+              </h3>
+              <ul className="ml-4 list-disc space-y-1 text-sm text-muted-foreground">
+                {personalityInfo.interviewWeaknesses.map((w) => (
+                  <li key={w}>{w}</li>
+                ))}
+              </ul>
+            </div>
+
+            {/* アドバイス */}
+            <div
+              className="rounded-lg p-4"
+              style={{ backgroundColor: `${personalityInfo.color}10` }}
+            >
+              <h3 className="mb-1 text-sm font-bold">面接アドバイス</h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {personalityInfo.adviceTip}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* アクションボタン */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          {!saved ? (
+            <Button onClick={handleSave} disabled={saving} size="lg">
+              {saving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle className="mr-2 h-4 w-4" />
+              )}
+              {saving ? "保存中..." : "プロフィールに保存する"}
+            </Button>
+          ) : (
+            <Button disabled size="lg" variant="outline" className="text-green-600 border-green-300">
+              <CheckCircle className="mr-2 h-4 w-4" />
+              保存しました
+            </Button>
+          )}
+
+          <Button variant="outline" size="lg" onClick={handleRetry}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            もう一度診断する
+          </Button>
+        </div>
+
+        {/* リンク */}
+        <div className="flex flex-col items-center gap-2 text-sm">
+          <Link
+            href={`/personality/${personalityInfo.type.toLowerCase()}`}
+            className="text-primary hover:underline"
+          >
+            {personalityInfo.type} の詳細ページを見る
+          </Link>
+          <Link
+            href="/profile"
+            className="text-muted-foreground hover:underline"
+          >
+            プロフィール設定に戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/app/personality/diagnosis/page.tsx
+++ b/src/app/personality/diagnosis/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getUserSubscription } from "@/lib/subscription";
+import { DiagnosisClient } from "./diagnosis-client";
+
+export const metadata: Metadata = {
+  title: "パーソナリティ診断テスト",
+  description:
+    "10問の簡単なテストであなたの16パーソナリティタイプを診断。面接での強み・弱みを把握して就活に活かそう。",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * パーソナリティ診断ページ (Server Component)
+ * - 認証チェック
+ * - Pro/Premium プランチェック
+ */
+export default async function DiagnosisPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  // プランチェック: Pro/Premium のみ
+  const subscription = await getUserSubscription(user.id);
+  if (subscription.plan === "free") {
+    redirect("/pricing");
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <DiagnosisClient />
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,6 +23,13 @@ import {
   isNotificationEnabled,
   setNotificationEnabled as setNotificationEnabledStorage,
 } from "@/lib/notifications";
+import {
+  PERSONALITY_TYPES,
+  PERSONALITY_DATA,
+  getGroupForType,
+  isValidPersonalityType,
+  type PersonalityType,
+} from "@/lib/personality/types";
 import type { Database } from "@/types/database";
 
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
@@ -114,6 +122,7 @@ export default function ProfilePage() {
   const [preferredWorkLocation, setPreferredWorkLocation] = useState<string[]>(
     []
   );
+  const [personalityType, setPersonalityType] = useState<string>("");
 
   // 通知設定
   const [notificationSupported, setNotificationSupported] = useState(false);
@@ -171,6 +180,7 @@ export default function ProfilePage() {
         setTargetJobType(profile.target_job_type ?? []);
         setJobHuntingStatus(profile.job_hunting_status ?? "not_started");
         setPreferredWorkLocation(profile.preferred_work_location ?? []);
+        setPersonalityType(profile.personality_type ?? "");
       }
     } catch {
       setToast({ type: "error", message: "プロフィールの読み込みに失敗しました" });
@@ -232,6 +242,7 @@ export default function ProfilePage() {
           target_job_type: targetJobType,
           job_hunting_status: jobHuntingStatus,
           preferred_work_location: preferredWorkLocation,
+          personality_type: personalityType || null,
         }),
       });
 
@@ -587,6 +598,93 @@ export default function ProfilePage() {
                 </div>
               </div>
             )}
+          </CardContent>
+        </Card>
+
+        {/* パーソナリティタイプ */}
+        <Card
+          style={
+            personalityType && isValidPersonalityType(personalityType)
+              ? { borderColor: `${PERSONALITY_DATA[personalityType as PersonalityType].color}40` }
+              : undefined
+          }
+        >
+          <CardHeader>
+            <CardTitle>パーソナリティタイプ</CardTitle>
+            <CardDescription>
+              16パーソナリティタイプを設定すると、AIフィードバックがより的確になります
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* 設定済みの場合: タイプ表示 */}
+            {personalityType && isValidPersonalityType(personalityType) && (() => {
+              const pInfo = PERSONALITY_DATA[personalityType as PersonalityType];
+              const gInfo = getGroupForType(personalityType as PersonalityType);
+              return (
+                <div
+                  className="flex items-center gap-4 rounded-lg p-4"
+                  style={{ backgroundColor: pInfo.colorLight }}
+                >
+                  <div className="text-4xl">{pInfo.animalEmoji}</div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="rounded-full px-2.5 py-0.5 text-xs font-bold text-white"
+                        style={{ backgroundColor: pInfo.color }}
+                      >
+                        {pInfo.type}
+                      </span>
+                      <span className="text-sm font-bold">{pInfo.name}</span>
+                      <span className="text-xs text-muted-foreground">{pInfo.nameEn}</span>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {gInfo.name}グループ / {pInfo.tagline}
+                    </p>
+                  </div>
+                </div>
+              );
+            })()}
+
+            {/* 手動選択ドロップダウン */}
+            <div className="space-y-2">
+              <Label htmlFor="personalityType">
+                タイプを手動で選択
+                <span className="ml-2 text-xs text-muted-foreground">
+                  (既に自分のタイプを知っている方)
+                </span>
+              </Label>
+              <select
+                id="personalityType"
+                value={personalityType}
+                onChange={(e) => setPersonalityType(e.target.value)}
+                autoComplete="off"
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                aria-label="パーソナリティタイプ"
+              >
+                <option value="">未設定</option>
+                {PERSONALITY_TYPES.map((t) => {
+                  const info = PERSONALITY_DATA[t];
+                  return (
+                    <option key={t} value={t}>
+                      {info.animalEmoji} {t} - {info.name}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+
+            {/* 診断リンク */}
+            <div className="rounded-lg border border-dashed p-4 text-center">
+              <p className="text-sm text-muted-foreground">
+                自分のタイプが分からない方は
+              </p>
+              <Link
+                href="/personality/diagnosis"
+                className="mt-2 inline-flex items-center text-sm font-medium text-primary hover:underline"
+              >
+                簡易診断テスト（10問・約2分）を受ける →
+              </Link>
+            </div>
           </CardContent>
         </Card>
 

--- a/src/lib/personality/diagnosis.ts
+++ b/src/lib/personality/diagnosis.ts
@@ -1,0 +1,151 @@
+// ============================================================
+// 16パーソナリティ簡易診断テスト（10問）
+// ============================================================
+
+import type { PersonalityType } from "./types";
+
+/** 判定軸 */
+export type Axis = "EI" | "SN" | "TF" | "JP";
+
+/** 選択肢 */
+export interface DiagnosisOption {
+  label: string;
+  /** 各軸のどちら側に加点するか (例: "E" or "I") */
+  value: string;
+}
+
+/** 質問 */
+export interface DiagnosisQuestion {
+  id: number;
+  axis: Axis;
+  question: string;
+  optionA: DiagnosisOption;
+  optionB: DiagnosisOption;
+}
+
+/** 診断結果 */
+export interface DiagnosisResult {
+  type: PersonalityType;
+  scores: Record<string, number>;
+}
+
+// ============================================================
+// 質問データ（10問 = 各軸2~3問）
+// ============================================================
+
+export const DIAGNOSIS_QUESTIONS: DiagnosisQuestion[] = [
+  // E/I 軸 (3問)
+  {
+    id: 1,
+    axis: "EI",
+    question: "グループワークの後、あなたはどう感じますか？",
+    optionA: { label: "エネルギーが湧いてきて、もっと話したい", value: "E" },
+    optionB: { label: "疲れるので、一人の時間が欲しくなる", value: "I" },
+  },
+  {
+    id: 2,
+    axis: "EI",
+    question: "新しい環境で人と出会うとき、あなたは？",
+    optionA: { label: "自分から積極的に話しかける", value: "E" },
+    optionB: { label: "相手から話しかけてくれるのを待つ", value: "I" },
+  },
+  {
+    id: 3,
+    axis: "EI",
+    question: "アイデアを思いついたとき、まず何をしますか？",
+    optionA: { label: "すぐに誰かに話して反応を見たい", value: "E" },
+    optionB: { label: "まず自分の中でじっくり考えを整理する", value: "I" },
+  },
+
+  // S/N 軸 (2問)
+  {
+    id: 4,
+    axis: "SN",
+    question: "情報を集めるとき、あなたが重視するのは？",
+    optionA: { label: "具体的な事実やデータ", value: "S" },
+    optionB: { label: "全体のパターンや可能性", value: "N" },
+  },
+  {
+    id: 5,
+    axis: "SN",
+    question: "説明を受けるとき、どちらが分かりやすいですか？",
+    optionA: { label: "ステップごとの具体的な手順", value: "S" },
+    optionB: { label: "全体像やコンセプトの説明", value: "N" },
+  },
+
+  // T/F 軸 (3問)
+  {
+    id: 6,
+    axis: "TF",
+    question: "友人が悩みを相談してきたとき、あなたは？",
+    optionA: { label: "論理的に解決策を提案する", value: "T" },
+    optionB: { label: "まず気持ちに寄り添い、共感する", value: "F" },
+  },
+  {
+    id: 7,
+    axis: "TF",
+    question: "チームで意見が対立したとき、あなたが重視するのは？",
+    optionA: { label: "論理的に正しい方を選ぶべき", value: "T" },
+    optionB: { label: "メンバーの感情や関係性を大切にしたい", value: "F" },
+  },
+
+  // J/P 軸 (2問)
+  {
+    id: 8,
+    axis: "JP",
+    question: "旅行の計画を立てるとき、あなたは？",
+    optionA: { label: "事前にスケジュールをしっかり決める", value: "J" },
+    optionB: { label: "大まかに決めて、現地で臨機応変に楽しむ", value: "P" },
+  },
+  {
+    id: 9,
+    axis: "JP",
+    question: "課題やレポートの締め切りに対して、あなたは？",
+    optionA: { label: "計画的に進めて、余裕を持って提出する", value: "J" },
+    optionB: { label: "締め切りが近づいてから集中して取り組む", value: "P" },
+  },
+  {
+    id: 10,
+    axis: "JP",
+    question: "予定外の出来事が起きたとき、あなたは？",
+    optionA: { label: "計画が乱れてストレスを感じる", value: "J" },
+    optionB: { label: "新しい展開にワクワクする", value: "P" },
+  },
+];
+
+// ============================================================
+// 診断ロジック
+// ============================================================
+
+/**
+ * 回答一覧からパーソナリティタイプを算出する。
+ * @param answers - 各質問IDに対する回答値 (例: { 1: "E", 2: "I", ... })
+ * @returns 診断結果
+ */
+export function calculatePersonalityType(
+  answers: Record<number, string>
+): DiagnosisResult {
+  const scores: Record<string, number> = {
+    E: 0, I: 0,
+    S: 0, N: 0,
+    T: 0, F: 0,
+    J: 0, P: 0,
+  };
+
+  for (const q of DIAGNOSIS_QUESTIONS) {
+    const answer = answers[q.id];
+    if (answer && scores[answer] !== undefined) {
+      scores[answer]++;
+    }
+  }
+
+  // 各軸で多い方を採用（同点は先頭文字を採用）
+  const ei = scores.E >= scores.I ? "E" : "I";
+  const sn = scores.S >= scores.N ? "S" : "N";
+  const tf = scores.T >= scores.F ? "T" : "F";
+  const jp = scores.J >= scores.P ? "J" : "P";
+
+  const type = `${ei}${sn}${tf}${jp}` as PersonalityType;
+
+  return { type, scores };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -84,6 +84,7 @@ const ONBOARDING_BYPASS_PREFIXES = [
   "/signup",
   "/reset-password",
   "/update-password",
+  "/personality",
 ];
 
 const ONBOARDING_REQUIRED_PREFIXES = [

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -133,6 +133,7 @@ export interface Database {
           job_hunting_status: JobHuntingStatus;
           job_hunting_start_date: string | null;
           preferred_work_location: string[];
+          personality_type: string | null;
           onboarding_completed: boolean;
           created_at: string;
           updated_at: string;
@@ -150,6 +151,7 @@ export interface Database {
           job_hunting_status?: JobHuntingStatus;
           job_hunting_start_date?: string | null;
           preferred_work_location?: string[];
+          personality_type?: string | null;
           onboarding_completed?: boolean;
           created_at?: string;
           updated_at?: string;
@@ -167,6 +169,7 @@ export interface Database {
           job_hunting_status?: JobHuntingStatus;
           job_hunting_start_date?: string | null;
           preferred_work_location?: string[];
+          personality_type?: string | null;
           onboarding_completed?: boolean;
           created_at?: string;
           updated_at?: string;

--- a/supabase/migrations/00009_personality_type.sql
+++ b/supabase/migrations/00009_personality_type.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- Migration: 00009_personality_type
+-- Issue #138 Part 2: パーソナリティタイプカラムを profiles に追加
+-- ============================================================
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS personality_type TEXT DEFAULT NULL;
+
+-- personality_type のバリデーション (16タイプのみ許可)
+ALTER TABLE profiles
+  ADD CONSTRAINT chk_personality_type CHECK (
+    personality_type IS NULL
+    OR personality_type IN (
+      'INTJ', 'INTP', 'ENTJ', 'ENTP',
+      'INFJ', 'INFP', 'ENFJ', 'ENFP',
+      'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
+      'ISTP', 'ISFP', 'ESTP', 'ESFP'
+    )
+  );
+
+COMMENT ON COLUMN profiles.personality_type IS '16パーソナリティタイプ (例: INTJ, ENFP)';


### PR DESCRIPTION
## Summary
Part 2/3 of #138

- `profiles` テーブルに `personality_type TEXT` カラムを追加（マイグレーション `00009_personality_type.sql`）
- `src/types/database.ts` の profiles 型に `personality_type` を追加
- 10問の簡易診断テスト `/personality/diagnosis` を実装（Pro/Premium 会員限定）
- プロフィールページにパーソナリティタイプの表示・手動選択ドロップダウンを追加
- タイプ別テーマカラー背景＋キャラクターアイコンをプロフィールに表示
- API ルート `/api/profile` に `personality_type` のバリデーションを追加

## Test plan
- [ ] `/personality/diagnosis` に Pro/Premium ユーザーでアクセスし、10問の診断が完了すること
- [ ] Free ユーザーで `/personality/diagnosis` にアクセスすると `/pricing` にリダイレクトされること
- [ ] 診断結果が正しく表示され、「プロフィールに保存する」ボタンで保存されること
- [ ] プロフィールページで手動ドロップダウンからタイプを選択・保存できること
- [ ] タイプ設定済みの場合、プロフィールページにテーマカラー背景とキャラクターアイコンが表示されること
- [ ] `npm run build` 成功
- [ ] `npm run test` 成功（全23テスト pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)