### PR TITLE
feat: #138 Part3 - AIフィードバック・模擬面接にパーソナリティ統合

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -5,6 +5,8 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { InterviewCategory, InterviewRound, SubscriptionPlan } from "@/types/database";
 import { checkUsageLimit, getModelForPlan } from "@/lib/subscription";
 import { PLANS } from "@/lib/stripe/config";
+import { PERSONALITY_DATA, isValidPersonalityType } from "@/lib/personality/types";
+import type { PersonalityType } from "@/lib/personality/types";
 
 // ============================================================
 // 型定義
@@ -163,7 +165,8 @@ function buildUserPrompt(
     faculty?: string | null;
     target_industry?: string[];
     target_job_type?: string[];
-  } | null
+  } | null,
+  personalityType: string | null
 ): string {
   const categoryGuideline = getCategoryGuideline(category, round);
 
@@ -186,6 +189,26 @@ ${parts.join("\n")}`;
     }
   }
 
+  // パーソナリティタイプに基づく追加ガイドライン
+  let personalitySection = "";
+  if (personalityType && isValidPersonalityType(personalityType)) {
+    const pData = PERSONALITY_DATA[personalityType.toUpperCase() as PersonalityType];
+    personalitySection = `
+
+【候補者のパーソナリティタイプ: ${pData.type}（${pData.name}）】
+このタイプの話し方の特徴: ${pData.talkStyle}
+面接での強み: ${pData.interviewStrengths.join("、")}
+面接での弱み: ${pData.interviewWeaknesses.join("、")}
+相性の良い企業文化: ${pData.compatibleCultures.join("、")}
+パーソナリティに基づくアドバイス: ${pData.adviceTip}
+
+以下の観点もフィードバックに含めてください:
+- このタイプの話し方の特徴が回答にどう表れているか
+- パーソナリティの強みを活かせている部分と、弱みが出ている部分
+- 志望企業の文化とパーソナリティタイプの相性に関するコメント
+- このタイプ特有の改善アドバイス（具体的なアクション付き）`;
+  }
+
   const categoryLabels: Record<InterviewCategory, string> = {
     arubaito: "アルバイト",
     intern: "インターン",
@@ -200,6 +223,7 @@ ${parts.join("\n")}`;
 - 面接カテゴリ: ${categoryLabels[category] || "その他"}
 ${round ? `- 面接ラウンド: ${round}` : ""}
 ${profileSection}
+${personalitySection}
 
 ${categoryGuideline}
 
@@ -456,7 +480,7 @@ export async function POST(request: Request) {
     // ユーザーのプロフィール情報を取得（パーソナライズ用）
     const { data: profileData } = await supabase
       .from("profiles")
-      .select("university, faculty, target_industry, target_job_type")
+      .select("university, faculty, target_industry, target_job_type, personality_type")
       .eq("user_id", user.id)
       .single();
 
@@ -465,7 +489,10 @@ export async function POST(request: Request) {
       faculty?: string | null;
       target_industry?: string[];
       target_job_type?: string[];
+      personality_type?: string | null;
     } | null;
+
+    const personalityType = profile?.personality_type ?? null;
 
     // プロンプト生成
     const systemPrompt = buildSystemPrompt();
@@ -474,7 +501,8 @@ export async function POST(request: Request) {
       (interview.interview_category as InterviewCategory) || "other",
       (interview.interview_round as InterviewRound) || null,
       (interview.company_name_snapshot as string) || "",
-      profile
+      profile,
+      personalityType
     );
 
     // Claude API 呼び出し（リトライ付き・プラン別モデル）

--- a/src/app/api/mock-interview/[id]/feedback/route.ts
+++ b/src/app/api/mock-interview/[id]/feedback/route.ts
@@ -9,6 +9,8 @@ import type {
 import { checkUsageLimit, getModelForPlan } from "@/lib/subscription";
 import { PLANS } from "@/lib/stripe/config";
 import type { SubscriptionPlan } from "@/types/database";
+import { PERSONALITY_DATA, isValidPersonalityType } from "@/lib/personality/types";
+import type { PersonalityType } from "@/lib/personality/types";
 
 // ============================================================
 // 定数
@@ -129,7 +131,8 @@ function buildFeedbackUserPrompt(
   qaPairs: { question: string; answer: string }[],
   category: string,
   companyName: string | null,
-  difficulty: string
+  difficulty: string,
+  personalityType: string | null
 ): string {
   const categoryLabels: Record<string, string> = {
     general: "人物面接（総合）",
@@ -151,13 +154,32 @@ function buildFeedbackUserPrompt(
     )
     .join("\n\n");
 
+  // パーソナリティタイプに基づく追加ガイドライン
+  let personalitySection = "";
+  if (personalityType && isValidPersonalityType(personalityType)) {
+    const pData = PERSONALITY_DATA[personalityType.toUpperCase() as PersonalityType];
+    personalitySection = `
+【候補者のパーソナリティタイプ: ${pData.type}（${pData.name}）】
+このタイプの話し方の特徴: ${pData.talkStyle}
+面接での強み: ${pData.interviewStrengths.join("、")}
+面接での弱み: ${pData.interviewWeaknesses.join("、")}
+相性の良い企業文化: ${pData.compatibleCultures.join("、")}
+パーソナリティに基づくアドバイス: ${pData.adviceTip}
+
+以下の観点もフィードバックに含めてください:
+- このタイプの話し方の特徴が回答にどう表れているか
+- パーソナリティの強みを活かせている部分と、弱みが出ている部分
+- このタイプ特有の面接戦略アドバイス（具体的なアクション付き）
+`;
+  }
+
   return `以下のAI模擬面接の会話を分析し、フィードバックを生成してください。
 
 【面接情報】
 - 企業名: ${companyName || "指定なし"}
 - 面接タイプ: ${categoryLabels[category] || "その他"}
 - 難易度: ${difficultyLabels[difficulty] || "標準"}
-
+${personalitySection}
 【質問と回答のペア】
 ${qaPairsText}
 
@@ -378,6 +400,15 @@ export async function POST(
     // プランに応じた AI モデルを決定
     const modelName = getModelForPlan(usageResult.plan);
 
+    // ユーザーのパーソナリティタイプを取得
+    const { data: profileData } = await supabase
+      .from("profiles")
+      .select("personality_type")
+      .eq("user_id", user.id)
+      .single();
+
+    const personalityType = (profileData as { personality_type?: string | null } | null)?.personality_type ?? null;
+
     // 会話データを構造化
     const conversationText = buildConversationText(messages);
     const qaPairs = extractQAPairs(messages);
@@ -389,7 +420,8 @@ export async function POST(
       qaPairs,
       mockInterview.category,
       mockInterview.company_name,
-      mockInterview.difficulty
+      mockInterview.difficulty,
+      personalityType
     );
 
     // Claude API 呼び出し

--- a/src/app/mock-interview/page.tsx
+++ b/src/app/mock-interview/page.tsx
@@ -28,12 +28,13 @@ export default async function MockInterviewPage() {
   // プロフィール情報を取得（初期値用）
   const { data: profile } = await supabase
     .from("profiles")
-    .select("target_industry")
+    .select("target_industry, personality_type")
     .eq("user_id", user.id)
     .single();
 
-  const targetIndustry =
-    (profile as { target_industry?: string[] } | null)?.target_industry ?? [];
+  const typedProfile = profile as { target_industry?: string[]; personality_type?: string | null } | null;
+  const targetIndustry = typedProfile?.target_industry ?? [];
+  const personalityType = typedProfile?.personality_type ?? null;
 
   return (
     <div className="container mx-auto max-w-2xl px-4 py-8">
@@ -41,7 +42,7 @@ export default async function MockInterviewPage() {
       <p className="mb-6 text-sm text-muted-foreground">
         AIが面接官役となり、リアルな模擬面接を体験できます。設定を選んで面接を始めましょう。
       </p>
-      <SetupForm defaultIndustry={targetIndustry[0] ?? ""} />
+      <SetupForm defaultIndustry={targetIndustry[0] ?? ""} personalityType={personalityType} />
     </div>
   );
 }

--- a/src/app/mock-interview/setup-form.tsx
+++ b/src/app/mock-interview/setup-form.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2, MessageSquare } from "lucide-react";
+import Link from "next/link";
+import { Loader2, MessageSquare, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,6 +21,8 @@ import type {
   MockInterviewRound,
   MockInterviewDifficulty,
 } from "@/types/database";
+import { PERSONALITY_DATA, isValidPersonalityType } from "@/lib/personality/types";
+import type { PersonalityType } from "@/lib/personality/types";
 
 // --- 定数 ---
 const MAX_COMPANY_NAME_LENGTH = 100;
@@ -71,9 +74,10 @@ const DIFFICULTY_OPTIONS: { value: MockInterviewDifficulty; label: string; descr
 
 interface SetupFormProps {
   defaultIndustry: string;
+  personalityType: string | null;
 }
 
-export function SetupForm({ defaultIndustry }: SetupFormProps) {
+export function SetupForm({ defaultIndustry, personalityType }: SetupFormProps) {
   // フォーム状態
   const [companyName, setCompanyName] = useState("");
   const [industry, setIndustry] = useState(defaultIndustry);
@@ -338,6 +342,48 @@ export function SetupForm({ defaultIndustry }: SetupFormProps) {
               </button>
             ))}
           </div>
+        </CardContent>
+      </Card>
+
+      {/* パーソナリティタイプ */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Sparkles className="h-4 w-4" />
+            パーソナリティタイプ
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {personalityType && isValidPersonalityType(personalityType) ? (() => {
+            const pData = PERSONALITY_DATA[personalityType.toUpperCase() as PersonalityType];
+            return (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-lg">{pData.animalEmoji}</span>
+                  <span className="font-medium">{pData.type} - {pData.name}</span>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  あなたのパーソナリティに基づいた面接練習ができます。フィードバックにタイプ固有のアドバイスが含まれます。
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  面接での強み: {pData.interviewStrengths.join("、")}
+                </p>
+              </div>
+            );
+          })() : (
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                パーソナリティタイプを設定すると、あなたに合ったフィードバックが得られます。
+              </p>
+              <Link
+                href="/personality"
+                className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                パーソナリティ診断を受ける
+              </Link>
+            </div>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- AIフィードバック生成（`/api/analyze`）でユーザーのパーソナリティタイプを取得し、Claude プロンプトにタイプ固有の情報（話し方の特徴、面接の強み・弱み、企業文化との相性）を追加
- 模擬面接フィードバック生成（`/api/mock-interview/[id]/feedback`）にも同様のパーソナリティ統合を実装
- 模擬面接セットアップフォームにパーソナリティタイプ表示を追加（設定済み：タイプ情報・強み表示、未設定：診断ページへの導線）
- パーソナリティタイプ未設定ユーザーでも正常動作（条件分岐で制御）

closes #138

## Test plan
- [x] `npm run build` 成功
- [x] `npm run test` 成功（23テスト全通過）
- [ ] パーソナリティタイプ設定済みユーザーで `/api/analyze` 呼び出し → フィードバックにタイプ固有アドバイスが含まれること
- [ ] パーソナリティタイプ未設定ユーザーで `/api/analyze` 呼び出し → 従来通り動作すること
- [ ] 模擬面接セットアップページでタイプが表示されること
- [ ] 未設定時に診断リンクが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)