### PR TITLE
test: Sprint 8 パーソナリティ機能のテスト追加

### DIFF
--- a/e2e/sprint8-personality.spec.ts
+++ b/e2e/sprint8-personality.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from "@playwright/test";
+
+// ============================================================
+// パーソナリティ一覧ページ（/personality）
+// ============================================================
+test.describe("パーソナリティ一覧ページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/personality");
+  });
+
+  test("ページが表示される", async ({ page }) => {
+    await expect(page).toHaveTitle(/16パーソナリティ/);
+  });
+
+  test("見出しが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { level: 1 })
+    ).toContainText("16パーソナリティ診断");
+  });
+
+  test("16タイプのカードが表示される", async ({ page }) => {
+    // 全16タイプのラベルが表示されていることを確認
+    const types = [
+      "INTJ", "INTP", "ENTJ", "ENTP",
+      "INFJ", "INFP", "ENFJ", "ENFP",
+      "ISTJ", "ISFJ", "ESTJ", "ESFJ",
+      "ISTP", "ISFP", "ESTP", "ESFP",
+    ];
+    for (const t of types) {
+      await expect(page.getByText(t, { exact: true }).first()).toBeVisible();
+    }
+  });
+
+  test("4つのグループ見出しが表示される", async ({ page }) => {
+    await expect(page.getByText("分析家").first()).toBeVisible();
+    await expect(page.getByText("外交官").first()).toBeVisible();
+    await expect(page.getByText("番人").first()).toBeVisible();
+    await expect(page.getByText("探検家").first()).toBeVisible();
+  });
+
+  test("CTAセクションが表示される", async ({ page }) => {
+    await expect(
+      page.getByText("あなたはどのタイプ？")
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /今すぐ診断する/ })
+    ).toBeVisible();
+  });
+
+  test("タイプカードから詳細ページへ遷移できる", async ({ page }) => {
+    // INTJ カードをクリック
+    await page.getByRole("link", { name: /INTJ/ }).first().click();
+    await expect(page).toHaveURL(/\/personality\/intj/);
+  });
+});
+
+// ============================================================
+// パーソナリティ詳細ページ（/personality/[type]）
+// ============================================================
+test.describe("パーソナリティ詳細ページ", () => {
+  test("INTJ 詳細ページが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page).toHaveTitle(/INTJ/);
+    await expect(
+      page.getByRole("heading", { level: 1 })
+    ).toContainText("建築家");
+  });
+
+  test("キャラクター画像が表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(
+      page.getByAltText("建築家のキャラクター")
+    ).toBeVisible();
+  });
+
+  test("グループバッジが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page.getByText("分析家").first()).toBeVisible();
+  });
+
+  test("性格の強み・弱みセクションが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page.getByText("性格の強み")).toBeVisible();
+    await expect(page.getByText("気をつけたいポイント")).toBeVisible();
+  });
+
+  test("面接の強み・弱みセクションが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page.getByText("面接での強み")).toBeVisible();
+    await expect(page.getByText("面接で気をつけること")).toBeVisible();
+  });
+
+  test("相性の良い業界セクションが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page.getByText("相性の良い業界")).toBeVisible();
+    await expect(page.getByText("コンサルティング")).toBeVisible();
+  });
+
+  test("面接コーチからのアドバイスが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page.getByText("面接コーチからのアドバイス")).toBeVisible();
+  });
+
+  test("SNSシェアボタンが存在する", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page.getByText("シェア:")).toBeVisible();
+    await expect(page.getByLabel("Xでシェア")).toBeVisible();
+    await expect(page.getByLabel("LINEでシェア")).toBeVisible();
+    await expect(page.getByLabel("リンクをコピー")).toBeVisible();
+  });
+
+  test("パンくずリストが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(
+      page.getByRole("link", { name: /16パーソナリティ一覧/ })
+    ).toBeVisible();
+  });
+
+  test("同グループの他タイプが表示される", async ({ page }) => {
+    await page.goto("/personality/intj");
+    await expect(page.getByText(/同じ「分析家」グループのタイプ/)).toBeVisible();
+    // INTJ は分析家グループ → 他の3タイプが表示される
+    await expect(page.getByText("INTP").first()).toBeVisible();
+    await expect(page.getByText("ENTJ").first()).toBeVisible();
+    await expect(page.getByText("ENTP").first()).toBeVisible();
+  });
+
+  test("小文字の URL でもページが表示される", async ({ page }) => {
+    await page.goto("/personality/enfp");
+    await expect(page).toHaveTitle(/ENFP/);
+    await expect(
+      page.getByRole("heading", { level: 1 })
+    ).toContainText("広報活動家");
+  });
+
+  test("存在しないタイプは 404 になる", async ({ page }) => {
+    await page.goto("/personality/xxxx");
+    await expect(page.getByText("404")).toBeVisible();
+  });
+});
+
+// ============================================================
+// 診断ページ（/personality/diagnosis）認証チェック
+// ============================================================
+test.describe("パーソナリティ診断ページ", () => {
+  test("未認証の場合ログインページにリダイレクトされる", async ({ page }) => {
+    await page.goto("/personality/diagnosis");
+    // 認証チェックにより /login にリダイレクトされる
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/src/lib/personality/diagnosis.test.ts
+++ b/src/lib/personality/diagnosis.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  DIAGNOSIS_QUESTIONS,
+  calculatePersonalityType,
+  type DiagnosisQuestion,
+} from "./diagnosis";
+
+describe("personality/diagnosis", () => {
+  // ============================================================
+  // 質問データのテスト
+  // ============================================================
+
+  describe("DIAGNOSIS_QUESTIONS", () => {
+    it("質問が10問ある", () => {
+      expect(DIAGNOSIS_QUESTIONS).toHaveLength(10);
+    });
+
+    it("各質問に必要なプロパティが存在する", () => {
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        expect(q.id).toBeTypeOf("number");
+        expect(q.axis).toMatch(/^(EI|SN|TF|JP)$/);
+        expect(q.question).toBeTruthy();
+        expect(q.optionA.label).toBeTruthy();
+        expect(q.optionA.value).toBeTruthy();
+        expect(q.optionB.label).toBeTruthy();
+        expect(q.optionB.value).toBeTruthy();
+      }
+    });
+
+    it("質問IDが1から10まで連番である", () => {
+      const ids = DIAGNOSIS_QUESTIONS.map((q) => q.id);
+      expect(ids).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    it("4つの軸すべてがカバーされている", () => {
+      const axes = new Set(DIAGNOSIS_QUESTIONS.map((q) => q.axis));
+      expect(axes).toEqual(new Set(["EI", "SN", "TF", "JP"]));
+    });
+
+    it("E/I軸が3問、S/N軸が2問、T/F軸が2問、J/P軸が3問ある", () => {
+      const axisCounts = DIAGNOSIS_QUESTIONS.reduce(
+        (acc, q) => {
+          acc[q.axis] = (acc[q.axis] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>
+      );
+      expect(axisCounts.EI).toBe(3);
+      expect(axisCounts.SN).toBe(2);
+      expect(axisCounts.TF).toBe(2);
+      expect(axisCounts.JP).toBe(3);
+    });
+  });
+
+  // ============================================================
+  // calculatePersonalityType のテスト
+  // ============================================================
+
+  describe("calculatePersonalityType", () => {
+    it("全て A を選んだ場合 ESTJ になる", () => {
+      // optionA の値: E, E, E, S, S, T, T, J, J, J
+      const answers: Record<number, string> = {};
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        answers[q.id] = q.optionA.value;
+      }
+      const result = calculatePersonalityType(answers);
+      expect(result.type).toBe("ESTJ");
+    });
+
+    it("全て B を選んだ場合 INFP になる", () => {
+      // optionB の値: I, I, I, N, N, F, F, P, P, P
+      const answers: Record<number, string> = {};
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        answers[q.id] = q.optionB.value;
+      }
+      const result = calculatePersonalityType(answers);
+      expect(result.type).toBe("INFP");
+    });
+
+    it("I, N, T, J を選ぶと INTJ になる", () => {
+      // E/I軸(3問) → I を選択, S/N軸(2問) → N を選択,
+      // T/F軸(2問) → T を選択, J/P軸(3問) → J を選択
+      const answers: Record<number, string> = {};
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        switch (q.axis) {
+          case "EI":
+            answers[q.id] = "I";
+            break;
+          case "SN":
+            answers[q.id] = "N";
+            break;
+          case "TF":
+            answers[q.id] = "T";
+            break;
+          case "JP":
+            answers[q.id] = "J";
+            break;
+        }
+      }
+      const result = calculatePersonalityType(answers);
+      expect(result.type).toBe("INTJ");
+    });
+
+    it("E, S, F, P を選ぶと ESFP になる", () => {
+      const answers: Record<number, string> = {};
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        switch (q.axis) {
+          case "EI":
+            answers[q.id] = "E";
+            break;
+          case "SN":
+            answers[q.id] = "S";
+            break;
+          case "TF":
+            answers[q.id] = "F";
+            break;
+          case "JP":
+            answers[q.id] = "P";
+            break;
+        }
+      }
+      const result = calculatePersonalityType(answers);
+      expect(result.type).toBe("ESFP");
+    });
+
+    it("E, N, F, J を選ぶと ENFJ になる", () => {
+      const answers: Record<number, string> = {};
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        switch (q.axis) {
+          case "EI":
+            answers[q.id] = "E";
+            break;
+          case "SN":
+            answers[q.id] = "N";
+            break;
+          case "TF":
+            answers[q.id] = "F";
+            break;
+          case "JP":
+            answers[q.id] = "J";
+            break;
+        }
+      }
+      const result = calculatePersonalityType(answers);
+      expect(result.type).toBe("ENFJ");
+    });
+
+    it("同点の場合は先頭文字が採用される（E >= I なら E）", () => {
+      // EI軸: 3問中 E=1, I=2 → I / 全てIを1, Eを2,3 にすると E=2, I=1 → E
+      // ここではスコアが同点のケースを作る
+      // EI軸3問: 1問E, 2問I → I が勝つ (E=1 < I=2) → I
+      // でも同点テストが必要なので、別の軸で同点を作る
+      // SN軸2問: 1問S, 1問N → S=1, N=1 → 同点 → S（>= で先頭文字）
+      const answers: Record<number, string> = {};
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        switch (q.axis) {
+          case "EI":
+            answers[q.id] = "E"; // 3問全てE → E
+            break;
+          case "SN":
+            // 2問: 1問目S, 2問目N → 同点 → S
+            if (q.id === 4) answers[q.id] = "S";
+            if (q.id === 5) answers[q.id] = "N";
+            break;
+          case "TF":
+            // 2問: 1問目T, 2問目F → 同点 → T
+            if (q.id === 6) answers[q.id] = "T";
+            if (q.id === 7) answers[q.id] = "F";
+            break;
+          case "JP":
+            answers[q.id] = "J"; // 3問全てJ → J
+            break;
+        }
+      }
+      const result = calculatePersonalityType(answers);
+      // E(3) >= I(0) → E, S(1) >= N(1) → S, T(1) >= F(1) → T, J(3) >= P(0) → J
+      expect(result.type).toBe("ESTJ");
+    });
+
+    it("スコアが正しく集計される", () => {
+      const answers: Record<number, string> = {};
+      for (const q of DIAGNOSIS_QUESTIONS) {
+        answers[q.id] = q.optionA.value;
+      }
+      const result = calculatePersonalityType(answers);
+      // optionA: E(3問), S(2問), T(2問), J(3問)
+      expect(result.scores.E).toBe(3);
+      expect(result.scores.I).toBe(0);
+      expect(result.scores.S).toBe(2);
+      expect(result.scores.N).toBe(0);
+      expect(result.scores.T).toBe(2);
+      expect(result.scores.F).toBe(0);
+      expect(result.scores.J).toBe(3);
+      expect(result.scores.P).toBe(0);
+    });
+
+    it("空の回答でもエラーにならない（デフォルトは ESTJ）", () => {
+      const result = calculatePersonalityType({});
+      // 全スコア0 → >= で先頭文字を採用: E, S, T, J
+      expect(result.type).toBe("ESTJ");
+      expect(result.scores.E).toBe(0);
+      expect(result.scores.I).toBe(0);
+    });
+
+    it("一部だけ回答した場合でもエラーにならない", () => {
+      const answers: Record<number, string> = { 1: "E", 4: "N" };
+      const result = calculatePersonalityType(answers);
+      expect(result.type).toBeTruthy();
+      expect(result.scores.E).toBe(1);
+      expect(result.scores.N).toBe(1);
+    });
+
+    it("無効な回答値は無視される", () => {
+      const answers: Record<number, string> = { 1: "X", 2: "E" };
+      const result = calculatePersonalityType(answers);
+      // "X" は scores に存在しないので無視される
+      expect(result.scores.E).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Sprint 8 で実装されたパーソナリティ機能（#138）に対する自動テストを追加
- ユニットテスト 15 ケース + E2E テスト 16 ケース
- 既存テスト 23 件と合わせて全 38 ユニットテストが PASS、ビルド成功を確認済み

## テスト内容

### ユニットテスト (`src/lib/personality/diagnosis.test.ts`)
- 質問データの構造検証（10問、4軸カバレッジ、各軸の問数）
- `calculatePersonalityType` の算出ロジック
  - 全 A 選択 → ESTJ / 全 B 選択 → INFP
  - 特定パターン: INTJ, ESFP, ENFJ
  - 同点時のデフォルト挙動（先頭文字採用）
  - スコア集計の正確性
  - エッジケース: 空回答、部分回答、無効値

### E2E テスト (`e2e/sprint8-personality.spec.ts`)
- `/personality` 一覧ページ: タイトル、見出し、16 タイプカード、4 グループ、CTA、カード遷移
- `/personality/intj` 詳細ページ: キャラクター画像、グループバッジ、強み弱み、業界、アドバイス、SNS シェアボタン、パンくず、同グループタイプ、小文字 URL 対応、404 ハンドリング
- `/personality/diagnosis`: 未認証リダイレクト確認

## Test plan
- [x] `npm run test` — 全 38 ユニットテスト PASS
- [x] `npm run build` — ビルド成功
- [ ] `npm run test:e2e` — E2E テスト（dev サーバー起動が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)