### PR TITLE
fix: auth pages spacing and signup accessibility

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -58,7 +58,7 @@ export default function LoginPage() {
             メールアドレスとパスワードでログイン
           </CardDescription>
         </CardHeader>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
           <CardContent className="space-y-4">
             {error && (
               <div

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -152,7 +152,7 @@ export default function ResetPasswordPage() {
             登録済みのメールアドレスを入力してください
           </CardDescription>
         </CardHeader>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
           <CardContent className="space-y-4">
             {error && (
               <div

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -74,10 +74,14 @@ export default function SignUpPage() {
             メールアドレスとパスワードで登録
           </CardDescription>
         </CardHeader>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
           <CardContent className="space-y-4">
             {error && (
-              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+              >
                 {error}
               </div>
             )}
@@ -86,6 +90,7 @@ export default function SignUpPage() {
               <Input
                 id="email"
                 type="email"
+                autoComplete="email"
                 placeholder="example@email.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -97,6 +102,7 @@ export default function SignUpPage() {
               <Input
                 id="password"
                 type="password"
+                autoComplete="new-password"
                 placeholder="8文字以上"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -106,7 +106,7 @@ export default function UpdatePasswordPage() {
             新しいパスワードを入力してください
           </CardDescription>
         </CardHeader>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
           <CardContent className="space-y-4">
             {error && (
               <div


### PR DESCRIPTION
## Summary
- 全認証ページ（signup, login, reset-password, update-password）の `<form>` タグに `flex flex-col gap-6` を追加し、CardContent と CardFooter 間のスペーシングを修正
- signup ページのエラーメッセージに `role="alert"` と `aria-live="assertive"` を追加（WCAG 2.1 AA 準拠）
- signup ページの input に `autoComplete` 属性を追加（email, new-password）

## 問題の根本原因
Card コンポーネントは `gap-6` を持つ flexbox だが、`<form>` タグが Card の直接の子要素となることで、form 内部の CardContent と CardFooter 間に gap が適用されなかった。特に signup ページでは、同意チェックボックスとサインアップボタンの間にスペースがなく、誤タップのリスクがあった。

## 修正内容
| ファイル | 変更 |
|---------|------|
| `src/app/signup/page.tsx` | form に gap-6 追加、エラーに role/aria-live 追加、input に autoComplete 追加 |
| `src/app/login/page.tsx` | form に gap-6 追加 |
| `src/app/reset-password/page.tsx` | form に gap-6 追加 |
| `src/app/update-password/page.tsx` | form に gap-6 追加 |

## Test plan
- [ ] signup ページでチェックボックスとボタンの間に適切なスペースがあること
- [ ] 全認証ページで CardContent と CardFooter 間に一貫したスペーシングがあること
- [ ] signup ページでエラー時にスクリーンリーダーがエラーメッセージを読み上げること
- [ ] `npm run build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)