### PR TITLE
feat: #158 #159 プロフィールUX改善 + ログイン時リダイレクト

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -6,21 +6,27 @@ import { PERSONALITY_TYPES } from "@/lib/personality/types";
 type ProfileInsert = Database["public"]["Tables"]["profiles"]["Insert"];
 
 /** バリデーション: 表示名は1~30文字 */
-function validateDisplayName(name: unknown): string | null {
-  if (typeof name !== "string") return null;
+function validateDisplayName(name: unknown): { value: string | null; error?: string } {
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return { value: null, error: "フルネームを入力してください（1〜30文字）" };
+  }
   const trimmed = name.trim();
-  if (trimmed.length < 1 || trimmed.length > 30) return null;
-  return trimmed;
+  if (trimmed.length > 30) {
+    return { value: null, error: "フルネームは30文字以内で入力してください" };
+  }
+  return { value: trimmed };
 }
 
 /** バリデーション: テキストフィールド (最大100文字) */
-function validateText(value: unknown, maxLength = 100): string | null {
-  if (value === null || value === undefined || value === "") return null;
-  if (typeof value !== "string") return null;
+function validateText(value: unknown, fieldName: string, maxLength = 100): { value: string | null; error?: string } {
+  if (value === null || value === undefined || value === "") return { value: null };
+  if (typeof value !== "string") return { value: null };
   const trimmed = value.trim();
-  if (trimmed.length === 0) return null;
-  if (trimmed.length > maxLength) return null;
-  return trimmed;
+  if (trimmed.length === 0) return { value: null };
+  if (trimmed.length > maxLength) {
+    return { value: null, error: `${fieldName}は${maxLength}文字以内で入力してください` };
+  }
+  return { value: trimmed };
 }
 
 /** バリデーション: 配列フィールド (最大5件) */
@@ -118,7 +124,7 @@ export async function GET() {
     return NextResponse.json({ profile: data ?? null });
   } catch {
     return NextResponse.json(
-      { error: "サーバーエラーが発生しました" },
+      { error: "サーバーとの通信に失敗しました。時間を置いて再度お試しください。" },
       { status: 500 }
     );
   }
@@ -142,17 +148,18 @@ export async function PUT(request: Request) {
 
     const body = await request.json();
 
-    // バリデーション
-    const displayName = validateDisplayName(body.display_name);
-    if (body.display_name !== undefined && body.display_name !== null && body.display_name !== "" && !displayName) {
-      return NextResponse.json(
-        { error: "表示名は1~30文字で入力してください" },
-        { status: 400 }
-      );
-    }
+    // バリデーション（エラーを収集して一括返却）
+    const errors: string[] = [];
 
-    const university = validateText(body.university, 100);
-    const faculty = validateText(body.faculty, 100);
+    const displayNameResult = validateDisplayName(body.display_name);
+    if (displayNameResult.error) errors.push(displayNameResult.error);
+
+    const universityResult = validateText(body.university, "大学名", 100);
+    if (universityResult.error) errors.push(universityResult.error);
+
+    const facultyResult = validateText(body.faculty, "学部・学科", 100);
+    if (facultyResult.error) errors.push(facultyResult.error);
+
     const graduationYear = validateGraduationYear(body.graduation_year);
     const graduationMonth = validateGraduationMonth(body.graduation_month);
     const targetIndustry = validateArray(body.target_industry, 5);
@@ -168,11 +175,18 @@ export async function PUT(request: Request) {
       ? validatePersonalityType(body.personality_type)
       : undefined;
 
+    if (errors.length > 0) {
+      return NextResponse.json(
+        { error: errors.join("\n"), errors },
+        { status: 400 }
+      );
+    }
+
     const profileData: ProfileInsert = {
       user_id: user.id,
-      display_name: displayName,
-      university,
-      faculty,
+      display_name: displayNameResult.value,
+      university: universityResult.value,
+      faculty: facultyResult.value,
       graduation_year: graduationYear,
       graduation_month: graduationMonth,
       target_industry: targetIndustry,
@@ -192,7 +206,7 @@ export async function PUT(request: Request) {
     if (error) {
       console.error("Profile upsert error:", error);
       return NextResponse.json(
-        { error: "プロフィールの保存に失敗しました" },
+        { error: "サーバーとの通信に失敗しました。時間を置いて再度お試しください。" },
         { status: 500 }
       );
     }
@@ -200,7 +214,7 @@ export async function PUT(request: Request) {
     return NextResponse.json({ profile: data });
   } catch {
     return NextResponse.json(
-      { error: "サーバーエラーが発生しました" },
+      { error: "サーバーとの通信に失敗しました。時間を置いて再度お試しください。" },
       { status: 500 }
     );
   }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -207,22 +207,47 @@ export default function ProfilePage() {
     }
   };
 
+  // フィールドごとのバリデーションエラー
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // クライアントサイドバリデーション
+  const validateForm = (): Record<string, string> => {
+    const errors: Record<string, string> = {};
+    const trimmedName = displayName.trim();
+    if (trimmedName.length === 0) {
+      errors.displayName = "フルネームを入力してください（1〜30文字）";
+    } else if (trimmedName.length > 30) {
+      errors.displayName = "フルネームは30文字以内で入力してください";
+    }
+    if (university.trim().length > 100) {
+      errors.university = "大学名は100文字以内で入力してください";
+    }
+    if (faculty.trim().length > 100) {
+      errors.faculty = "学部・学科は100文字以内で入力してください";
+    }
+    if (targetIndustry.length > 5) {
+      errors.targetIndustry = "志望業界は最大5つまで選択できます";
+    }
+    if (targetJobType.length > 5) {
+      errors.targetJobType = "志望職種は最大5つまで選択できます";
+    }
+    return errors;
+  };
+
   // 保存（二重送信防止付き）
   const handleSave = async (e?: React.FormEvent) => {
     e?.preventDefault();
     if (savingRef.current) return;
 
-    // バリデーション
-    if (displayName.trim().length > 0 && displayName.trim().length > 30) {
-      setToast({ type: "error", message: "表示名は1~30文字で入力してください" });
-      return;
-    }
-    if (targetIndustry.length > 5) {
-      setToast({ type: "error", message: "志望業界は最大5つまで選択できます" });
-      return;
-    }
-    if (targetJobType.length > 5) {
-      setToast({ type: "error", message: "志望職種は最大5つまで選択できます" });
+    // クライアントバリデーション
+    const errors = validateForm();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      const errorMessages = Object.values(errors);
+      setToast({
+        type: "error",
+        message: `入力内容を確認してください:\n${errorMessages.join("\n")}`,
+      });
       return;
     }
 
@@ -248,13 +273,17 @@ export default function ProfilePage() {
 
       if (!res.ok) {
         const data = await res.json();
-        throw new Error(data.error || "保存に失敗しました");
+        throw new Error(
+          data.error || "サーバーとの通信に失敗しました。時間を置いて再度お試しください。"
+        );
       }
 
       setToast({ type: "success", message: "プロフィールを保存しました" });
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "保存に失敗しました";
+        err instanceof Error
+          ? err.message
+          : "サーバーとの通信に失敗しました。時間を置いて再度お試しください。";
       setToast({ type: "error", message });
     } finally {
       setSaving(false);
@@ -288,13 +317,14 @@ export default function ProfilePage() {
               : "border-red-200 bg-red-50 text-red-800"
           }`}
           role="alert"
+          aria-live="assertive"
         >
           {toast.type === "success" ? (
             <CheckCircle className="h-4 w-4 shrink-0" />
           ) : (
             <AlertCircle className="h-4 w-4 shrink-0" />
           )}
-          <span className="text-sm">{toast.message}</span>
+          <span className="text-sm whitespace-pre-line">{toast.message}</span>
           <button
             onClick={() => setToast(null)}
             className="ml-auto"
@@ -311,50 +341,109 @@ export default function ProfilePage() {
           <CardHeader>
             <CardTitle>基本情報</CardTitle>
             <CardDescription>
-              あなたの基本的な情報を入力してください
+              あなたの基本的な情報を入力してください（<span className="text-destructive">*</span>は必須項目）
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="displayName">フルネーム</Label>
+              <Label htmlFor="displayName">
+                フルネーム<span className="text-destructive">*</span>
+              </Label>
               <Input
                 id="displayName"
                 value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
+                onChange={(e) => {
+                  setDisplayName(e.target.value);
+                  if (fieldErrors.displayName) {
+                    setFieldErrors((prev) => {
+                      const next = { ...prev };
+                      delete next.displayName;
+                      return next;
+                    });
+                  }
+                }}
                 placeholder="山田 太郎"
                 maxLength={30}
+                autoComplete="name"
                 aria-describedby="displayName-hint"
+                aria-invalid={!!fieldErrors.displayName}
+                aria-errormessage={fieldErrors.displayName ? "displayName-error" : undefined}
+                required
               />
-              <p id="displayName-hint" className="text-xs text-muted-foreground">
-                1~30文字
-              </p>
+              {fieldErrors.displayName ? (
+                <p id="displayName-error" className="text-xs text-destructive" role="alert">
+                  {fieldErrors.displayName}
+                </p>
+              ) : (
+                <p id="displayName-hint" className="text-xs text-muted-foreground">
+                  1〜30文字（必須）
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="university">大学名</Label>
+              <Label htmlFor="university">
+                大学名<span className="ml-1 text-xs text-muted-foreground">（任意）</span>
+              </Label>
               <Input
                 id="university"
                 value={university}
-                onChange={(e) => setUniversity(e.target.value)}
+                onChange={(e) => {
+                  setUniversity(e.target.value);
+                  if (fieldErrors.university) {
+                    setFieldErrors((prev) => {
+                      const next = { ...prev };
+                      delete next.university;
+                      return next;
+                    });
+                  }
+                }}
                 placeholder="東京大学"
                 maxLength={100}
+                autoComplete="organization"
+                aria-invalid={!!fieldErrors.university}
               />
+              {fieldErrors.university && (
+                <p className="text-xs text-destructive" role="alert">
+                  {fieldErrors.university}
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="faculty">学部・学科</Label>
+              <Label htmlFor="faculty">
+                学部・学科<span className="ml-1 text-xs text-muted-foreground">（任意）</span>
+              </Label>
               <Input
                 id="faculty"
                 value={faculty}
-                onChange={(e) => setFaculty(e.target.value)}
+                onChange={(e) => {
+                  setFaculty(e.target.value);
+                  if (fieldErrors.faculty) {
+                    setFieldErrors((prev) => {
+                      const next = { ...prev };
+                      delete next.faculty;
+                      return next;
+                    });
+                  }
+                }}
                 placeholder="工学部 情報工学科"
                 maxLength={100}
+                autoComplete="off"
+                aria-invalid={!!fieldErrors.faculty}
               />
+              {fieldErrors.faculty && (
+                <p className="text-xs text-destructive" role="alert">
+                  {fieldErrors.faculty}
+                </p>
+              )}
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label htmlFor="graduationYear">卒業予定年</Label>
+                <Label htmlFor="graduationYear">
+                  卒業予定年<span className="ml-1 text-xs text-muted-foreground">（任意）</span>
+                </Label>
                 <select
                   id="graduationYear"
                   value={graduationYear}
@@ -375,7 +464,9 @@ export default function ProfilePage() {
                 </select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="graduationMonth">卒業予定月</Label>
+                <Label htmlFor="graduationMonth">
+                  卒業予定月<span className="ml-1 text-xs text-muted-foreground">（任意）</span>
+                </Label>
                 <select
                   id="graduationMonth"
                   value={graduationMonth}
@@ -409,7 +500,9 @@ export default function ProfilePage() {
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="space-y-2">
-              <Label htmlFor="jobHuntingStatus">就活状況</Label>
+              <Label htmlFor="jobHuntingStatus">
+                就活状況<span className="ml-1 text-xs text-muted-foreground">（任意）</span>
+              </Label>
               <select
                 id="jobHuntingStatus"
                 value={jobHuntingStatus}
@@ -427,10 +520,7 @@ export default function ProfilePage() {
 
             <div className="space-y-2">
               <Label>
-                志望業界
-                <span className="ml-2 text-xs text-muted-foreground">
-                  (最大5つ)
-                </span>
+                志望業界<span className="ml-1 text-xs text-muted-foreground">（任意・最大5つ）</span>
               </Label>
               <div className="flex flex-wrap gap-2">
                 {INDUSTRIES.map((industry) => {
@@ -469,10 +559,7 @@ export default function ProfilePage() {
 
             <div className="space-y-2">
               <Label>
-                志望職種
-                <span className="ml-2 text-xs text-muted-foreground">
-                  (最大5つ)
-                </span>
+                志望職種<span className="ml-1 text-xs text-muted-foreground">（任意・最大5つ）</span>
               </Label>
               <div className="flex flex-wrap gap-2">
                 {JOB_TYPES.map((jobType) => {
@@ -519,7 +606,9 @@ export default function ProfilePage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label>希望勤務地</Label>
+              <Label>
+                希望勤務地<span className="ml-1 text-xs text-muted-foreground">（任意）</span>
+              </Label>
               <div className="flex flex-wrap gap-2">
                 {WORK_LOCATIONS.map((location) => {
                   const selected = preferredWorkLocation.includes(location);
@@ -648,10 +737,7 @@ export default function ProfilePage() {
             {/* 手動選択ドロップダウン */}
             <div className="space-y-2">
               <Label htmlFor="personalityType">
-                タイプを手動で選択
-                <span className="ml-2 text-xs text-muted-foreground">
-                  (既に自分のタイプを知っている方)
-                </span>
+                タイプを手動で選択<span className="ml-1 text-xs text-muted-foreground">（任意・既に自分のタイプを知っている方）</span>
               </Label>
               <select
                 id="personalityType"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -134,6 +134,18 @@ export async function middleware(request: NextRequest) {
 
   const response = await updateSession(request);
 
+  // ログイン済みユーザーがトップページ（/）にアクセスした場合、ダッシュボードにリダイレクト
+  if (request.nextUrl.pathname === "/") {
+    const hasSession = request.cookies.getAll().some(
+      (cookie) => cookie.name.startsWith("sb-") && cookie.name.endsWith("-auth-token")
+    );
+    if (hasSession) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/dashboard";
+      return NextResponse.redirect(url);
+    }
+  }
+
   if (shouldCheckOnboarding(request.nextUrl.pathname)) {
     const onboardingCompleted = request.cookies.get("onboarding_completed")?.value;
     const hasSession = request.cookies.getAll().some(


### PR DESCRIPTION
## 概要
closes #158
closes #159

## 変更内容
### プロフィールページ UX改善 (#158)
- 必須フィールド（フルネーム）にラベルに `*` マーク表示
- 任意フィールドにラベルに `（任意）` 表示
- クライアントサイドバリデーション: フィールドごとの具体的エラーメッセージ
- サーバーサイドバリデーション: エラーを一括収集して返却
- エラーメッセージ例: 「フルネームを入力してください（1〜30文字）」「大学名は100文字以内で入力してください」
- API エラー: 「サーバーとの通信に失敗しました。時間を置いて再度お試しください。」
- `aria-live="assertive"` + `role="alert"` でアクセシビリティ対応
- `autoComplete` 属性を各入力フィールドに追加

### ログイン済みリダイレクト (#159)
- middleware でログイン済みユーザーの `/` アクセスを `/dashboard` にサーバーサイドリダイレクト
- 未ログインユーザーには従来通り LP 表示

## 受け入れ基準の確認
- [x] 必須フィールドに `*` マーク表示
- [x] 任意フィールドに `（任意）` 表示
- [x] フルネーム未入力時の具体的エラーメッセージ
- [x] 文字数超過時の具体的エラーメッセージ
- [x] API エラー時のアクション指向メッセージ
- [x] `role="alert"` + `aria-live="assertive"` 付与
- [x] ログイン済みで `/` → `/dashboard` リダイレクト
- [x] ビルド成功確認