### PR TITLE
fix: #166 オンボーディングエラー改善 + ヘッダーメニューUX

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -93,9 +93,9 @@ export async function PUT(request: Request) {
         );
 
       if (error) {
-        console.error("Onboarding skip error:", error);
+        console.error("Onboarding skip error:", JSON.stringify(error));
         return NextResponse.json(
-          { error: "オンボーディングの完了に失敗しました" },
+          { error: "サーバーとの通信に失敗しました。時間を置いて再度お試しください。", detail: error.message },
           { status: 500 }
         );
       }
@@ -152,9 +152,9 @@ export async function PUT(request: Request) {
       .single();
 
     if (error) {
-      console.error("Onboarding upsert error:", error);
+      console.error("Onboarding upsert error:", JSON.stringify(error));
       return NextResponse.json(
-        { error: "プロフィールの保存に失敗しました" },
+        { error: "サーバーとの通信に失敗しました。時間を置いて再度お試しください。", detail: error.message },
         { status: 500 }
       );
     }
@@ -170,9 +170,10 @@ export async function PUT(request: Request) {
     });
 
     return NextResponse.json({ profile: data });
-  } catch {
+  } catch (err) {
+    console.error("Onboarding unexpected error:", err);
     return NextResponse.json(
-      { error: "サーバーエラーが発生しました" },
+      { error: "サーバーとの通信に失敗しました。時間を置いて再度お試しください。" },
       { status: 500 }
     );
   }

--- a/src/app/onboarding/onboarding-wizard.tsx
+++ b/src/app/onboarding/onboarding-wizard.tsx
@@ -191,7 +191,7 @@ export function OnboardingWizard() {
 
       {/* エラー表示 */}
       {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert" aria-live="assertive">
           {error}
         </div>
       )}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -18,6 +18,7 @@ import type { User } from "@supabase/supabase-js";
 export function Header() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [onboardingCompleted, setOnboardingCompleted] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -31,12 +32,28 @@ export function Header() {
           data: { user },
         } = await supabase.auth.getUser();
         setUser(user);
+
+        // オンボーディング完了チェック
+        if (user) {
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("onboarding_completed")
+            .eq("user_id", user.id)
+            .single();
+          setOnboardingCompleted(
+            !!(profile as { onboarding_completed?: boolean } | null)?.onboarding_completed
+          );
+        }
+
         setLoading(false);
       };
       getUser();
 
       const { data } = supabase.auth.onAuthStateChange((_event, session) => {
         setUser(session?.user ?? null);
+        if (!session?.user) {
+          setOnboardingCompleted(false);
+        }
       });
       subscription = data.subscription;
     } catch {
@@ -62,7 +79,8 @@ export function Header() {
     { href: "/personality", label: "16パーソナリティ" },
   ];
 
-  const authNavItems = user
+  // オンボーディング完了後のみ表示する保護対象ナビ
+  const authNavItems = user && onboardingCompleted
     ? [
         { href: "/dashboard", label: "ダッシュボード" },
         { href: "/mock-interview", label: "模擬面接" },


### PR DESCRIPTION
## 概要
closes #166

## 変更内容
### バグ修正: オンボーディング保存エラーメッセージ
- 曖昧な「保存に失敗しました」→ 「サーバーとの通信に失敗しました。時間を置いて再度お試しください。」
- エラーログにSupabaseエラーの詳細を出力（デバッグ用）
- `role="alert"` `aria-live="assertive"` 追加

### UX改善: ヘッダーメニューのオンボーディング連動
- オンボーディング未完了時: ヘッダーに保護対象ページ（ダッシュボード、模擬面接、ES添削等）のリンクを非表示
- オンボーディング完了後: 全メニューが表示される
- ログアウト時: メニューをリセット

## 受け入れ基準の確認
- [x] エラーメッセージが具体的かつアクション指向
- [x] オンボーディング未完了時はヘッダーに保護対象ページ非表示
- [x] ビルド成功確認