### PR TITLE
fix: サインアップ後のメール確認フローを実装

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/auth/callback
+ * Supabase メール確認リンクからのコールバック処理
+ * - code パラメータを使ってセッションを確立
+ * - 成功時はオンボーディングページへリダイレクト
+ */
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/onboarding";
+
+  const redirectBase = process.env.NEXT_PUBLIC_APP_URL || origin;
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      return NextResponse.redirect(`${redirectBase}${next}`);
+    }
+  }
+
+  // エラー時はログインページへ（エラーメッセージ付き）
+  return NextResponse.redirect(
+    `${redirectBase}/login?error=メール確認に失敗しました。もう一度お試しください。`
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -15,13 +15,31 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Loader2 } from "lucide-react";
 
 export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // auth callback からのエラーメッセージを表示
+  useEffect(() => {
+    const errorParam = searchParams.get("error");
+    if (errorParam) {
+      setError(errorParam);
+    }
+  }, [searchParams]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -36,14 +54,18 @@ export default function LoginPage() {
       });
 
       if (error) {
-        setError("メールアドレスまたはパスワードが正しくありません");
+        if (error.message.includes("Email not confirmed")) {
+          setError("メールアドレスの確認が完了していません。受信トレイの確認メールからアカウントを有効化してください。");
+        } else {
+          setError("メールアドレスまたはパスワードが正しくありません。入力内容をご確認ください。");
+        }
         return;
       }
 
       router.push("/dashboard");
       router.refresh();
     } catch {
-      setError("ログイン中にエラーが発生しました");
+      setError("サーバーとの通信に失敗しました。時間を置いて再度お試しください。");
     } finally {
       setLoading(false);
     }
@@ -103,6 +125,7 @@ export default function LoginPage() {
           </CardContent>
           <CardFooter className="flex flex-col gap-4">
             <Button type="submit" className="w-full" disabled={loading}>
+              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {loading ? "ログイン中..." : "ログイン"}
             </Button>
             <p className="text-sm text-muted-foreground">

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -15,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Loader2, Mail } from "lucide-react";
 
 export default function SignUpPage() {
   const [email, setEmail] = useState("");
@@ -22,7 +22,7 @@ export default function SignUpPage() {
   const [agreed, setAgreed] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
+  const [emailSent, setEmailSent] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -45,25 +45,68 @@ export default function SignUpPage() {
       const { error } = await supabase.auth.signUp({
         email,
         password,
+        options: {
+          emailRedirectTo: `${window.location.origin}/api/auth/callback`,
+        },
       });
 
       if (error) {
         if (error.message.includes("already registered")) {
-          setError("このメールアドレスは既に登録されています");
+          setError("このメールアドレスは既に登録されています。ログインページからお試しください。");
         } else {
-          setError(error.message);
+          setError("アカウント作成に失敗しました。入力内容を確認して再度お試しください。");
         }
         return;
       }
 
-      router.push("/dashboard");
-      router.refresh();
+      setEmailSent(true);
     } catch {
-      setError("サインアップ中にエラーが発生しました");
+      setError("サーバーとの通信に失敗しました。時間を置いて再度お試しください。");
     } finally {
       setLoading(false);
     }
   };
+
+  // メール送信完了画面
+  if (emailSent) {
+    return (
+      <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+              <Mail className="h-8 w-8 text-primary" />
+            </div>
+            <CardTitle className="text-2xl">メールを確認してください</CardTitle>
+            <CardDescription className="mt-2 text-base">
+              <span className="font-medium text-foreground">{email}</span>
+              {" "}に確認メールを送信しました。
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-md bg-muted p-4 text-sm text-muted-foreground">
+              <p className="mb-2">メール内のリンクをクリックして、アカウントの登録を完了してください。</p>
+              <p>メールが届かない場合は、迷惑メールフォルダもご確認ください。</p>
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-4">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => setEmailSent(false)}
+            >
+              別のメールアドレスで登録する
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              すでにアカウントをお持ちですか？{" "}
+              <Link href="/login" className="text-primary hover:underline">
+                ログイン
+              </Link>
+            </p>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
@@ -147,6 +190,7 @@ export default function SignUpPage() {
               className="w-full"
               disabled={loading || !agreed}
             >
+              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {loading ? "登録中..." : "サインアップ"}
             </Button>
             <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## 概要

サインアップ後にダッシュボードへ直接遷移していた問題を修正。
Supabase のメール確認フローに準拠し、「メールを確認してください」画面を表示するように変更。

## 変更内容

- **サインアップページ** (`src/app/signup/page.tsx`):
  - 成功後にメール確認画面を表示（Mail アイコン + 「メールを確認してください」メッセージ）
  - `emailRedirectTo` オプションを追加（確認リンクの遷移先を `/api/auth/callback` に設定）
  - ボタンにローディングスピナー追加
  - エラーメッセージをアクション指向に改善

- **auth callback ルート** (`src/app/api/auth/callback/route.ts`): 新規作成
  - Supabase の確認メールリンクからの `code` パラメータを受け取りセッション確立
  - 成功時は `/onboarding` へリダイレクト
  - 失敗時はエラーメッセージ付きでログインページへリダイレクト

- **ログインページ** (`src/app/login/page.tsx`):
  - クエリパラメータ `error` からのメッセージ表示に対応
  - 「メール未確認」エラーの専用メッセージを追加
  - ボタンにローディングスピナー追加
  - Suspense 境界を追加（useSearchParams 対応）

## フロー

```
サインアップ → メール確認画面 → メール内リンクをクリック → /api/auth/callback → /onboarding
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)