### PR TITLE
feat: #176 認証コールバックのエラーメッセージ改善

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -21,10 +21,22 @@ export async function GET(request: Request) {
     if (!error) {
       return NextResponse.redirect(`${redirectBase}${next}`);
     }
+
+    // Supabase エラーメッセージに基づくエラーコード分岐
+    const errorCode = error.message?.includes("expired")
+      ? "email_expired"
+      : error.message?.includes("already used") ||
+          error.message?.includes("already confirmed")
+        ? "code_used"
+        : "email_confirm_failed";
+
+    return NextResponse.redirect(
+      `${redirectBase}/login?error=${errorCode}`
+    );
   }
 
-  // エラー時はログインページへ（エラーメッセージ付き）
+  // code パラメータが無い場合
   return NextResponse.redirect(
-    `${redirectBase}/login?error=メール確認に失敗しました。もう一度お試しください。`
+    `${redirectBase}/login?error=auth_error`
   );
 }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !supabaseAnonKey) {
-      return NextResponse.redirect(`${origin}/login?error=config`);
+      return NextResponse.redirect(`${origin}/login?error=config_error`);
     }
 
     const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
@@ -60,8 +60,21 @@ export async function GET(request: Request) {
       // 通常のログイン/サインアップの場合はダッシュボードへ
       return NextResponse.redirect(`${origin}/dashboard`);
     }
+
+    // エラーの種類に応じたエラーコードを判定
+    const errorCode =
+      type === "recovery" && error.message?.includes("expired")
+        ? "recovery_expired"
+        : error.message?.includes("expired")
+          ? "email_expired"
+          : error.message?.includes("already used") ||
+              error.message?.includes("already confirmed")
+            ? "code_used"
+            : "auth_error";
+
+    return NextResponse.redirect(`${origin}/login?error=${errorCode}`);
   }
 
-  // エラーの場合はログインページにリダイレクト
-  return NextResponse.redirect(`${origin}/login?error=auth`);
+  // code パラメータが無い場合
+  return NextResponse.redirect(`${origin}/login?error=auth_error`);
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
+import { getAuthErrorInfo } from "@/lib/auth/error-messages";
+import type { AuthErrorInfo } from "@/lib/auth/error-messages";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,21 +31,25 @@ function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [errorAction, setErrorAction] = useState<AuthErrorInfo["action"]>();
   const [loading, setLoading] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // auth callback からのエラーメッセージを表示
+  // auth callback からのエラーコードをマッピングして表示（XSS 対策）
   useEffect(() => {
     const errorParam = searchParams.get("error");
-    if (errorParam) {
-      setError(errorParam);
+    const errorInfo = getAuthErrorInfo(errorParam);
+    if (errorInfo) {
+      setError(errorInfo.message);
+      setErrorAction(errorInfo.action);
     }
   }, [searchParams]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setErrorAction(undefined);
     setLoading(true);
 
     try {
@@ -88,7 +94,15 @@ function LoginForm() {
                 aria-live="assertive"
                 className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
               >
-                {error}
+                <p>{error}</p>
+                {errorAction && (
+                  <Link
+                    href={errorAction.href}
+                    className="mt-1 inline-block font-medium underline hover:no-underline"
+                  >
+                    {errorAction.label}
+                  </Link>
+                )}
               </div>
             )}
             <div className="space-y-2">

--- a/src/lib/auth/error-messages.ts
+++ b/src/lib/auth/error-messages.ts
@@ -1,0 +1,55 @@
+/**
+ * 認証エラーコード → 日本語メッセージのマッピング
+ *
+ * XSS 対策: login ページでは error パラメータの値を直接表示せず、
+ * このマッピングテーブルに存在するコードのみ対応するメッセージを返す。
+ * 不明なコードは汎用メッセージに置換される。
+ */
+
+export interface AuthErrorInfo {
+  message: string;
+  action?: {
+    label: string;
+    href: string;
+  };
+}
+
+export const AUTH_ERROR_MESSAGES: Record<string, AuthErrorInfo> = {
+  auth_error: {
+    message: "認証処理中にエラーが発生しました。もう一度お試しください。",
+  },
+  config_error: {
+    message:
+      "サーバーの設定に問題があります。管理者にお問い合わせください。",
+  },
+  email_expired: {
+    message:
+      "確認リンクの有効期限が切れています。再度サインアップしてください。",
+    action: { label: "サインアップ", href: "/signup" },
+  },
+  code_used: {
+    message: "このリンクは既に使用済みです。ログインしてください。",
+  },
+  recovery_expired: {
+    message:
+      "パスワードリセットリンクの有効期限が切れています。再度リセットをリクエストしてください。",
+    action: { label: "パスワードリセット", href: "/reset-password" },
+  },
+  email_confirm_failed: {
+    message: "メール確認に失敗しました。もう一度お試しください。",
+    action: { label: "サインアップ", href: "/signup" },
+  },
+};
+
+export const DEFAULT_ERROR: AuthErrorInfo = {
+  message: "認証処理中にエラーが発生しました。もう一度お試しください。",
+};
+
+/**
+ * エラーコードから AuthErrorInfo を取得する。
+ * マッピングに存在しないコードは DEFAULT_ERROR を返す（XSS 対策）。
+ */
+export function getAuthErrorInfo(code: string | null): AuthErrorInfo | null {
+  if (!code) return null;
+  return AUTH_ERROR_MESSAGES[code] ?? DEFAULT_ERROR;
+}


### PR DESCRIPTION
## Summary

closes #176

認証コールバックのエラーメッセージをエラーコードベースのマッピングシステムに改善し、ユーザーフレンドリーな日本語メッセージとリカバリーアクションリンクを表示するようにしました。

### 変更内容

- **`src/lib/auth/error-messages.ts`（新規）**: エラーコード→日本語メッセージのマッピング定義。`getAuthErrorInfo()` 関数で安全にメッセージを取得（マッピングに無いコードは汎用メッセージを返しXSS対策）
- **`src/app/auth/callback/route.ts`**: エラー種別に応じた具体的なエラーコード（`auth_error`, `config_error`, `email_expired`, `recovery_expired`, `code_used`）でリダイレクト
- **`src/app/api/auth/callback/route.ts`**: ハードコード日本語メッセージをエラーコードベースに置換。Supabaseエラー内容に応じた分岐追加
- **`src/app/login/page.tsx`**: `error` パラメータをマッピングテーブルから安全に日本語メッセージに変換。リカバリーアクションリンク（サインアップ、パスワードリセット等）を表示

### セキュリティ改善

- `error` クエリパラメータの値を直接 DOM に表示しない（XSS対策）
- マッピングテーブルに存在しないコードは汎用メッセージに置換

## Test plan

- [ ] `/login?error=auth_error` → 「認証処理中にエラーが発生しました。」メッセージ表示
- [ ] `/login?error=email_expired` → 期限切れメッセージ + 「サインアップ」リンク表示
- [ ] `/login?error=recovery_expired` → リセット期限切れメッセージ + 「パスワードリセット」リンク表示
- [ ] `/login?error=config_error` → サーバー設定エラーメッセージ表示
- [ ] `/login?error=code_used` → 使用済みリンクメッセージ表示
- [ ] `/login?error=unknown_code` → 汎用エラーメッセージ表示
- [ ] `/login?error=<script>alert(1)</script>` → XSS が実行されず汎用メッセージ表示
- [ ] `npm run build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)