### PR TITLE
feat: メールテンプレートのカスタマイズ #104

### DIFF
--- a/docs/email-templates/README.md
+++ b/docs/email-templates/README.md
@@ -1,0 +1,76 @@
+# メールテンプレート
+
+InterviewCoach の認証メールテンプレートを管理するディレクトリです。
+
+## テンプレート一覧
+
+| ファイル | 用途 | 件名 |
+|----------|------|------|
+| `confirm-signup.html` | サインアップ確認メール | InterviewCoach - メールアドレスの確認 |
+| `reset-password.html` | パスワードリセットメール | InterviewCoach - パスワードのリセット |
+| `magic-link.html` | マジックリンクメール | InterviewCoach - ログインリンク |
+| `change-email.html` | メールアドレス変更確認メール | InterviewCoach - メールアドレスの変更確認 |
+
+## デザイン仕様
+
+- ヘッダー: 背景色 `#1e3a5f`（ダークブルー）、テキスト白
+- 本文: 背景色 `#ffffff`、テキスト `#333333`
+- CTA ボタン: 背景色 `#1e3a5f`、テキスト白、角丸 6px
+- フッター: 背景色 `#f5f5f5`、テキスト `#888888`、フォントサイズ 12px
+- 最大幅: 600px（モバイルレスポンシブ対応）
+- レイアウト: テーブルベース（Outlook 互換）
+- スタイル: インライン（メールクライアント互換）
+
+## テンプレート変数（Supabase）
+
+| 変数 | 説明 |
+|------|------|
+| `{{ .ConfirmationURL }}` | 確認・リセット等のアクション URL |
+| `{{ .Token }}` | 認証トークン |
+| `{{ .SiteURL }}` | サイトの URL |
+
+## Supabase Dashboard への適用手順
+
+Supabase Dashboard →「Authentication」→「Email Templates」
+
+### 1. Confirm signup（サインアップ確認）
+
+1. 「Confirm signup」タブを選択
+2. Subject に `InterviewCoach - メールアドレスの確認` を入力
+3. Body（HTML）に `confirm-signup.html` の内容を貼り付け
+4. 「Save」をクリック
+
+### 2. Reset password（パスワードリセット）
+
+1. 「Reset password」タブを選択
+2. Subject に `InterviewCoach - パスワードのリセット` を入力
+3. Body（HTML）に `reset-password.html` の内容を貼り付け
+4. 「Save」をクリック
+
+### 3. Magic link（マジックリンク）
+
+1. 「Magic link」タブを選択
+2. Subject に `InterviewCoach - ログインリンク` を入力
+3. Body（HTML）に `magic-link.html` の内容を貼り付け
+4. 「Save」をクリック
+
+### 4. Change email address（メールアドレス変更）
+
+1. 「Change email address」タブを選択
+2. Subject に `InterviewCoach - メールアドレスの変更確認` を入力
+3. Body（HTML）に `change-email.html` の内容を貼り付け
+4. 「Save」をクリック
+
+## 動作確認方法
+
+1. テスト用アカウントでサインアップし、確認メールが届くか確認
+2. パスワードリセットをリクエストし、リセットメールが届くか確認
+3. 各メールのCTAボタンが正しく動作するか確認
+4. モバイルデバイスでメール表示が崩れないか確認
+5. Gmail / Outlook / Apple Mail など主要クライアントでの表示を確認
+
+## 注意事項
+
+- テンプレートを変更した場合は、このリポジトリのファイルも更新してください
+- Supabase Dashboard での直接編集とリポジトリの内容が乖離しないよう注意してください
+- テンプレート変数（`{{ .ConfirmationURL }}` 等）を誤って削除しないでください

--- a/docs/email-templates/change-email.html
+++ b/docs/email-templates/change-email.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>InterviewCoach - メールアドレスの変更確認</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; background-color: #f0f2f5; font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;">
+  <!-- Wrapper Table -->
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f0f2f5;">
+    <tr>
+      <td align="center" style="padding: 24px 16px;">
+        <!-- Email Container -->
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background-color: #1e3a5f; padding: 28px 32px; text-align: center;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #ffffff; font-size: 24px; font-weight: bold; letter-spacing: 1px; text-align: center;">
+                    InterviewCoach
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding: 40px 32px 32px 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #333333; font-size: 16px; line-height: 1.7;">
+                    <p style="margin: 0 0 20px 0; font-size: 18px; font-weight: bold; color: #1e3a5f;">
+                      メールアドレスの変更確認
+                    </p>
+                    <p style="margin: 0 0 20px 0;">
+                      メールアドレスの変更がリクエストされました。
+                    </p>
+                    <p style="margin: 0 0 28px 0;">
+                      以下のボタンをクリックして、新しいメールアドレスを確認してください。
+                    </p>
+                  </td>
+                </tr>
+                <!-- CTA Button -->
+                <tr>
+                  <td align="center" style="padding: 0 0 28px 0;">
+                    <!--[if mso]>
+                    <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ .ConfirmationURL }}" style="height:48px;v-text-anchor:middle;width:320px;" arcsize="13%" fillcolor="#1e3a5f">
+                      <w:anchorlock/>
+                      <center style="color:#ffffff;font-family:'Helvetica Neue',Arial,sans-serif;font-size:16px;font-weight:bold;">メールアドレスの変更を確認する</center>
+                    </v:roundrect>
+                    <![endif]-->
+                    <!--[if !mso]><!-->
+                    <a href="{{ .ConfirmationURL }}" target="_blank" style="display: inline-block; background-color: #1e3a5f; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: bold; padding: 14px 28px; border-radius: 6px; min-width: 200px; text-align: center; mso-hide: all;">
+                      メールアドレスの変更を確認する
+                    </a>
+                    <!--<![endif]-->
+                  </td>
+                </tr>
+                <tr>
+                  <td style="color: #666666; font-size: 14px; line-height: 1.6;">
+                    <p style="margin: 0 0 12px 0;">
+                      このリンクは <strong>24時間</strong> 有効です。
+                    </p>
+                    <p style="margin: 0 0 12px 0;">
+                      ボタンが機能しない場合は、以下のURLをブラウザに貼り付けてください:
+                    </p>
+                    <p style="margin: 0 0 20px 0; word-break: break-all; color: #1e3a5f; font-size: 13px;">
+                      {{ .ConfirmationURL }}
+                    </p>
+                    <!-- Security notice -->
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fff8e1; border-left: 4px solid #f5a623; border-radius: 4px; margin-top: 8px;">
+                      <tr>
+                        <td style="padding: 12px 16px; color: #666666; font-size: 13px; line-height: 1.5;">
+                          <strong style="color: #e65100;">ご注意:</strong> このリクエストに心当たりがない場合は、このメールを無視してください。メールアドレスは変更されません。
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background-color: #f5f5f5; padding: 24px 32px; border-top: 1px solid #e8e8e8;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #888888; font-size: 12px; line-height: 1.6; text-align: center;">
+                    <p style="margin: 0 0 8px 0;">
+                      &copy; InterviewCoach
+                    </p>
+                    <p style="margin: 0 0 8px 0;">
+                      <a href="{{ .SiteURL }}" style="color: #1e3a5f; text-decoration: underline;">{{ .SiteURL }}</a>
+                    </p>
+                    <p style="margin: 0;">
+                      このメールに心当たりがない場合は無視してください。
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/docs/email-templates/confirm-signup.html
+++ b/docs/email-templates/confirm-signup.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>InterviewCoach - メールアドレスの確認</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; background-color: #f0f2f5; font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;">
+  <!-- Wrapper Table -->
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f0f2f5;">
+    <tr>
+      <td align="center" style="padding: 24px 16px;">
+        <!-- Email Container -->
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background-color: #1e3a5f; padding: 28px 32px; text-align: center;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #ffffff; font-size: 24px; font-weight: bold; letter-spacing: 1px; text-align: center;">
+                    InterviewCoach
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding: 40px 32px 32px 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #333333; font-size: 16px; line-height: 1.7;">
+                    <p style="margin: 0 0 20px 0; font-size: 18px; font-weight: bold; color: #1e3a5f;">
+                      こんにちは！
+                    </p>
+                    <p style="margin: 0 0 20px 0;">
+                      InterviewCoach へのご登録ありがとうございます。
+                    </p>
+                    <p style="margin: 0 0 28px 0;">
+                      以下のボタンをクリックして、メールアドレスを確認してください。
+                    </p>
+                  </td>
+                </tr>
+                <!-- CTA Button -->
+                <tr>
+                  <td align="center" style="padding: 0 0 28px 0;">
+                    <!--[if mso]>
+                    <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ .ConfirmationURL }}" style="height:48px;v-text-anchor:middle;width:280px;" arcsize="13%" fillcolor="#1e3a5f">
+                      <w:anchorlock/>
+                      <center style="color:#ffffff;font-family:'Helvetica Neue',Arial,sans-serif;font-size:16px;font-weight:bold;">メールアドレスを確認する</center>
+                    </v:roundrect>
+                    <![endif]-->
+                    <!--[if !mso]><!-->
+                    <a href="{{ .ConfirmationURL }}" target="_blank" style="display: inline-block; background-color: #1e3a5f; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: bold; padding: 14px 28px; border-radius: 6px; min-width: 200px; text-align: center; mso-hide: all;">
+                      メールアドレスを確認する
+                    </a>
+                    <!--<![endif]-->
+                  </td>
+                </tr>
+                <tr>
+                  <td style="color: #666666; font-size: 14px; line-height: 1.6;">
+                    <p style="margin: 0 0 12px 0;">
+                      このリンクは <strong>24時間</strong> 有効です。
+                    </p>
+                    <p style="margin: 0 0 12px 0;">
+                      ボタンが機能しない場合は、以下のURLをブラウザに貼り付けてください:
+                    </p>
+                    <p style="margin: 0; word-break: break-all; color: #1e3a5f; font-size: 13px;">
+                      {{ .ConfirmationURL }}
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background-color: #f5f5f5; padding: 24px 32px; border-top: 1px solid #e8e8e8;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #888888; font-size: 12px; line-height: 1.6; text-align: center;">
+                    <p style="margin: 0 0 8px 0;">
+                      &copy; InterviewCoach
+                    </p>
+                    <p style="margin: 0 0 8px 0;">
+                      <a href="{{ .SiteURL }}" style="color: #1e3a5f; text-decoration: underline;">{{ .SiteURL }}</a>
+                    </p>
+                    <p style="margin: 0;">
+                      このメールに心当たりがない場合は無視してください。
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/docs/email-templates/magic-link.html
+++ b/docs/email-templates/magic-link.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>InterviewCoach - ログインリンク</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; background-color: #f0f2f5; font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;">
+  <!-- Wrapper Table -->
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f0f2f5;">
+    <tr>
+      <td align="center" style="padding: 24px 16px;">
+        <!-- Email Container -->
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background-color: #1e3a5f; padding: 28px 32px; text-align: center;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #ffffff; font-size: 24px; font-weight: bold; letter-spacing: 1px; text-align: center;">
+                    InterviewCoach
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding: 40px 32px 32px 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #333333; font-size: 16px; line-height: 1.7;">
+                    <p style="margin: 0 0 20px 0; font-size: 18px; font-weight: bold; color: #1e3a5f;">
+                      ログインリンク
+                    </p>
+                    <p style="margin: 0 0 20px 0;">
+                      InterviewCoach へのログインがリクエストされました。
+                    </p>
+                    <p style="margin: 0 0 28px 0;">
+                      以下のボタンをクリックしてログインしてください。
+                    </p>
+                  </td>
+                </tr>
+                <!-- CTA Button -->
+                <tr>
+                  <td align="center" style="padding: 0 0 28px 0;">
+                    <!--[if mso]>
+                    <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ .ConfirmationURL }}" style="height:48px;v-text-anchor:middle;width:280px;" arcsize="13%" fillcolor="#1e3a5f">
+                      <w:anchorlock/>
+                      <center style="color:#ffffff;font-family:'Helvetica Neue',Arial,sans-serif;font-size:16px;font-weight:bold;">ログインする</center>
+                    </v:roundrect>
+                    <![endif]-->
+                    <!--[if !mso]><!-->
+                    <a href="{{ .ConfirmationURL }}" target="_blank" style="display: inline-block; background-color: #1e3a5f; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: bold; padding: 14px 28px; border-radius: 6px; min-width: 200px; text-align: center; mso-hide: all;">
+                      ログインする
+                    </a>
+                    <!--<![endif]-->
+                  </td>
+                </tr>
+                <tr>
+                  <td style="color: #666666; font-size: 14px; line-height: 1.6;">
+                    <p style="margin: 0 0 12px 0;">
+                      このリンクは <strong>24時間</strong> 有効です。一度使用すると無効になります。
+                    </p>
+                    <p style="margin: 0 0 12px 0;">
+                      ボタンが機能しない場合は、以下のURLをブラウザに貼り付けてください:
+                    </p>
+                    <p style="margin: 0 0 20px 0; word-break: break-all; color: #1e3a5f; font-size: 13px;">
+                      {{ .ConfirmationURL }}
+                    </p>
+                    <!-- Security notice -->
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fff8e1; border-left: 4px solid #f5a623; border-radius: 4px; margin-top: 8px;">
+                      <tr>
+                        <td style="padding: 12px 16px; color: #666666; font-size: 13px; line-height: 1.5;">
+                          <strong style="color: #e65100;">セキュリティに関する注意:</strong> このリンクは他の人と共有しないでください。InterviewCoach がこのリンクをメール以外で送信することはありません。
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background-color: #f5f5f5; padding: 24px 32px; border-top: 1px solid #e8e8e8;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #888888; font-size: 12px; line-height: 1.6; text-align: center;">
+                    <p style="margin: 0 0 8px 0;">
+                      &copy; InterviewCoach
+                    </p>
+                    <p style="margin: 0 0 8px 0;">
+                      <a href="{{ .SiteURL }}" style="color: #1e3a5f; text-decoration: underline;">{{ .SiteURL }}</a>
+                    </p>
+                    <p style="margin: 0;">
+                      このメールに心当たりがない場合は無視してください。
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/docs/email-templates/reset-password.html
+++ b/docs/email-templates/reset-password.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>InterviewCoach - パスワードのリセット</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; background-color: #f0f2f5; font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;">
+  <!-- Wrapper Table -->
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f0f2f5;">
+    <tr>
+      <td align="center" style="padding: 24px 16px;">
+        <!-- Email Container -->
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background-color: #1e3a5f; padding: 28px 32px; text-align: center;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #ffffff; font-size: 24px; font-weight: bold; letter-spacing: 1px; text-align: center;">
+                    InterviewCoach
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding: 40px 32px 32px 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #333333; font-size: 16px; line-height: 1.7;">
+                    <p style="margin: 0 0 20px 0; font-size: 18px; font-weight: bold; color: #1e3a5f;">
+                      パスワードのリセット
+                    </p>
+                    <p style="margin: 0 0 20px 0;">
+                      パスワードのリセットがリクエストされました。
+                    </p>
+                    <p style="margin: 0 0 28px 0;">
+                      以下のボタンをクリックして、新しいパスワードを設定してください。
+                    </p>
+                  </td>
+                </tr>
+                <!-- CTA Button -->
+                <tr>
+                  <td align="center" style="padding: 0 0 28px 0;">
+                    <!--[if mso]>
+                    <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ .ConfirmationURL }}" style="height:48px;v-text-anchor:middle;width:280px;" arcsize="13%" fillcolor="#1e3a5f">
+                      <w:anchorlock/>
+                      <center style="color:#ffffff;font-family:'Helvetica Neue',Arial,sans-serif;font-size:16px;font-weight:bold;">パスワードをリセットする</center>
+                    </v:roundrect>
+                    <![endif]-->
+                    <!--[if !mso]><!-->
+                    <a href="{{ .ConfirmationURL }}" target="_blank" style="display: inline-block; background-color: #1e3a5f; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: bold; padding: 14px 28px; border-radius: 6px; min-width: 200px; text-align: center; mso-hide: all;">
+                      パスワードをリセットする
+                    </a>
+                    <!--<![endif]-->
+                  </td>
+                </tr>
+                <tr>
+                  <td style="color: #666666; font-size: 14px; line-height: 1.6;">
+                    <p style="margin: 0 0 12px 0;">
+                      このリンクは <strong>24時間</strong> 有効です。
+                    </p>
+                    <p style="margin: 0 0 12px 0;">
+                      ボタンが機能しない場合は、以下のURLをブラウザに貼り付けてください:
+                    </p>
+                    <p style="margin: 0 0 20px 0; word-break: break-all; color: #1e3a5f; font-size: 13px;">
+                      {{ .ConfirmationURL }}
+                    </p>
+                    <!-- Security notice -->
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fff8e1; border-left: 4px solid #f5a623; border-radius: 4px; margin-top: 8px;">
+                      <tr>
+                        <td style="padding: 12px 16px; color: #666666; font-size: 13px; line-height: 1.5;">
+                          <strong style="color: #e65100;">ご注意:</strong> このリクエストに心当たりがない場合は、このメールを無視してください。パスワードは変更されません。
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background-color: #f5f5f5; padding: 24px 32px; border-top: 1px solid #e8e8e8;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="color: #888888; font-size: 12px; line-height: 1.6; text-align: center;">
+                    <p style="margin: 0 0 8px 0;">
+                      &copy; InterviewCoach
+                    </p>
+                    <p style="margin: 0 0 8px 0;">
+                      <a href="{{ .SiteURL }}" style="color: #1e3a5f; text-decoration: underline;">{{ .SiteURL }}</a>
+                    </p>
+                    <p style="margin: 0;">
+                      このメールに心当たりがない場合は無視してください。
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes #104

Supabase 認証メール用の HTML テンプレート 4 種と適用手順ドキュメントを作成。

- **confirm-signup.html**: サインアップ確認メール（件名: InterviewCoach - メールアドレスの確認）
- **reset-password.html**: パスワードリセットメール（件名: InterviewCoach - パスワードのリセット）
- **magic-link.html**: マジックリンクメール（件名: InterviewCoach - ログインリンク）
- **change-email.html**: メールアドレス変更確認メール（件名: InterviewCoach - メールアドレスの変更確認）
- **README.md**: Supabase Dashboard への適用手順

## 受け入れ基準の充足状況

- [x] 全メールにサービス名「InterviewCoach」が含まれる
- [x] 全メールが日本語で記述されている
- [x] ブランドカラー（ダークブルー `#1e3a5f`）のボタン・ヘッダーが適用されている
- [x] レスポンシブ HTML メール（モバイル対応、最大幅 600px）
- [x] フッターにサービス URL と「このメールに心当たりがない場合は無視してください」が含まれる
- [x] テンプレート HTML が `docs/email-templates/` に保存されている
- [x] テーブルベースレイアウト + インラインスタイル（Outlook 互換）
- [x] Outlook 用 VML ボタンフォールバック対応
- [x] Supabase テンプレート変数（`{{ .ConfirmationURL }}`, `{{ .SiteURL }}`）使用

## 技術詳細

- **レイアウト**: テーブルベース（`<table role="presentation">`）で Outlook 互換性を確保
- **スタイル**: 全てインラインスタイル（メールクライアントの CSS サポートの制約に対応）
- **Outlook 対応**: MSO 条件コメントで VML ボタンを提供
- **フォント**: 日本語フォント（Hiragino Kaku Gothic ProN, Hiragino Sans, Meiryo）をフォールバック指定
- **セキュリティ**: パスワードリセット・マジックリンク・メールアドレス変更には注意喚起バナーを配置

## 適用方法

Supabase Dashboard → Authentication → Email Templates で各テンプレートの HTML と件名を設定（詳細は `docs/email-templates/README.md` を参照）

## Test plan

- [ ] 各 HTML ファイルをブラウザで開き、レイアウトとデザインを目視確認
- [ ] モバイル幅（600px 以下）でのレスポンシブ表示を確認
- [ ] Supabase Dashboard に設定後、テストアカウントでサインアップし確認メールの受信・表示を確認
- [ ] パスワードリセットメールの受信・CTA ボタンの動作確認
- [ ] Gmail / Outlook / Apple Mail での表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)