### PR TITLE
feat: #132 - 回答テンプレート・模範解答機能

### DIFF
--- a/src/app/questions/[id]/page.tsx
+++ b/src/app/questions/[id]/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import {
   ArrowLeft,
-  BookOpen,
   CheckCircle,
   Lightbulb,
   Mic,
@@ -15,6 +14,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { questions, getQuestionById } from "@/lib/questions/data";
 import { DIFFICULTY_LABELS } from "@/lib/questions/types";
 import type { Difficulty } from "@/lib/questions/types";
+import { ExampleAnswer } from "@/components/questions/example-answer";
+import { FrameworkGuide } from "@/components/questions/framework-guide";
+import { AnswerComparison } from "@/components/questions/answer-comparison";
 
 const DIFFICULTY_COLORS: Record<Difficulty, string> = {
   easy: "bg-green-100 text-green-800",
@@ -138,23 +140,14 @@ export default async function QuestionDetailPage({ params }: PageProps) {
             </CardContent>
           </Card>
 
-          {/* 模範解答 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <BookOpen className="size-5 text-primary" />
-                模範解答
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="rounded-lg bg-muted/50 p-4">
-                <p className="text-sm leading-relaxed">{question.exampleAnswer}</p>
-              </div>
-              <p className="mt-3 text-xs text-muted-foreground">
-                ※ 模範解答はあくまで参考例です。自分の経験に基づいたオリジナルの回答を作成しましょう。
-              </p>
-            </CardContent>
-          </Card>
+          {/* 模範解答（アコーディオン） */}
+          <ExampleAnswer exampleAnswer={question.exampleAnswer} />
+
+          {/* 回答フレームワークガイド */}
+          <FrameworkGuide />
+
+          {/* 自分の回答入力 */}
+          <AnswerComparison questionId={question.id} />
 
           {/* この質問で練習する */}
           <Card className="border-primary">

--- a/src/components/questions/answer-comparison.tsx
+++ b/src/components/questions/answer-comparison.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { PenLine, Save, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+
+const MAX_LENGTH = 5000;
+
+interface AnswerComparisonProps {
+  questionId: string;
+}
+
+function getStorageKey(questionId: string) {
+  return `answer-${questionId}`;
+}
+
+export function AnswerComparison({ questionId }: AnswerComparisonProps) {
+  const [answer, setAnswer] = useState("");
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+  const [isOverLimit, setIsOverLimit] = useState(false);
+
+  // localStorage から復元
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(getStorageKey(questionId));
+      if (stored) {
+        const parsed = JSON.parse(stored) as {
+          text: string;
+          savedAt: string;
+        };
+        setAnswer(parsed.text);
+        setSavedAt(parsed.savedAt);
+      }
+    } catch {
+      // localStorage が使えない場合は無視
+    }
+  }, [questionId]);
+
+  // 自動保存（入力から500ms後）
+  const saveToStorage = useCallback(
+    (text: string) => {
+      try {
+        const now = new Date().toLocaleString("ja-JP");
+        localStorage.setItem(
+          getStorageKey(questionId),
+          JSON.stringify({ text, savedAt: now })
+        );
+        setSavedAt(now);
+      } catch {
+        // localStorage が使えない場合は無視
+      }
+    },
+    [questionId]
+  );
+
+  useEffect(() => {
+    if (answer.length === 0) return;
+
+    const timer = setTimeout(() => {
+      saveToStorage(answer);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [answer, saveToStorage]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setIsOverLimit(value.length > MAX_LENGTH);
+    if (value.length <= MAX_LENGTH) {
+      setAnswer(value);
+    }
+  };
+
+  const handleClear = () => {
+    setAnswer("");
+    setSavedAt(null);
+    try {
+      localStorage.removeItem(getStorageKey(questionId));
+    } catch {
+      // localStorage が使えない場合は無視
+    }
+  };
+
+  const handleSave = () => {
+    saveToStorage(answer);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <PenLine className="size-5 text-primary" />
+          自分の回答を書いてみよう
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-3 text-sm text-muted-foreground">
+          模範解答を参考に、自分の経験に基づいた回答を作成しましょう。入力内容はブラウザに自動保存されます。
+        </p>
+        <Textarea
+          placeholder="ここに自分の回答を入力してください..."
+          value={answer}
+          onChange={handleChange}
+          className="min-h-[160px] resize-y"
+          aria-label="自分の回答"
+          aria-invalid={isOverLimit}
+        />
+        <div className="mt-2 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span
+              className={`text-xs ${
+                answer.length > MAX_LENGTH * 0.9
+                  ? "text-destructive"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {answer.length.toLocaleString()} / {MAX_LENGTH.toLocaleString()}文字
+            </span>
+            {isOverLimit && (
+              <span className="text-xs text-destructive">
+                文字数制限を超えています
+              </span>
+            )}
+          </div>
+          {savedAt && (
+            <span className="text-xs text-muted-foreground">
+              保存済み: {savedAt}
+            </span>
+          )}
+        </div>
+        <div className="mt-4 flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSave}
+            disabled={answer.length === 0}
+          >
+            <Save className="mr-1 size-4" />
+            保存
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            disabled={answer.length === 0}
+          >
+            <RotateCcw className="mr-1 size-4" />
+            クリア
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/questions/example-answer.tsx
+++ b/src/components/questions/example-answer.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { BookOpen, ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface ExampleAnswerProps {
+  exampleAnswer: string;
+}
+
+export function ExampleAnswer({ exampleAnswer }: ExampleAnswerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const hasAnswer = exampleAnswer && exampleAnswer.trim().length > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <BookOpen className="size-5 text-primary" />
+          模範解答
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {hasAnswer ? (
+          <>
+            <Button
+              variant="outline"
+              className="mb-4 w-full justify-between"
+              onClick={() => setIsOpen(!isOpen)}
+              aria-expanded={isOpen}
+            >
+              <span>{isOpen ? "模範解答を閉じる" : "模範解答を見る"}</span>
+              {isOpen ? (
+                <ChevronUp className="size-4" />
+              ) : (
+                <ChevronDown className="size-4" />
+              )}
+            </Button>
+            {isOpen && (
+              <div className="animate-in fade-in slide-in-from-top-2 duration-200">
+                <div className="rounded-lg bg-muted/50 p-4">
+                  <p className="text-sm leading-relaxed">{exampleAnswer}</p>
+                </div>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  ※
+                  模範解答はあくまで参考例です。自分の経験に基づいたオリジナルの回答を作成しましょう。
+                </p>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="rounded-lg bg-muted/50 p-4 text-center">
+            <p className="text-sm text-muted-foreground">
+              模範解答は準備中です
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/questions/framework-guide.tsx
+++ b/src/components/questions/framework-guide.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { FileText } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const STAR_STEPS = [
+  {
+    label: "Situation",
+    title: "状況",
+    description: "いつ・どこで・どんな状況だったかを簡潔に説明します。",
+    template: "私は大学○年生の時、○○で○○という状況に直面しました。",
+    color: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  },
+  {
+    label: "Task",
+    title: "課題",
+    description: "その状況で自分に求められた役割・課題を明確にします。",
+    template: "そこで私は○○という課題に取り組む必要がありました。",
+    color:
+      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  },
+  {
+    label: "Action",
+    title: "行動",
+    description:
+      "課題に対して自分がどのような行動を取ったかを具体的に説明します。",
+    template: "具体的には、○○を行い、○○に取り組みました。",
+    color:
+      "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  },
+  {
+    label: "Result",
+    title: "結果",
+    description: "行動の結果どうなったか、数字や評価を交えて伝えます。",
+    template: "その結果、○○を達成し、○○という成果を得ることができました。",
+    color:
+      "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  },
+];
+
+const PREP_STEPS = [
+  {
+    label: "Point",
+    title: "結論",
+    description: "まず結論を最初に述べます。面接官に要点を明確に伝えます。",
+    template: "私の強みは○○です。",
+    color: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  },
+  {
+    label: "Reason",
+    title: "理由",
+    description: "結論の根拠となる理由を説明します。",
+    template: "なぜなら、○○という経験を通じて培ったからです。",
+    color: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  },
+  {
+    label: "Example",
+    title: "具体例",
+    description:
+      "理由を裏付ける具体的なエピソードを挙げます。数字や事実を含めると説得力が増します。",
+    template: "例えば、○○の場面で○○を行い、○○という結果を出しました。",
+    color:
+      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  },
+  {
+    label: "Point",
+    title: "結論（再提示）",
+    description: "最後に結論を繰り返し、入社後の活かし方に繋げます。",
+    template:
+      "この○○という強みを活かして、御社でも○○に貢献したいと考えています。",
+    color: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  },
+];
+
+interface FrameworkStepProps {
+  step: {
+    label: string;
+    title: string;
+    description: string;
+    template: string;
+    color: string;
+  };
+  index: number;
+}
+
+function FrameworkStep({ step, index }: FrameworkStepProps) {
+  return (
+    <div className="flex gap-3">
+      <div className="flex flex-col items-center">
+        <span
+          className={`flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-bold ${step.color}`}
+        >
+          {index + 1}
+        </span>
+        {index < 3 && (
+          <div className="mt-1 h-full w-0.5 bg-border" />
+        )}
+      </div>
+      <div className="pb-6">
+        <div className="mb-1 flex items-center gap-2">
+          <span className="text-sm font-semibold">{step.label}</span>
+          <span className="text-xs text-muted-foreground">({step.title})</span>
+        </div>
+        <p className="mb-2 text-sm text-muted-foreground">{step.description}</p>
+        <div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 px-3 py-2">
+          <p className="text-xs italic text-muted-foreground">
+            {step.template}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FrameworkGuide() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="size-5 text-primary" />
+          回答フレームワーク
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="star">
+          <TabsList className="mb-4 w-full">
+            <TabsTrigger value="star" className="flex-1">
+              STAR法
+            </TabsTrigger>
+            <TabsTrigger value="prep" className="flex-1">
+              PREP法
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="star">
+            <div className="mb-3">
+              <p className="text-sm text-muted-foreground">
+                経験・エピソードを構造的に伝えるフレームワークです。ガクチカや自己PRに最適です。
+              </p>
+            </div>
+            <div className="mt-4">
+              {STAR_STEPS.map((step, index) => (
+                <FrameworkStep key={step.label + index} step={step} index={index} />
+              ))}
+            </div>
+          </TabsContent>
+          <TabsContent value="prep">
+            <div className="mb-3">
+              <p className="text-sm text-muted-foreground">
+                結論ファーストで論理的に伝えるフレームワークです。志望動機や長所短所の質問に最適です。
+              </p>
+            </div>
+            <div className="mt-4">
+              {PREP_STEPS.map((step, index) => (
+                <FrameworkStep key={step.label + index} step={step} index={index} />
+              ))}
+            </div>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- 質問詳細ページに模範解答のアコーディオン表示を追加（初期状態は折りたたみ、ボタンクリックで展開）
- STAR法・PREP法の回答フレームワークガイドをタブ切り替えで表示
- 自分の回答を入力・localStorage自動保存する機能を追加（5000文字制限、ページ再訪時に復元）

closes #132

## 変更ファイル
- `src/components/questions/example-answer.tsx` — 模範解答アコーディオンコンポーネント（新規）
- `src/components/questions/framework-guide.tsx` — STAR法/PREP法ガイドコンポーネント（新規）
- `src/components/questions/answer-comparison.tsx` — 自分の回答入力コンポーネント（新規）
- `src/app/questions/[id]/page.tsx` — 上記コンポーネントを質問詳細ページに組み込み

## Test plan
- [ ] 質問詳細ページ（/questions/q001 等）で模範解答が折りたたみ状態であること
- [ ] 「模範解答を見る」ボタンで模範解答が展開・折りたたみされること
- [ ] STAR法・PREP法タブが正しく切り替わること
- [ ] 回答入力欄に文字を入力し、ページリロード後に復元されること
- [ ] 5000文字制限が機能すること
- [ ] モバイル表示でレイアウトが崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)