### PR TITLE
feat: #160 ボタン操作後のフィードバックUI改善

### DIFF
--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -14,6 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Loader2 } from "lucide-react";
 
 /** クールダウン秒数 */
 const COOLDOWN_SECONDS = 60;
@@ -178,6 +179,7 @@ export default function ResetPasswordPage() {
           </CardContent>
           <CardFooter className="flex flex-col gap-4">
             <Button type="submit" className="w-full" disabled={loading || cooldown > 0}>
+              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {loading
                 ? "送信中..."
                 : cooldown > 0

--- a/src/app/settings/billing/billing-client.tsx
+++ b/src/app/settings/billing/billing-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
-import { CreditCard, ExternalLink } from "lucide-react";
+import { CreditCard, ExternalLink, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -89,9 +89,9 @@ export function BillingClient({ plan, status, planName, priceMonthly, currentPer
           ) : null}
           {hasStripeCustomer ? (
             <Button variant="outline" onClick={handleOpenPortal} disabled={portalLoading}>
-              <CreditCard className="mr-2 size-4" />
+              {portalLoading ? <Loader2 className="mr-2 size-4 animate-spin" /> : <CreditCard className="mr-2 size-4" />}
               {portalLoading ? "読み込み中..." : "支払い・プラン管理"}
-              <ExternalLink className="ml-2 size-3" />
+              {!portalLoading && <ExternalLink className="ml-2 size-3" />}
             </Button>
           ) : null}
         </CardFooter>

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -15,6 +15,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Loader2 } from "lucide-react";
 
 export default function UpdatePasswordPage() {
   const [password, setPassword] = useState("");
@@ -149,6 +150,7 @@ export default function UpdatePasswordPage() {
           </CardContent>
           <CardFooter className="flex flex-col gap-4">
             <Button type="submit" className="w-full" disabled={loading}>
+              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {loading ? "更新中..." : "パスワードを更新"}
             </Button>
             <Link


### PR DESCRIPTION
## Summary
- パスワード更新ページ (`/update-password`) のボタンに Loader2 スピナーを追加
- パスワードリセットページ (`/reset-password`) のボタンに Loader2 スピナーを追加
- 課金管理ページ (`/settings/billing`) のポータルボタンに Loader2 スピナーを追加
- 全フォーム送信ボタンのローディングUI（Loader2 + disabled + 進行形テキスト）を統一

closes #160

## Test plan
- [ ] `/update-password` ページでパスワード更新ボタン押下時にスピナーが表示されること
- [ ] `/reset-password` ページでリセットメール送信ボタン押下時にスピナーが表示されること
- [ ] `/settings/billing` ページで「支払い・プラン管理」ボタン押下時にスピナーが表示されること
- [ ] ローディング中はボタンが disabled になり二重送信が防止されること
- [ ] `npm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)