### PR TITLE
feat: #174 スケルトンスクリーン・ローディング状態の統一

### DIFF
--- a/src/app/dashboard/growth/loading.tsx
+++ b/src/app/dashboard/growth/loading.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 export default function GrowthLoading() {
   return (
-    <div className="container mx-auto px-4 py-8 animate-pulse">
+    <div role="status" aria-label="読み込み中" className="container mx-auto px-4 py-8 animate-pulse">
       {/* ナビゲーション */}
       <div className="mb-6">
         <div className="h-4 w-40 rounded bg-muted" />
@@ -57,6 +57,8 @@ export default function GrowthLoading() {
           </Card>
         ))}
       </div>
+
+      <span className="sr-only">読み込み中</span>
     </div>
   );
 }

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 export default function DashboardLoading() {
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div role="status" aria-label="読み込み中" className="container mx-auto px-4 py-8">
       {/* ヘッダー */}
       <div className="flex items-center justify-between">
         <div className="h-8 w-32 animate-pulse rounded bg-muted" />
@@ -48,6 +48,8 @@ export default function DashboardLoading() {
           </Card>
         ))}
       </div>
+
+      <span className="sr-only">読み込み中</span>
     </div>
   );
 }

--- a/src/app/es-review/loading.tsx
+++ b/src/app/es-review/loading.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * ES添削ページのスケルトンスクリーン
+ * 実際のフォームレイアウトに近い形状でローディング状態を表示する
+ */
+export default function ESReviewLoading() {
+  return (
+    <div
+      role="status"
+      aria-label="読み込み中"
+      className="container mx-auto max-w-2xl px-4 py-8"
+    >
+      {/* ヘッダー */}
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="mt-2 h-4 w-72 max-w-full" />
+        </div>
+        <Skeleton className="h-9 w-24 rounded-md" />
+      </div>
+
+      <div className="space-y-6">
+        {/* ESの設問 */}
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-9 w-full rounded-md" />
+          {/* 質問例ボタン */}
+          <div className="flex flex-wrap gap-1.5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton
+                key={i}
+                className="h-7 rounded-full"
+                style={{ width: `${80 + i * 20}px` }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* ESの回答 */}
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-24" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Skeleton className="h-[250px] w-full rounded-md" />
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3 w-16" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-1.5 w-24 rounded-full" />
+                <Skeleton className="h-3 w-8" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 添削ボタン */}
+        <Skeleton className="h-11 w-full rounded-md" />
+      </div>
+
+      <span className="sr-only">読み込み中</span>
+    </div>
+  );
+}

--- a/src/app/es-review/page.tsx
+++ b/src/app/es-review/page.tsx
@@ -165,8 +165,43 @@ export default function ESReviewPage() {
 
   if (authLoading) {
     return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <div
+        role="status"
+        aria-label="読み込み中"
+        className="container mx-auto max-w-2xl px-4 py-8"
+      >
+        {/* ヘッダー */}
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <div className="h-8 w-24 animate-pulse rounded bg-muted" />
+            <div className="mt-2 h-4 w-72 max-w-full animate-pulse rounded bg-muted" />
+          </div>
+          <div className="h-9 w-24 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="space-y-6">
+          {/* ESの設問 */}
+          <div className="space-y-2">
+            <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+            <div className="h-9 w-full animate-pulse rounded-md bg-muted" />
+            <div className="flex flex-wrap gap-1.5">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-7 animate-pulse rounded-full bg-muted"
+                  style={{ width: `${80 + i * 20}px` }}
+                />
+              ))}
+            </div>
+          </div>
+          {/* ESの回答 */}
+          <div className="rounded-lg border bg-card p-6">
+            <div className="h-6 w-24 animate-pulse rounded bg-muted" />
+            <div className="mt-4 h-[250px] w-full animate-pulse rounded-md bg-muted" />
+          </div>
+          {/* 添削ボタン */}
+          <div className="h-11 w-full animate-pulse rounded-md bg-muted" />
+        </div>
+        <span className="sr-only">読み込み中</span>
       </div>
     );
   }

--- a/src/app/interview/[id]/result/loading.tsx
+++ b/src/app/interview/[id]/result/loading.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 export default function ResultLoading() {
   return (
-    <div className="container mx-auto max-w-4xl px-4 py-8 animate-pulse">
+    <div role="status" aria-label="読み込み中" className="container mx-auto max-w-4xl px-4 py-8 animate-pulse">
       {/* ヘッダー */}
       <div className="mb-6 flex items-center gap-4">
         <div className="h-9 w-48 rounded-md bg-muted" />
@@ -74,6 +74,8 @@ export default function ResultLoading() {
           </Card>
         ))}
       </div>
+
+      <span className="sr-only">読み込み中</span>
     </div>
   );
 }

--- a/src/app/mock-interview/loading.tsx
+++ b/src/app/mock-interview/loading.tsx
@@ -1,0 +1,97 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * AI模擬面接セットアップページのスケルトンスクリーン
+ * 実際のフォームレイアウトに近い形状でローディング状態を表示する
+ */
+export default function MockInterviewLoading() {
+  return (
+    <div
+      role="status"
+      aria-label="読み込み中"
+      className="container mx-auto max-w-2xl px-4 py-8"
+    >
+      {/* ヘッダー */}
+      <Skeleton className="mb-2 h-8 w-40" />
+      <Skeleton className="mb-6 h-4 w-96 max-w-full" />
+
+      <div className="space-y-6">
+        {/* 企業名 */}
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-72 max-w-full" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+
+        {/* 業界 */}
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+
+        {/* 面接タイプ */}
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-24" />
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="rounded-lg border p-3">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="mt-2 h-3 w-full" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 面接ラウンド */}
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+
+        {/* 面接時間 */}
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+
+        {/* 難易度 */}
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-16" />
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="rounded-lg border p-3">
+                  <Skeleton className="h-4 w-16" />
+                  <Skeleton className="mt-2 h-3 w-full" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* パーソナリティタイプ */}
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-40" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-4 w-72 max-w-full" />
+            <Skeleton className="mt-2 h-4 w-40" />
+          </CardContent>
+        </Card>
+
+        {/* 送信ボタン */}
+        <Skeleton className="h-11 w-full rounded-md" />
+      </div>
+
+      <span className="sr-only">読み込み中</span>
+    </div>
+  );
+}

--- a/src/app/profile/loading.tsx
+++ b/src/app/profile/loading.tsx
@@ -1,0 +1,143 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * プロフィール設定ページのスケルトンスクリーン
+ * 実際のレイアウトに近い形状でローディング状態を表示する
+ */
+export default function ProfileLoading() {
+  return (
+    <div
+      role="status"
+      aria-label="読み込み中"
+      className="container mx-auto max-w-2xl px-4 py-8"
+    >
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="mt-2 h-4 w-96 max-w-full" />
+      </div>
+
+      {/* 基本情報カード */}
+      <Card className="mb-6">
+        <CardHeader>
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="mt-1 h-4 w-64" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* フルネーム */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          {/* 大学名 */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          {/* 学部・学科 */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          {/* 卒業予定年・月 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-9 w-full rounded-md" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-9 w-full rounded-md" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 就活情報カード */}
+      <Card className="mb-6">
+        <CardHeader>
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="mt-1 h-4 w-56" />
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* 就活状況 */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          {/* 志望業界 */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 9 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-16 rounded-full" />
+              ))}
+            </div>
+          </div>
+          {/* 志望職種 */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-20 rounded-full" />
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 希望条件カード */}
+      <Card className="mb-6">
+        <CardHeader>
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="mt-1 h-4 w-48" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 9 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-14 rounded-full" />
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* パーソナリティタイプカード */}
+      <Card className="mb-6">
+        <CardHeader>
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="mt-1 h-4 w-80 max-w-full" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <Skeleton className="h-16 w-full rounded-lg" />
+        </CardContent>
+      </Card>
+
+      {/* 通知設定カード */}
+      <Card className="mb-6">
+        <CardHeader>
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="mt-1 h-4 w-56" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-16 w-full rounded-lg" />
+          <Skeleton className="h-16 w-full rounded-lg" />
+        </CardContent>
+      </Card>
+
+      {/* 保存ボタン */}
+      <div className="flex justify-end">
+        <Skeleton className="h-11 w-32 rounded-md" />
+      </div>
+
+      <span className="sr-only">読み込み中</span>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -293,8 +293,56 @@ export default function ProfilePage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <div
+        role="status"
+        aria-label="読み込み中"
+        className="container mx-auto max-w-2xl px-4 py-8"
+      >
+        {/* ヘッダー */}
+        <div className="mb-6">
+          <div className="h-8 w-48 animate-pulse rounded bg-muted" />
+          <div className="mt-2 h-4 w-96 max-w-full animate-pulse rounded bg-muted" />
+        </div>
+        {/* 基本情報カード */}
+        <div className="mb-6 rounded-lg border bg-card p-6">
+          <div className="h-6 w-24 animate-pulse rounded bg-muted" />
+          <div className="mt-1 h-4 w-64 animate-pulse rounded bg-muted" />
+          <div className="mt-4 space-y-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+                <div className="h-9 w-full animate-pulse rounded-md bg-muted" />
+              </div>
+            ))}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+                <div className="h-9 w-full animate-pulse rounded-md bg-muted" />
+              </div>
+              <div className="space-y-2">
+                <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+                <div className="h-9 w-full animate-pulse rounded-md bg-muted" />
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* 就活情報カード */}
+        <div className="mb-6 rounded-lg border bg-card p-6">
+          <div className="h-6 w-24 animate-pulse rounded bg-muted" />
+          <div className="mt-4 space-y-4">
+            <div className="h-9 w-full animate-pulse rounded-md bg-muted" />
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 9 }).map((_, i) => (
+                <div key={i} className="h-8 w-16 animate-pulse rounded-full bg-muted" />
+              ))}
+            </div>
+          </div>
+        </div>
+        {/* 保存ボタン */}
+        <div className="flex justify-end">
+          <div className="h-11 w-32 animate-pulse rounded-md bg-muted" />
+        </div>
+        <span className="sr-only">読み込み中</span>
       </div>
     );
   }

--- a/src/app/settings/billing/loading.tsx
+++ b/src/app/settings/billing/loading.tsx
@@ -1,0 +1,60 @@
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * プラン管理ページのスケルトンスクリーン
+ * 実際のレイアウトに近い形状でローディング状態を表示する
+ */
+export default function BillingLoading() {
+  return (
+    <div role="status" aria-label="読み込み中" className="px-4 py-16">
+      <div className="mx-auto max-w-2xl">
+        {/* ヘッダー */}
+        <Skeleton className="h-9 w-40" />
+        <Skeleton className="mt-2 h-5 w-72 max-w-full" />
+
+        <div className="mt-8 space-y-6">
+          {/* 現在のプランカード */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-7 w-36" />
+                <Skeleton className="h-6 w-12 rounded-full" />
+              </div>
+              <Skeleton className="mt-1 h-4 w-48" />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="mt-1 h-4 w-32" />
+              </div>
+            </CardContent>
+            <CardFooter className="flex gap-3">
+              <Skeleton className="h-10 w-32 rounded-md" />
+              <Skeleton className="h-10 w-44 rounded-md" />
+            </CardFooter>
+          </Card>
+
+          {/* 利用状況カード */}
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-7 w-36" />
+              <Skeleton className="mt-1 h-4 w-40" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+                <Skeleton className="h-2 w-full rounded-full" />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <span className="sr-only">読み込み中</span>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * スケルトンスクリーン用の汎用コンポーネント
+ * animate-pulse + bg-muted で統一されたローディングプレースホルダーを提供する
+ */
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
## Summary

closes #174

- `src/components/ui/skeleton.tsx` を新規作成（`cn` ユーティリティ対応の汎用 Skeleton コンポーネント）
- 主要4ページに `loading.tsx`（Next.js App Router 規約）を追加:
  - `/profile` — カード形式のフォームスケルトン
  - `/mock-interview` — セットアップフォームスケルトン
  - `/es-review` — 設問・回答入力フォームスケルトン
  - `/settings/billing` — プラン・利用状況カードスケルトン
- プロフィールページ・ES添削ページのクライアントサイド `Loader2` スピナーをスケルトンUIに置換
- 既存 loading.tsx（ダッシュボード、成長記録、面接結果）にアクセシビリティ属性を追加:
  - `role="status"` + `aria-label="読み込み中"`
  - `<span className="sr-only">読み込み中</span>` をスクリーンリーダー向けに追加

### デザイン統一方針
- `animate-pulse` + `bg-muted` + `rounded` を全スケルトンで統一
- 実際のページレイアウトに近い形状（CLS防止）
- モバイルレスポンシブ対応（`max-w-full` 等）

## Test plan

- [ ] `/profile` に遷移時、スケルトンスクリーンが表示されること
- [ ] `/mock-interview` に遷移時、スケルトンスクリーンが表示されること
- [ ] `/es-review` に遷移時、スケルトンスクリーンが表示されること
- [ ] `/settings/billing` に遷移時、スケルトンスクリーンが表示されること
- [ ] 既存の `/dashboard`, `/dashboard/growth`, `/interview/[id]/result` のスケルトンが引き続き正常動作すること
- [ ] スクリーンリーダーで「読み込み中」がアナウンスされること
- [ ] モバイルビューでレイアウトが崩れないこと
- [ ] `npm run build` が成功すること（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)