### PR TITLE
feat: #177 アイコンライブラリの統一（インラインSVG → Lucide Icons）

### DIFF
--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -13,6 +13,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import type { CategoryScores } from "@/types/database";
 import { CATEGORY_LABELS } from "@/lib/constants";
+import { Share2, CheckCircle2, AlertTriangle, ArrowRight } from "lucide-react";
 
 // ============================================================
 // 型定義
@@ -281,20 +282,7 @@ export default async function SharedResultPage({ params }: SharedPageProps) {
       {/* ヘッダー */}
       <div className="mb-8 text-center">
         <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-blue-50 px-4 py-1 text-sm text-blue-700 dark:bg-blue-950/30 dark:text-blue-300">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-            />
-          </svg>
+          <Share2 className="h-4 w-4" />
           共有された面接結果
         </div>
         <h1 className="text-2xl font-bold md:text-3xl">{interview.title}</h1>
@@ -377,20 +365,7 @@ export default async function SharedResultPage({ params }: SharedPageProps) {
         <div className="mb-6 grid gap-4 sm:grid-cols-2">
           <div className="rounded-xl border bg-card p-6">
             <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-green-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <CheckCircle2 className="h-5 w-5" />
               良い点
             </h2>
             {displayGoodPoints.length === 0 ? (
@@ -399,20 +374,7 @@ export default async function SharedResultPage({ params }: SharedPageProps) {
               <ul className="space-y-3">
                 {displayGoodPoints.map((point, i) => (
                   <li key={i} className="flex items-start gap-2 text-sm">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="mt-0.5 h-4 w-4 shrink-0 text-green-500"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
                     <span>{point}</span>
                   </li>
                 ))}
@@ -422,20 +384,7 @@ export default async function SharedResultPage({ params }: SharedPageProps) {
 
           <div className="rounded-xl border bg-card p-6">
             <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-orange-600">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
-                />
-              </svg>
+              <AlertTriangle className="h-5 w-5" />
               改善点
             </h2>
             {displayImprovementPoints.length === 0 ? (
@@ -444,20 +393,7 @@ export default async function SharedResultPage({ params }: SharedPageProps) {
               <ul className="space-y-3">
                 {displayImprovementPoints.map((point, i) => (
                   <li key={i} className="flex items-start gap-2 text-sm">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="mt-0.5 h-4 w-4 shrink-0 text-orange-500"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
-                      />
-                    </svg>
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-orange-500" />
                     <span>{point}</span>
                   </li>
                 ))}
@@ -508,20 +444,7 @@ export default async function SharedResultPage({ params }: SharedPageProps) {
           className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-700"
         >
           無料で始める
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M13 7l5 5m0 0l-5 5m5-5H6"
-            />
-          </svg>
+          <ArrowRight className="h-4 w-4" />
         </Link>
       </div>
     </div>

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -10,6 +10,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
+import { Loader2, Share2, Check, Copy, Ban } from "lucide-react";
 
 // ============================================================
 // 型定義
@@ -190,41 +191,9 @@ export function ShareButton({ interviewId }: ShareButtonProps) {
           disabled={state.loading}
         >
           {state.loading ? (
-            <svg
-              className="mr-2 h-4 w-4 animate-spin"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : (
-            <svg
-              className="mr-2 h-4 w-4"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-              />
-            </svg>
+            <Share2 className="mr-2 h-4 w-4" />
           )}
           共有リンクを作成
         </Button>
@@ -259,38 +228,12 @@ export function ShareButton({ interviewId }: ShareButtonProps) {
           >
             {state.copied ? (
               <>
-                <svg
-                  className="mr-1 h-4 w-4 text-green-500"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
+                <Check className="mr-1 h-4 w-4 text-green-500" />
                 コピー済み
               </>
             ) : (
               <>
-                <svg
-                  className="mr-1 h-4 w-4"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                  />
-                </svg>
+                <Copy className="mr-1 h-4 w-4" />
                 コピー
               </>
             )}
@@ -353,41 +296,9 @@ export function ShareButton({ interviewId }: ShareButtonProps) {
             className="ml-auto text-xs text-red-500 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/20"
           >
             {state.revoking ? (
-              <svg
-                className="mr-1 h-3 w-3 animate-spin"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
+              <Loader2 className="mr-1 h-3 w-3 animate-spin" />
             ) : (
-              <svg
-                className="mr-1 h-3 w-3"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
-                />
-              </svg>
+              <Ban className="mr-1 h-3 w-3" />
             )}
             共有を取り消す
           </Button>


### PR DESCRIPTION
## Summary

- `share-button.tsx` のインラインSVG 6箇所を Lucide Icons (`Loader2`, `Share2`, `Check`, `Copy`, `Ban`) に置換
- `share/[token]/page.tsx` のインラインSVG 6箇所を Lucide Icons (`Share2`, `CheckCircle2`, `AlertTriangle`, `ArrowRight`) に置換
- X/Twitter, LINE のブランドアイコンはインラインSVGを維持（Lucide に同等アイコンなし）
- `personality/share-buttons.tsx` のブランドアイコンも同様に維持
- 180行のインラインSVGを14行の Lucide import + JSX に削減

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/components/share-button.tsx` | `Loader2`, `Share2`, `Check`, `Copy`, `Ban` に置換 |
| `src/app/share/[token]/page.tsx` | `Share2`, `CheckCircle2`, `AlertTriangle`, `ArrowRight` に置換 |

## 置換マッピング

- ローディングスピナー SVG → `<Loader2 className="animate-spin" />`
- 共有アイコン SVG → `<Share2 />`
- コピーアイコン SVG → `<Copy />` / `<Check />`
- 無効化アイコン SVG → `<Ban />`
- チェックマーク(丸) SVG → `<CheckCircle2 />`
- 警告三角 SVG → `<AlertTriangle />`
- 矢印 SVG → `<ArrowRight />`

## Test plan

- [x] `npm run build` 成功
- [ ] 共有ボタンの表示確認（リンク未作成/作成済み状態）
- [ ] コピーボタンのアイコン切り替え確認
- [ ] 無効化ボタンのアイコン表示確認
- [ ] `/share/[token]` ページのアイコン表示確認

closes #177