### PR TITLE
feat: #178 パスワード強度インジケーター・バリデーション改善

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -15,6 +15,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Loader2, Mail } from "lucide-react";
+import { PasswordStrength } from "@/components/ui/password-strength";
+import { PasswordInput } from "@/components/ui/password-input";
 
 export default function SignUpPage() {
   const [email, setEmail] = useState("");
@@ -142,9 +144,8 @@ export default function SignUpPage() {
             </div>
             <div className="space-y-2">
               <Label htmlFor="password">パスワード</Label>
-              <Input
+              <PasswordInput
                 id="password"
-                type="password"
                 autoComplete="new-password"
                 placeholder="8文字以上"
                 value={password}
@@ -152,6 +153,7 @@ export default function SignUpPage() {
                 required
                 minLength={8}
               />
+              <PasswordStrength password={password} />
             </div>
             <div className="flex items-start gap-2">
               <input

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Card,
@@ -16,6 +15,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
+import { PasswordStrength } from "@/components/ui/password-strength";
+import { PasswordInput } from "@/components/ui/password-input";
 
 export default function UpdatePasswordPage() {
   const [password, setPassword] = useState("");
@@ -120,9 +121,8 @@ export default function UpdatePasswordPage() {
             )}
             <div className="space-y-2">
               <Label htmlFor="password">新しいパスワード</Label>
-              <Input
+              <PasswordInput
                 id="password"
-                type="password"
                 autoComplete="new-password"
                 placeholder="8文字以上"
                 value={password}
@@ -130,12 +130,12 @@ export default function UpdatePasswordPage() {
                 required
                 minLength={8}
               />
+              <PasswordStrength password={password} />
             </div>
             <div className="space-y-2">
               <Label htmlFor="confirmPassword">新しいパスワード（確認）</Label>
-              <Input
+              <PasswordInput
                 id="confirmPassword"
-                type="password"
                 autoComplete="new-password"
                 placeholder="もう一度入力"
                 value={confirmPassword}
@@ -144,9 +144,6 @@ export default function UpdatePasswordPage() {
                 minLength={8}
               />
             </div>
-            <p className="text-xs text-muted-foreground">
-              パスワードは8文字以上で設定してください。
-            </p>
           </CardContent>
           <CardFooter className="flex flex-col gap-4">
             <Button type="submit" className="w-full" disabled={loading}>

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState, forwardRef } from "react";
+import { cn } from "@/lib/utils";
+import { Eye, EyeOff } from "lucide-react";
+
+const PasswordInput = forwardRef<
+  HTMLInputElement,
+  React.ComponentProps<"input">
+>(({ className, ...props }, ref) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className="relative">
+      <input
+        type={showPassword ? "text" : "password"}
+        ref={ref}
+        data-slot="input"
+        className={cn(
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 pr-9 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          className
+        )}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setShowPassword((prev) => !prev)}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm p-0.5"
+        aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
+        tabIndex={-1}
+      >
+        {showPassword ? (
+          <EyeOff className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <Eye className="h-4 w-4" aria-hidden="true" />
+        )}
+      </button>
+    </div>
+  );
+});
+
+PasswordInput.displayName = "PasswordInput";
+
+export { PasswordInput };

--- a/src/components/ui/password-strength.tsx
+++ b/src/components/ui/password-strength.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { Check, X } from "lucide-react";
+
+interface PasswordStrengthProps {
+  password: string;
+}
+
+interface StrengthCriteria {
+  label: string;
+  met: boolean;
+}
+
+type StrengthLevel = 0 | 1 | 2 | 3;
+
+interface StrengthInfo {
+  level: StrengthLevel;
+  label: string;
+  color: string;
+  barColor: string;
+}
+
+function evaluateCriteria(password: string): StrengthCriteria[] {
+  return [
+    { label: "8文字以上", met: password.length >= 8 },
+    { label: "英大文字を含む", met: /[A-Z]/.test(password) },
+    { label: "英小文字を含む", met: /[a-z]/.test(password) },
+    { label: "数字を含む", met: /[0-9]/.test(password) },
+    { label: "記号を含む", met: /[^A-Za-z0-9]/.test(password) },
+  ];
+}
+
+function calculateStrength(password: string): StrengthInfo {
+  if (password.length === 0) {
+    return { level: 0, label: "", color: "", barColor: "bg-muted" };
+  }
+
+  const hasLower = /[a-z]/.test(password);
+  const hasUpper = /[A-Z]/.test(password);
+  const hasDigit = /[0-9]/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+  const isLong = password.length >= 12;
+
+  // 強い: 大文字+小文字+数字+記号 かつ 12文字以上
+  if (hasLower && hasUpper && hasDigit && hasSymbol && isLong) {
+    return {
+      level: 3,
+      label: "非常に強い",
+      color: "text-green-600 dark:text-green-400",
+      barColor: "bg-green-500",
+    };
+  }
+
+  // 普通〜強い: 複数の文字種の組み合わせ
+  const typesCount = [hasLower, hasUpper, hasDigit, hasSymbol].filter(Boolean).length;
+
+  if (typesCount >= 3 && password.length >= 8) {
+    return {
+      level: 2,
+      label: "強い",
+      color: "text-yellow-600 dark:text-yellow-400",
+      barColor: "bg-yellow-500",
+    };
+  }
+
+  if (typesCount >= 2 && password.length >= 8) {
+    return {
+      level: 1,
+      label: "普通",
+      color: "text-orange-600 dark:text-orange-400",
+      barColor: "bg-orange-500",
+    };
+  }
+
+  // 弱い: 8文字未満 or 1種類のみ
+  return {
+    level: 0,
+    label: "弱い",
+    color: "text-red-600 dark:text-red-400",
+    barColor: "bg-red-500",
+  };
+}
+
+export function PasswordStrength({ password }: PasswordStrengthProps) {
+  const criteria = useMemo(() => evaluateCriteria(password), [password]);
+  const strength = useMemo(() => calculateStrength(password), [password]);
+
+  if (password.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* 強度バー */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">パスワード強度</span>
+          <span
+            className={cn("text-xs font-medium", strength.color)}
+            aria-live="polite"
+            role="status"
+          >
+            {strength.label}
+          </span>
+        </div>
+        <div className="flex gap-1" role="progressbar" aria-valuenow={strength.level} aria-valuemin={0} aria-valuemax={3} aria-label={`パスワード強度: ${strength.label}`}>
+          {[0, 1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className={cn(
+                "h-1.5 flex-1 rounded-full transition-colors duration-300",
+                i <= strength.level && password.length > 0
+                  ? strength.barColor
+                  : "bg-muted"
+              )}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* チェックリスト */}
+      <ul className="space-y-1" aria-label="パスワード条件">
+        {criteria.map((criterion) => (
+          <li
+            key={criterion.label}
+            className={cn(
+              "flex items-center gap-1.5 text-xs transition-colors",
+              criterion.met
+                ? "text-green-600 dark:text-green-400"
+                : "text-muted-foreground"
+            )}
+          >
+            {criterion.met ? (
+              <Check className="h-3 w-3 shrink-0" aria-hidden="true" />
+            ) : (
+              <X className="h-3 w-3 shrink-0" aria-hidden="true" />
+            )}
+            <span>{criterion.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- パスワード強度インジケーターコンポーネント (`PasswordStrength`) を新規作成。4段階バー表示（弱い/普通/強い/非常に強い）＋条件チェックリスト（8文字以上・英大文字・英小文字・数字・記号）をリアルタイム表示
- パスワード表示/非表示トグル付き入力コンポーネント (`PasswordInput`) を新規作成。Eye/EyeOff アイコンで切替
- サインアップページ (`/signup`) とパスワード更新ページ (`/update-password`) に統合

## 技術詳細
- 外部ライブラリ不使用（自前の軽量実装）
- `aria-live="polite"` + `role="progressbar"` でスクリーンリーダー対応
- `useMemo` でパフォーマンス最適化
- コピー&ペースト・パスワードマネージャー自動入力にも `onChange` イベントで対応

## 判定基準
| レベル | 条件 | 色 |
|---|---|---|
| 弱い | 8文字未満 or 1種類のみ | 赤 |
| 普通 | 2種類以上の文字種 + 8文字以上 | オレンジ |
| 強い | 3種類以上の文字種 + 8文字以上 | 黄 |
| 非常に強い | 4種類(大小英字+数字+記号) + 12文字以上 | 緑 |

## Test plan
- [ ] `/signup` でパスワード入力時にリアルタイムで強度バーが変化する
- [ ] `/update-password` でも同様に強度バーが表示される
- [ ] 目のアイコンクリックでパスワード表示/非表示が切り替わる
- [ ] 条件チェックリストが各条件に応じてリアルタイムで更新される
- [ ] コピー&ペーストで入力してもインジケーターが正しく更新される
- [ ] `npm run build` 成功確認済み

closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)