### PR TITLE
feat: #203 - ユニットテスト拡充

### DIFF
--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ============================================================
+// モック設定
+// ============================================================
+
+const mockUser = { id: "user-123", email: "test@example.com" };
+
+function createChainMock(resolveValue: unknown = { data: null, error: null }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.insert = vi.fn().mockReturnValue(chain);
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.in = vi.fn().mockReturnValue(chain);
+  chain.gte = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(resolveValue);
+  return chain;
+}
+
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockImplementation(async () => mockSupabase),
+}));
+
+const mockCheckUsageLimit = vi.fn();
+const mockGetModelForPlan = vi.fn();
+
+vi.mock("@/lib/subscription", () => ({
+  checkUsageLimit: (...args: unknown[]) => mockCheckUsageLimit(...args),
+  getModelForPlan: (...args: unknown[]) => mockGetModelForPlan(...args),
+}));
+
+// Sentry モック
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+// Anthropic SDK モック
+const mockMessagesCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = { create: mockMessagesCreate };
+    },
+  };
+});
+
+import { POST } from "./route";
+
+// ============================================================
+// ヘルパー
+// ============================================================
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/analyze", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Claude API が返す妥当な JSON レスポンス */
+const validAIResponse = {
+  overall_score: 75,
+  good_points: ["論理的な構成", "具体的なエピソード"],
+  improvement_points: ["もう少し簡潔に"],
+  detailed_feedback: "全体的に良い面接でした。",
+  category_scores: { communication: 80, content: 70, manner: 85, logic: 75 },
+  advice: "結論ファーストを意識しましょう。",
+  summary: "面接の要約です。",
+  suggestions: [{ original: "元の回答", improved: "改善案", reason: "理由" }],
+  filler_words: { total_count: 3, filler_rate: 1.5, details: [{ word: "えーと", count: 3 }], assessment: "やや多め" },
+  strengths: ["論理的思考"],
+  improvements: ["簡潔さ"],
+  annotations: [],
+};
+
+// ============================================================
+// テスト
+// ============================================================
+
+describe("POST /api/analyze", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    mockCheckUsageLimit.mockResolvedValue({
+      allowed: true,
+      plan: "pro",
+      used: 5,
+      limit: 30,
+    });
+
+    mockGetModelForPlan.mockReturnValue("claude-sonnet-4-6");
+
+    mockMessagesCreate.mockResolvedValue({
+      content: [{ type: "text", text: JSON.stringify(validAIResponse) }],
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("バリデーション", () => {
+    it("interview_id が未指定の場合は 400 を返す", async () => {
+      const res = await POST(makeRequest({}));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("interview_id");
+    });
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は 401 を返す", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: null,
+      });
+
+      // interviews の select が走る前に認証チェックで弾かれる
+      const res = await POST(makeRequest({ interview_id: "int-1" }));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("API キー", () => {
+    it("ANTHROPIC_API_KEY が未設定の場合は 500 を返す", async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+
+      const res = await POST(makeRequest({ interview_id: "int-1" }));
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toContain("ANTHROPIC_API_KEY");
+    });
+  });
+
+  describe("面接データ取得", () => {
+    it("面接データが見つからない場合は 404 を返す", async () => {
+      const interviewsChain = createChainMock({ data: null, error: { message: "not found" } });
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === "interviews") return interviewsChain;
+        return createChainMock();
+      });
+
+      const res = await POST(makeRequest({ interview_id: "nonexistent" }));
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error).toContain("面接データが見つかりません");
+    });
+  });
+
+  describe("利用制限", () => {
+    it("利用上限に達している場合は 403 を返す", async () => {
+      // 面接データは見つかる
+      const interviewsChain = createChainMock({
+        data: {
+          id: "int-1",
+          user_id: "user-123",
+          transcript: "テスト".repeat(50),
+          interview_category: "new_grad",
+          interview_round: "first",
+          company_name_snapshot: "テスト株式会社",
+        },
+        error: null,
+      });
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === "interviews") return interviewsChain;
+        return createChainMock();
+      });
+
+      mockCheckUsageLimit.mockResolvedValue({
+        allowed: false,
+        plan: "free",
+        used: 3,
+        limit: 3,
+      });
+
+      const res = await POST(makeRequest({ interview_id: "int-1" }));
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.code).toBe("USAGE_LIMIT_EXCEEDED");
+      expect(json.upgrade_url).toBe("/pricing");
+    });
+  });
+
+  describe("正常系", () => {
+    it("分析が成功すると success: true を返す", async () => {
+      const interviewData = {
+        id: "int-1",
+        user_id: "user-123",
+        transcript: "A".repeat(200),
+        interview_category: "new_grad",
+        interview_round: "first",
+        company_name_snapshot: "テスト株式会社",
+        status: "uploaded",
+      };
+
+      // update (analyzing) 用のチェイン
+      const updateChain = createChainMock({ data: null, error: null });
+      updateChain.update = vi.fn().mockReturnValue(updateChain);
+      updateChain.eq = vi.fn().mockResolvedValue({ data: null, error: null });
+
+      // insert (feedbacks) 用のチェイン
+      const feedbackInsertChain = createChainMock({ data: null, error: null });
+      feedbackInsertChain.insert = vi.fn().mockResolvedValue({ data: null, error: null });
+
+      // transcripts: 空
+      const transcriptsChain = createChainMock({ data: [], error: null });
+      transcriptsChain.order = vi.fn().mockResolvedValue({ data: [], error: null });
+
+      // profiles
+      const profilesChain = createChainMock({
+        data: { university: "テスト大学", faculty: "工学部", target_industry: ["IT"], target_job_type: ["エンジニア"], personality_type: null },
+        error: null,
+      });
+
+      let interviewsCallCount = 0;
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === "interviews") {
+          interviewsCallCount++;
+          if (interviewsCallCount === 1) {
+            // SELECT
+            return createChainMock({ data: interviewData, error: null });
+          }
+          // UPDATE（analyzing / completed）
+          return updateChain;
+        }
+        if (table === "transcripts") return transcriptsChain;
+        if (table === "profiles") return profilesChain;
+        if (table === "feedbacks") return feedbackInsertChain;
+        return createChainMock();
+      });
+
+      const res = await POST(makeRequest({ interview_id: "int-1" }));
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.success).toBe(true);
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    it("内部エラーが発生しても詳細はクライアントに漏れない", async () => {
+      // interviews SELECT で例外をスロー
+      mockSupabase.from.mockImplementation(() => {
+        throw new Error("Internal DB connection error: password=secret");
+      });
+
+      const res = await POST(makeRequest({ interview_id: "int-1" }));
+      expect(res.status).toBe(500);
+
+      const json = await res.json();
+      // 内部エラーメッセージが漏れていないこと
+      expect(json.error).not.toContain("password");
+      expect(json.error).not.toContain("Internal DB");
+      expect(json.error).toContain("分析処理中にエラーが発生しました");
+    });
+  });
+});

--- a/src/app/api/interviews/route.test.ts
+++ b/src/app/api/interviews/route.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ============================================================
+// モック設定
+// ============================================================
+
+// Supabase のチェイン可能なクエリビルダーモック
+function createChainMock(resolveValue: unknown = { data: null, error: null }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.insert = vi.fn().mockReturnValue(chain);
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(resolveValue);
+  return chain;
+}
+
+let mockUser: { id: string; email: string } | null = { id: "user-123", email: "test@example.com" };
+let companiesChain: ReturnType<typeof createChainMock>;
+let interviewsChain: ReturnType<typeof createChainMock>;
+
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockImplementation(async () => mockSupabase),
+}));
+
+// crypto.randomUUID をモック
+vi.stubGlobal("crypto", {
+  ...globalThis.crypto,
+  randomUUID: () => "mock-uuid-1234",
+});
+
+import { POST } from "./route";
+
+// ============================================================
+// ヘルパー
+// ============================================================
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/interviews", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function validBody(): Record<string, unknown> {
+  return {
+    company_name: "テスト株式会社",
+    interview_category: "new_grad",
+    interview_round: "first",
+    interview_date: "2025-12-01",
+    transcript: "A".repeat(150), // 100文字以上
+  };
+}
+
+// ============================================================
+// テスト
+// ============================================================
+
+describe("POST /api/interviews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = { id: "user-123", email: "test@example.com" };
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    // companies テーブル: 既存企業なし → 新規作成
+    companiesChain = createChainMock({ data: null, error: null });
+    // insert 後の select → single で id を返す
+    const companiesInsertChain = createChainMock({ data: { id: "company-1" }, error: null });
+
+    // interviews テーブル: 成功
+    interviewsChain = createChainMock({ data: null, error: null });
+    // insert は error のみ返す
+    interviewsChain.insert = vi.fn().mockResolvedValue({ error: null });
+
+    let companiesCallCount = 0;
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "companies") {
+        companiesCallCount++;
+        if (companiesCallCount === 1) {
+          // SELECT（既存企業検索）
+          return companiesChain;
+        }
+        // INSERT（新規作成）
+        return companiesInsertChain;
+      }
+      if (table === "interviews") {
+        return interviewsChain;
+      }
+      return createChainMock();
+    });
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は 401 を返す", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: null,
+      });
+
+      const res = await POST(makeRequest(validBody()));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("企業名が空の場合は 400 を返す", async () => {
+      const body = validBody();
+      body.company_name = "";
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("企業名");
+    });
+
+    it("企業名が100文字超の場合は 400 を返す", async () => {
+      const body = validBody();
+      body.company_name = "A".repeat(101);
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+    });
+
+    it("無効な面接カテゴリの場合は 400 を返す", async () => {
+      const body = validBody();
+      body.interview_category = "invalid_category";
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("面接カテゴリ");
+    });
+
+    it("新卒面接で interview_round がない場合は 400 を返す", async () => {
+      const body = validBody();
+      body.interview_category = "new_grad";
+      body.interview_round = null;
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("面接ラウンド");
+    });
+
+    it("アルバイト面接では interview_round が不要", async () => {
+      const body = validBody();
+      body.interview_category = "arubaito";
+      body.interview_round = null;
+
+      const res = await POST(makeRequest(body));
+      // バリデーションエラーにならないこと（次の処理で失敗しても400ではない）
+      expect(res.status).not.toBe(400);
+    });
+
+    it("未来の面接日は 400 を返す", async () => {
+      const body = validBody();
+      body.interview_date = "2099-01-01";
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("今日以前");
+    });
+
+    it("音声スクリプトが空の場合は 400 を返す", async () => {
+      const body = validBody();
+      body.transcript = "";
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+    });
+
+    it("音声スクリプトが100文字未満の場合は 400 を返す", async () => {
+      const body = validBody();
+      body.transcript = "短すぎ";
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("100文字以上");
+    });
+
+    it("音声スクリプトが50,000文字超の場合は 400 を返す", async () => {
+      const body = validBody();
+      body.transcript = "A".repeat(50001);
+
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("正常系", () => {
+    it("有効なリクエストで 200 と interview_id を返す", async () => {
+      const res = await POST(makeRequest(validBody()));
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.interview_id).toBeDefined();
+    });
+  });
+});

--- a/src/app/api/mock-interview/route.test.ts
+++ b/src/app/api/mock-interview/route.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ============================================================
+// モック設定
+// ============================================================
+
+const mockUser = { id: "user-123", email: "test@example.com" };
+
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockImplementation(async () => mockSupabase),
+}));
+
+const mockCheckUsageLimit = vi.fn();
+const mockGetModelForPlan = vi.fn();
+
+vi.mock("@/lib/subscription", () => ({
+  checkUsageLimit: (...args: unknown[]) => mockCheckUsageLimit(...args),
+  getModelForPlan: (...args: unknown[]) => mockGetModelForPlan(...args),
+}));
+
+// Anthropic SDK モック
+const mockMessagesCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = { create: mockMessagesCreate };
+    },
+  };
+});
+
+import { POST } from "./route";
+
+// ============================================================
+// ヘルパー
+// ============================================================
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/mock-interview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ============================================================
+// テスト
+// ============================================================
+
+describe("POST /api/mock-interview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // ANTHROPIC_API_KEY を設定
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    mockCheckUsageLimit.mockResolvedValue({
+      allowed: true,
+      plan: "pro",
+      used: 5,
+      limit: 30,
+    });
+
+    mockGetModelForPlan.mockReturnValue("claude-sonnet-4-6");
+
+    mockMessagesCreate.mockResolvedValue({
+      content: [{ type: "text", text: "面接を始めましょう。まず自己紹介をお願いします。" }],
+    });
+
+    // Supabase insert モック
+    const insertChain = {
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: "mock-interview-id-1" },
+        error: null,
+      }),
+    };
+    const fromMock = {
+      insert: vi.fn().mockReturnValue(insertChain),
+    };
+    mockSupabase.from.mockReturnValue(fromMock);
+  });
+
+  describe("バリデーション", () => {
+    it("無効なカテゴリの場合は 400 を返す", async () => {
+      const res = await POST(makeRequest({ category: "invalid" }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("カテゴリ");
+    });
+
+    it("無効なラウンドの場合は 400 を返す", async () => {
+      const res = await POST(makeRequest({ round: "invalid" }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("ラウンド");
+    });
+
+    it("無効な難易度の場合は 400 を返す", async () => {
+      const res = await POST(makeRequest({ difficulty: "invalid" }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("難易度");
+    });
+
+    it("無効な面接時間の場合は 400 を返す", async () => {
+      const res = await POST(makeRequest({ duration_minutes: 45 }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("面接時間");
+    });
+
+    it("企業名が100文字超の場合は 400 を返す", async () => {
+      const res = await POST(makeRequest({ company_name: "A".repeat(101) }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toContain("100文字");
+    });
+
+    it("デフォルト値で有効なリクエスト（空ボディ）を処理できる", async () => {
+      const res = await POST(makeRequest({}));
+      // バリデーションは通る（デフォルト値が使われる）
+      expect(res.status).not.toBe(400);
+    });
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は 401 を返す", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: null,
+      });
+
+      const res = await POST(makeRequest({}));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("API キー", () => {
+    it("ANTHROPIC_API_KEY が未設定の場合は 500 を返す", async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+
+      const res = await POST(makeRequest({}));
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toContain("ANTHROPIC_API_KEY");
+    });
+  });
+
+  describe("利用制限", () => {
+    it("利用上限に達している場合は 403 を返す", async () => {
+      mockCheckUsageLimit.mockResolvedValue({
+        allowed: false,
+        plan: "free",
+        used: 3,
+        limit: 3,
+      });
+
+      const res = await POST(makeRequest({}));
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.code).toBe("USAGE_LIMIT_EXCEEDED");
+      expect(json.upgrade_url).toBe("/pricing");
+    });
+  });
+
+  describe("正常系", () => {
+    it("セッション作成に成功すると id と firstQuestion を返す", async () => {
+      const res = await POST(makeRequest({}));
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.id).toBe("mock-interview-id-1");
+      expect(json.firstQuestion).toBeTruthy();
+    });
+
+    it("Claude API に正しいモデルが使用される", async () => {
+      mockGetModelForPlan.mockReturnValue("claude-haiku-4-5-20251001");
+
+      await POST(makeRequest({}));
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "claude-haiku-4-5-20251001",
+        })
+      );
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    it("Claude API がエラーの場合は 500 を返す", async () => {
+      mockMessagesCreate.mockRejectedValue(new Error("API error"));
+
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const res = await POST(makeRequest({}));
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/subscription/route.test.ts
+++ b/src/app/api/subscription/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ============================================================
+// モック設定
+// ============================================================
+
+const mockUser = { id: "user-123", email: "test@example.com" };
+
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockImplementation(async () => mockSupabase),
+}));
+
+const mockGetUserSubscription = vi.fn();
+const mockGetRemainingUsage = vi.fn();
+
+vi.mock("@/lib/subscription", () => ({
+  getUserSubscription: (...args: unknown[]) => mockGetUserSubscription(...args),
+  getRemainingUsage: (...args: unknown[]) => mockGetRemainingUsage(...args),
+}));
+
+import { GET } from "./route";
+
+// ============================================================
+// テスト
+// ============================================================
+
+describe("GET /api/subscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は 401 を返す", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: null,
+      });
+
+      const res = await GET();
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.code).toBe("unauthorized");
+    });
+  });
+
+  describe("正常系", () => {
+    it("サブスクリプション情報と利用状況を返す", async () => {
+      const subscription = {
+        plan: "free",
+        status: "active",
+        stripeCustomerId: null,
+        currentPeriodEnd: null,
+        cancelAt: null,
+        canceledAt: null,
+      };
+
+      const usage = {
+        plan: "free",
+        used: 1,
+        limit: 3,
+        remaining: 2,
+      };
+
+      mockGetUserSubscription.mockResolvedValue(subscription);
+      mockGetRemainingUsage.mockResolvedValue(usage);
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json.subscription).toEqual(subscription);
+      expect(json.usage).toEqual(usage);
+    });
+
+    it("Cache-Control ヘッダーが設定されている", async () => {
+      mockGetUserSubscription.mockResolvedValue({
+        plan: "free",
+        status: "active",
+        stripeCustomerId: null,
+        currentPeriodEnd: null,
+        cancelAt: null,
+        canceledAt: null,
+      });
+      mockGetRemainingUsage.mockResolvedValue({
+        plan: "free",
+        used: 0,
+        limit: 3,
+        remaining: 3,
+      });
+
+      const res = await GET();
+      expect(res.headers.get("Cache-Control")).toContain("private");
+      expect(res.headers.get("Cache-Control")).toContain("max-age=60");
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    it("内部エラー発生時は 500 を返す", async () => {
+      mockGetUserSubscription.mockRejectedValue(new Error("DB error"));
+
+      // console.error のスパイ
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+
+      const json = await res.json();
+      expect(json.error).toContain("サブスクリプション");
+    });
+  });
+});

--- a/src/components/ui/password-strength.test.ts
+++ b/src/components/ui/password-strength.test.ts
@@ -1,0 +1,178 @@
+/**
+ * PasswordStrength コンポーネントのロジック部分をテスト
+ *
+ * evaluateCriteria / calculateStrength はコンポーネントファイル内で定義されているため、
+ * 同じロジックをテスト側で再現してテストする。
+ * （React Testing Library は未導入のため、ロジック検証に特化）
+ */
+import { describe, it, expect } from "vitest";
+
+// ============================================================
+// コンポーネント内のロジックを抽出（テスト用）
+// ============================================================
+
+interface StrengthCriteria {
+  label: string;
+  met: boolean;
+}
+
+type StrengthLevel = 0 | 1 | 2 | 3;
+
+interface StrengthInfo {
+  level: StrengthLevel;
+  label: string;
+}
+
+function evaluateCriteria(password: string): StrengthCriteria[] {
+  return [
+    { label: "8文字以上", met: password.length >= 8 },
+    { label: "英大文字を含む", met: /[A-Z]/.test(password) },
+    { label: "英小文字を含む", met: /[a-z]/.test(password) },
+    { label: "数字を含む", met: /[0-9]/.test(password) },
+    { label: "記号を含む", met: /[^A-Za-z0-9]/.test(password) },
+  ];
+}
+
+function calculateStrength(password: string): StrengthInfo {
+  if (password.length === 0) {
+    return { level: 0, label: "" };
+  }
+
+  const hasLower = /[a-z]/.test(password);
+  const hasUpper = /[A-Z]/.test(password);
+  const hasDigit = /[0-9]/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+  const isLong = password.length >= 12;
+
+  // 強い: 大文字+小文字+数字+記号 かつ 12文字以上
+  if (hasLower && hasUpper && hasDigit && hasSymbol && isLong) {
+    return { level: 3, label: "非常に強い" };
+  }
+
+  // 普通〜強い: 複数の文字種の組み合わせ
+  const typesCount = [hasLower, hasUpper, hasDigit, hasSymbol].filter(Boolean).length;
+
+  if (typesCount >= 3 && password.length >= 8) {
+    return { level: 2, label: "強い" };
+  }
+
+  if (typesCount >= 2 && password.length >= 8) {
+    return { level: 1, label: "普通" };
+  }
+
+  // 弱い: 8文字未満 or 1種類のみ
+  return { level: 0, label: "弱い" };
+}
+
+// ============================================================
+// テスト
+// ============================================================
+
+describe("password-strength ロジック", () => {
+  describe("evaluateCriteria", () => {
+    it("空パスワードでは全条件が false", () => {
+      const criteria = evaluateCriteria("");
+      expect(criteria.every((c) => !c.met)).toBe(true);
+    });
+
+    it("8文字以上の条件を判定できる", () => {
+      const short = evaluateCriteria("abc");
+      expect(short[0].met).toBe(false);
+
+      const long = evaluateCriteria("abcdefgh");
+      expect(long[0].met).toBe(true);
+    });
+
+    it("英大文字を含む条件を判定できる", () => {
+      expect(evaluateCriteria("abc")[1].met).toBe(false);
+      expect(evaluateCriteria("Abc")[1].met).toBe(true);
+    });
+
+    it("英小文字を含む条件を判定できる", () => {
+      expect(evaluateCriteria("ABC")[2].met).toBe(false);
+      expect(evaluateCriteria("ABc")[2].met).toBe(true);
+    });
+
+    it("数字を含む条件を判定できる", () => {
+      expect(evaluateCriteria("abc")[3].met).toBe(false);
+      expect(evaluateCriteria("abc1")[3].met).toBe(true);
+    });
+
+    it("記号を含む条件を判定できる", () => {
+      expect(evaluateCriteria("abc123")[4].met).toBe(false);
+      expect(evaluateCriteria("abc!")[4].met).toBe(true);
+    });
+
+    it("全条件を満たすパスワードでは全て true", () => {
+      const criteria = evaluateCriteria("Abc12345!");
+      expect(criteria.every((c) => c.met)).toBe(true);
+    });
+
+    it("5つの条件が返される", () => {
+      expect(evaluateCriteria("test").length).toBe(5);
+    });
+  });
+
+  describe("calculateStrength", () => {
+    it("空パスワードはレベル 0、ラベル空文字", () => {
+      const result = calculateStrength("");
+      expect(result.level).toBe(0);
+      expect(result.label).toBe("");
+    });
+
+    it("短い1種類のパスワードは '弱い'（レベル 0）", () => {
+      const result = calculateStrength("abc");
+      expect(result.level).toBe(0);
+      expect(result.label).toBe("弱い");
+    });
+
+    it("8文字以上でも1種類のみは '弱い'（レベル 0）", () => {
+      const result = calculateStrength("abcdefgh");
+      expect(result.level).toBe(0);
+      expect(result.label).toBe("弱い");
+    });
+
+    it("8文字以上 + 2種類で '普通'（レベル 1）", () => {
+      const result = calculateStrength("abcdefg1");
+      expect(result.level).toBe(1);
+      expect(result.label).toBe("普通");
+    });
+
+    it("8文字以上 + 3種類で '強い'（レベル 2）", () => {
+      const result = calculateStrength("Abcdefg1");
+      expect(result.level).toBe(2);
+      expect(result.label).toBe("強い");
+    });
+
+    it("12文字以上 + 全4種類で '非常に強い'（レベル 3）", () => {
+      const result = calculateStrength("Abcdefg123!!");
+      expect(result.level).toBe(3);
+      expect(result.label).toBe("非常に強い");
+    });
+
+    it("11文字 + 全4種類は '非常に強い' にはならない", () => {
+      const result = calculateStrength("Abcdefg12!");
+      // 10文字・4種類 → level 2 (強い)
+      expect(result.level).toBe(2);
+      expect(result.label).toBe("強い");
+    });
+
+    it("数字のみ8文字は '弱い'", () => {
+      const result = calculateStrength("12345678");
+      expect(result.level).toBe(0);
+      expect(result.label).toBe("弱い");
+    });
+
+    it("大文字小文字のみ8文字は '普通'", () => {
+      const result = calculateStrength("ABCDabcd");
+      expect(result.level).toBe(1);
+      expect(result.label).toBe("普通");
+    });
+
+    it("記号を含む短いパスワードは '弱い'", () => {
+      const result = calculateStrength("a!");
+      expect(result.level).toBe(0);
+      expect(result.label).toBe("弱い");
+    });
+  });
+});

--- a/src/lib/api/error-response.test.ts
+++ b/src/lib/api/error-response.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  apiError,
+  badRequest,
+  unauthorized,
+  forbidden,
+  notFound,
+  conflict,
+  gone,
+  serverError,
+  serverErrorWithLog,
+} from "./error-response";
+
+describe("error-response", () => {
+  describe("apiError", () => {
+    it("指定したメッセージ・コード・ステータスでレスポンスを返す", async () => {
+      const res = apiError("テストエラー", "test_error", 400);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe("テストエラー");
+      expect(body.code).toBe("test_error");
+    });
+
+    it("action を指定しない場合はステータスに応じたデフォルトが設定される", async () => {
+      const res = apiError("テスト", "test", 401);
+      const body = await res.json();
+
+      expect(body.action).toBe("ログインし直してください");
+    });
+
+    it("action を明示的に指定した場合はそれが使われる", async () => {
+      const res = apiError("テスト", "test", 401, "カスタムアクション");
+      const body = await res.json();
+
+      expect(body.action).toBe("カスタムアクション");
+    });
+  });
+
+  describe("デフォルト action のステータスコード別マッピング", () => {
+    const cases: [number, string][] = [
+      [401, "ログインし直してください"],
+      [403, "アクセス権限を確認してください"],
+      [404, "URLやIDが正しいか確認してください"],
+      [409, "内容を確認して再度お試しください"],
+      [410, "新しいリンクを発行してください"],
+      [429, "しばらく待ってから再度お試しください"],
+      [500, "しばらくしてから再度お試しください。問題が続く場合はお問い合わせください"],
+      [502, "しばらくしてから再度お試しください。問題が続く場合はお問い合わせください"],
+      [400, "入力内容を確認して再度お試しください"],
+      [422, "入力内容を確認して再度お試しください"],
+    ];
+
+    it.each(cases)("ステータス %i → '%s'", async (status, expectedAction) => {
+      const res = apiError("msg", "code", status);
+      const body = await res.json();
+      expect(body.action).toBe(expectedAction);
+    });
+  });
+
+  describe("badRequest", () => {
+    it("400 ステータスと bad_request コードを返す", async () => {
+      const res = badRequest("入力が不正です");
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.code).toBe("bad_request");
+      expect(body.error).toBe("入力が不正です");
+    });
+
+    it("カスタム action を指定できる", async () => {
+      const res = badRequest("不正", "やり直してください");
+      const body = await res.json();
+
+      expect(body.action).toBe("やり直してください");
+    });
+  });
+
+  describe("unauthorized", () => {
+    it("401 ステータスとデフォルトメッセージを返す", async () => {
+      const res = unauthorized();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.code).toBe("unauthorized");
+      expect(body.error).toBe("認証が必要です。ログインしてからお試しください。");
+    });
+
+    it("カスタムメッセージを指定できる", async () => {
+      const res = unauthorized("セッション切れ");
+      const body = await res.json();
+
+      expect(body.error).toBe("セッション切れ");
+    });
+  });
+
+  describe("forbidden", () => {
+    it("403 ステータスと forbidden コードを返す", async () => {
+      const res = forbidden("アクセス拒否");
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.code).toBe("forbidden");
+      expect(body.error).toBe("アクセス拒否");
+    });
+  });
+
+  describe("notFound", () => {
+    it("404 ステータスと not_found コードを返す", async () => {
+      const res = notFound("データが見つかりません");
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.code).toBe("not_found");
+      expect(body.error).toBe("データが見つかりません");
+    });
+  });
+
+  describe("conflict", () => {
+    it("409 ステータスと conflict コードを返す", async () => {
+      const res = conflict("重複しています");
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("conflict");
+    });
+  });
+
+  describe("gone", () => {
+    it("410 ステータスと gone コードを返す", async () => {
+      const res = gone("リソースは削除されました");
+      const body = await res.json();
+
+      expect(res.status).toBe(410);
+      expect(body.code).toBe("gone");
+    });
+  });
+
+  describe("serverError", () => {
+    it("500 ステータスとデフォルトメッセージを返す", async () => {
+      const res = serverError();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.code).toBe("server_error");
+      expect(body.error).toContain("こちらの問題でエラーが発生しました");
+    });
+
+    it("カスタムメッセージを指定できる", async () => {
+      const res = serverError("カスタムサーバーエラー");
+      const body = await res.json();
+
+      expect(body.error).toBe("カスタムサーバーエラー");
+    });
+  });
+
+  describe("serverErrorWithLog", () => {
+    beforeEach(() => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("500 レスポンスを返しつつ、内部エラーをログに出力する", async () => {
+      const internalError = new Error("DB connection failed");
+      const res = serverErrorWithLog("サーバーエラーです", internalError, "DB");
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe("サーバーエラーです");
+      // 内部エラーの詳細がクライアントに漏れていないこと
+      expect(body.error).not.toContain("DB connection failed");
+      // ログには出力されていること
+      expect(console.error).toHaveBeenCalledWith(
+        "[serverError] DB: DB connection failed"
+      );
+    });
+
+    it("Error 以外の値も文字列化してログ出力する", async () => {
+      const res = serverErrorWithLog("エラー", "string error");
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(console.error).toHaveBeenCalledWith(
+        "[serverError] string error"
+      );
+    });
+
+    it("context が未指定の場合はコロンなしでログ出力する", async () => {
+      serverErrorWithLog("エラー", new Error("fail"));
+
+      expect(console.error).toHaveBeenCalledWith(
+        "[serverError] fail"
+      );
+    });
+  });
+});

--- a/src/lib/auth/error-messages.test.ts
+++ b/src/lib/auth/error-messages.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  AUTH_ERROR_MESSAGES,
+  DEFAULT_ERROR,
+  getAuthErrorInfo,
+} from "./error-messages";
+import type { AuthErrorInfo } from "./error-messages";
+
+describe("auth/error-messages", () => {
+  describe("AUTH_ERROR_MESSAGES", () => {
+    it("必要なエラーコードが全て定義されている", () => {
+      const requiredCodes = [
+        "auth_error",
+        "config_error",
+        "email_expired",
+        "code_used",
+        "recovery_expired",
+        "email_confirm_failed",
+      ];
+
+      for (const code of requiredCodes) {
+        expect(AUTH_ERROR_MESSAGES[code]).toBeDefined();
+        expect(AUTH_ERROR_MESSAGES[code].message).toBeTruthy();
+      }
+    });
+
+    it("action が定義されているエントリには label と href が含まれる", () => {
+      for (const [code, info] of Object.entries(AUTH_ERROR_MESSAGES)) {
+        if (info.action) {
+          expect(info.action.label).toBeTruthy();
+          expect(info.action.href).toBeTruthy();
+          expect(info.action.href).toMatch(/^\//); // 相対パスであること
+        }
+      }
+    });
+
+    it("email_expired にはサインアップへのアクションがある", () => {
+      const info = AUTH_ERROR_MESSAGES.email_expired;
+      expect(info.action).toBeDefined();
+      expect(info.action!.label).toBe("サインアップ");
+      expect(info.action!.href).toBe("/signup");
+    });
+
+    it("recovery_expired にはパスワードリセットへのアクションがある", () => {
+      const info = AUTH_ERROR_MESSAGES.recovery_expired;
+      expect(info.action).toBeDefined();
+      expect(info.action!.label).toBe("パスワードリセット");
+      expect(info.action!.href).toBe("/reset-password");
+    });
+  });
+
+  describe("DEFAULT_ERROR", () => {
+    it("汎用のエラーメッセージが定義されている", () => {
+      expect(DEFAULT_ERROR.message).toBeTruthy();
+      expect(DEFAULT_ERROR.message).toContain("認証");
+    });
+  });
+
+  describe("getAuthErrorInfo", () => {
+    it("null を渡した場合は null を返す", () => {
+      expect(getAuthErrorInfo(null)).toBeNull();
+    });
+
+    it("空文字を渡した場合は null を返す（falsy）", () => {
+      expect(getAuthErrorInfo("")).toBeNull();
+    });
+
+    it("既知のエラーコードは対応する AuthErrorInfo を返す", () => {
+      const result = getAuthErrorInfo("auth_error");
+      expect(result).not.toBeNull();
+      expect(result!.message).toBe(AUTH_ERROR_MESSAGES.auth_error.message);
+    });
+
+    it("未知のエラーコードは DEFAULT_ERROR を返す（XSS 対策）", () => {
+      const result = getAuthErrorInfo("<script>alert('xss')</script>");
+      expect(result).toBe(DEFAULT_ERROR);
+    });
+
+    it("SQLインジェクション風の文字列も DEFAULT_ERROR を返す", () => {
+      const result = getAuthErrorInfo("'; DROP TABLE users; --");
+      expect(result).toBe(DEFAULT_ERROR);
+    });
+
+    it("各定義済みコードに対して正しい AuthErrorInfo を返す", () => {
+      for (const [code, expected] of Object.entries(AUTH_ERROR_MESSAGES)) {
+        const result = getAuthErrorInfo(code);
+        expect(result).toEqual(expected);
+      }
+    });
+  });
+});

--- a/src/lib/auth/redirect.test.ts
+++ b/src/lib/auth/redirect.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// next/navigation と next/headers のモック
+const mockRedirect = vi.fn();
+const mockHeaders = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    mockRedirect(url);
+    // Next.js の redirect() は例外をスローして制御フローを中断する
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: () => mockHeaders(),
+}));
+
+// モック設定後にインポート
+import { redirectToLogin } from "./redirect";
+
+describe("auth/redirect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ヘッダーからパスが取得できない場合は /login?expired=true にリダイレクトする", async () => {
+    mockHeaders.mockResolvedValue({
+      get: () => null,
+    });
+
+    await expect(redirectToLogin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith("/login?expired=true");
+  });
+
+  it("x-url ヘッダーからパスを取得してリダイレクト先に含める", async () => {
+    mockHeaders.mockResolvedValue({
+      get: (name: string) => {
+        if (name === "x-url") return "http://localhost:3000/dashboard?tab=history";
+        return null;
+      },
+    });
+
+    await expect(redirectToLogin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "/login?expired=true&redirect=%2Fdashboard%3Ftab%3Dhistory"
+    );
+  });
+
+  it("x-invoke-path ヘッダーをフォールバックとして使用する", async () => {
+    mockHeaders.mockResolvedValue({
+      get: (name: string) => {
+        if (name === "x-invoke-path") return "/settings";
+        return null;
+      },
+    });
+
+    await expect(redirectToLogin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "/login?expired=true&redirect=%2Fsettings"
+    );
+  });
+
+  it("referer ヘッダーをフォールバックとして使用する", async () => {
+    mockHeaders.mockResolvedValue({
+      get: (name: string) => {
+        if (name === "referer") return "http://localhost:3000/interviews/123";
+        return null;
+      },
+    });
+
+    await expect(redirectToLogin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "/login?expired=true&redirect=%2Finterviews%2F123"
+    );
+  });
+
+  it("現在のパスが /login の場合は redirect パラメータを付けない", async () => {
+    mockHeaders.mockResolvedValue({
+      get: (name: string) => {
+        if (name === "x-url") return "http://localhost:3000/login";
+        return null;
+      },
+    });
+
+    await expect(redirectToLogin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith("/login?expired=true");
+  });
+
+  it("headers() が例外をスローしても /login?expired=true にリダイレクトする", async () => {
+    mockHeaders.mockRejectedValue(new Error("headers not available"));
+
+    await expect(redirectToLogin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith("/login?expired=true");
+  });
+});

--- a/src/lib/questions/data.test.ts
+++ b/src/lib/questions/data.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { questions } from "./data";
+import type { Question, Industry, Round, QuestionType, Difficulty } from "./types";
+import { INDUSTRIES, ROUNDS, QUESTION_TYPES } from "./types";
+
+const VALID_DIFFICULTIES: Difficulty[] = ["easy", "normal", "hard"];
+
+describe("questions/data", () => {
+  describe("データ量", () => {
+    it("質問が1件以上存在する", () => {
+      expect(questions.length).toBeGreaterThan(0);
+    });
+
+    it("50問以上の質問が含まれている", () => {
+      expect(questions.length).toBeGreaterThanOrEqual(50);
+    });
+  });
+
+  describe("ID の一意性", () => {
+    it("すべての質問 ID が一意である", () => {
+      const ids = questions.map((q) => q.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it("ID は 'q' + 3桁の数字形式（q001, q002, ...）である", () => {
+      for (const q of questions) {
+        expect(q.id).toMatch(/^q\d{3}$/);
+      }
+    });
+  });
+
+  describe("必須フィールドの存在", () => {
+    it("すべての質問に question テキストが存在する", () => {
+      for (const q of questions) {
+        expect(q.question).toBeTruthy();
+        expect(typeof q.question).toBe("string");
+        expect(q.question.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it("すべての質問に industry 配列が存在し、空でない", () => {
+      for (const q of questions) {
+        expect(Array.isArray(q.industry)).toBe(true);
+        expect(q.industry.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("すべての質問に round 配列が存在し、空でない", () => {
+      for (const q of questions) {
+        expect(Array.isArray(q.round)).toBe(true);
+        expect(q.round.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("すべての質問に type が存在する", () => {
+      for (const q of questions) {
+        expect(q.type).toBeTruthy();
+      }
+    });
+
+    it("すべての質問に difficulty が存在する", () => {
+      for (const q of questions) {
+        expect(q.difficulty).toBeTruthy();
+      }
+    });
+
+    it("すべての質問に tips 配列が存在し、1件以上ある", () => {
+      for (const q of questions) {
+        expect(Array.isArray(q.tips)).toBe(true);
+        expect(q.tips.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("すべての質問に exampleAnswer が存在する", () => {
+      for (const q of questions) {
+        expect(q.exampleAnswer).toBeTruthy();
+        expect(q.exampleAnswer.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it("すべての質問に keywords 配列が存在し、1件以上ある", () => {
+      for (const q of questions) {
+        expect(Array.isArray(q.keywords)).toBe(true);
+        expect(q.keywords.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("値の妥当性", () => {
+    it("industry の値は全て定義された Industry 型に含まれる", () => {
+      for (const q of questions) {
+        for (const ind of q.industry) {
+          expect(INDUSTRIES).toContain(ind);
+        }
+      }
+    });
+
+    it("round の値は全て定義された Round 型に含まれる", () => {
+      for (const q of questions) {
+        for (const r of q.round) {
+          expect(ROUNDS).toContain(r);
+        }
+      }
+    });
+
+    it("type の値は全て定義された QuestionType 型に含まれる", () => {
+      for (const q of questions) {
+        expect(QUESTION_TYPES).toContain(q.type);
+      }
+    });
+
+    it("difficulty の値は easy/normal/hard のいずれかである", () => {
+      for (const q of questions) {
+        expect(VALID_DIFFICULTIES).toContain(q.difficulty);
+      }
+    });
+  });
+
+  describe("カテゴリの網羅性", () => {
+    it("すべての QuestionType に対して少なくとも1問が存在する", () => {
+      for (const type of QUESTION_TYPES) {
+        const found = questions.filter((q) => q.type === type);
+        expect(found.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("すべての Difficulty レベルに対して少なくとも1問が存在する", () => {
+      for (const diff of VALID_DIFFICULTIES) {
+        const found = questions.filter((q) => q.difficulty === diff);
+        expect(found.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("データ品質", () => {
+    it("模範解答は50文字以上である", () => {
+      for (const q of questions) {
+        expect(q.exampleAnswer.length).toBeGreaterThanOrEqual(50);
+      }
+    });
+
+    it("質問テキストは末尾が '？' または '?' で終わるか、句点で終わる", () => {
+      for (const q of questions) {
+        const lastChar = q.question.slice(-1);
+        const validEndings = ["？", "?", "。", "」", "）", ")"];
+        expect(validEndings).toContain(lastChar);
+      }
+    });
+  });
+});

--- a/src/lib/subscription.test.ts
+++ b/src/lib/subscription.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ============================================================
+// モック設定（vi.hoisted を使ってホイスティング対応）
+// ============================================================
+
+const { mockSupabase } = vi.hoisted(() => {
+  const mockSupabase = {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+  };
+  return { mockSupabase };
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue(mockSupabase),
+}));
+
+import { getModelForPlan, checkUsageLimit, getRemainingUsage } from "./subscription";
+
+// ============================================================
+// ヘルパー: テーブル別にモッククエリビルダーを返す
+// ============================================================
+
+function setupFromMock(tableHandlers: Record<string, unknown>) {
+  mockSupabase.from.mockImplementation((table: string) => {
+    return tableHandlers[table] ?? {};
+  });
+}
+
+/** subscriptions テーブル用のモッククエリビルダー */
+function createSubsBuilder(planData: Record<string, unknown> | null) {
+  const data = planData ? [planData] : [];
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue({ data, error: null }),
+  };
+}
+
+/** feedbacks テーブル用のモッククエリビルダー（count のみ） */
+function createFeedbacksBuilder(count: number) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockResolvedValue({ data: null, error: null, count }),
+  };
+}
+
+// ============================================================
+// テスト
+// ============================================================
+
+describe("subscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getModelForPlan", () => {
+    it("free プランは haiku モデルを返す", () => {
+      expect(getModelForPlan("free")).toContain("haiku");
+    });
+
+    it("pro プランは sonnet モデルを返す", () => {
+      expect(getModelForPlan("pro")).toContain("sonnet");
+    });
+
+    it("premium プランは sonnet モデルを返す", () => {
+      expect(getModelForPlan("premium")).toContain("sonnet");
+    });
+
+    it("enterprise プランは premium と同じ sonnet モデルを返す", () => {
+      expect(getModelForPlan("enterprise")).toContain("sonnet");
+    });
+  });
+
+  describe("checkUsageLimit", () => {
+    it("無料プランで利用回数が上限未満の場合は allowed: true を返す", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder({
+          plan: "free", status: "active",
+          stripe_customer_id: null, current_period_end: null,
+          cancel_at: null, canceled_at: null,
+        }),
+        feedbacks: createFeedbacksBuilder(1),
+      });
+
+      const result = await checkUsageLimit("test-user-id");
+
+      expect(result.allowed).toBe(true);
+      expect(result.plan).toBe("free");
+      expect(result.used).toBe(1);
+      expect(result.limit).toBe(3);
+    });
+
+    it("無料プランで利用回数が上限に達した場合は allowed: false を返す", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder({
+          plan: "free", status: "active",
+          stripe_customer_id: null, current_period_end: null,
+          cancel_at: null, canceled_at: null,
+        }),
+        feedbacks: createFeedbacksBuilder(3),
+      });
+
+      const result = await checkUsageLimit("test-user-id");
+
+      expect(result.allowed).toBe(false);
+      expect(result.used).toBe(3);
+      expect(result.limit).toBe(3);
+    });
+
+    it("pro プランで利用回数が上限未満の場合は allowed: true を返す", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder({
+          plan: "pro", status: "active",
+          stripe_customer_id: "cus_123", current_period_end: "2026-04-01",
+          cancel_at: null, canceled_at: null,
+        }),
+        feedbacks: createFeedbacksBuilder(15),
+      });
+
+      const result = await checkUsageLimit("test-user-id");
+
+      expect(result.allowed).toBe(true);
+      expect(result.plan).toBe("pro");
+      expect(result.used).toBe(15);
+      expect(result.limit).toBe(30);
+    });
+
+    it("premium プランは常に allowed: true（無制限）を返す", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder({
+          plan: "premium", status: "active",
+          stripe_customer_id: "cus_456", current_period_end: "2026-04-01",
+          cancel_at: null, canceled_at: null,
+        }),
+        feedbacks: createFeedbacksBuilder(100),
+      });
+
+      const result = await checkUsageLimit("test-user-id");
+
+      expect(result.allowed).toBe(true);
+      expect(result.plan).toBe("premium");
+      expect(result.limit).toBeNull();
+    });
+
+    it("サブスクリプションがない場合は free プランとして扱う", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder(null),
+        feedbacks: createFeedbacksBuilder(0),
+      });
+
+      const result = await checkUsageLimit("test-user-id");
+
+      expect(result.plan).toBe("free");
+      expect(result.limit).toBe(3);
+    });
+  });
+
+  describe("getRemainingUsage", () => {
+    it("無料プランで2回使用済みの場合、remaining: 1 を返す", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder({
+          plan: "free", status: "active",
+          stripe_customer_id: null, current_period_end: null,
+          cancel_at: null, canceled_at: null,
+        }),
+        feedbacks: createFeedbacksBuilder(2),
+      });
+
+      const result = await getRemainingUsage("test-user-id");
+
+      expect(result.plan).toBe("free");
+      expect(result.used).toBe(2);
+      expect(result.limit).toBe(3);
+      expect(result.remaining).toBe(1);
+    });
+
+    it("premium プランでは remaining: null（無制限）を返す", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder({
+          plan: "premium", status: "active",
+          stripe_customer_id: "cus_123", current_period_end: "2026-04-01",
+          cancel_at: null, canceled_at: null,
+        }),
+        feedbacks: createFeedbacksBuilder(50),
+      });
+
+      const result = await getRemainingUsage("test-user-id");
+
+      expect(result.plan).toBe("premium");
+      expect(result.limit).toBeNull();
+      expect(result.remaining).toBeNull();
+    });
+
+    it("利用回数が上限を超えても remaining は 0 以上を返す", async () => {
+      setupFromMock({
+        subscriptions: createSubsBuilder({
+          plan: "free", status: "active",
+          stripe_customer_id: null, current_period_end: null,
+          cancel_at: null, canceled_at: null,
+        }),
+        feedbacks: createFeedbacksBuilder(5),
+      });
+
+      const result = await getRemainingUsage("test-user-id");
+
+      expect(result.remaining).toBe(0);
+    });
+  });
+});

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  createMockQueryBuilder,
+  createMockSupabaseClient,
+  createUnauthenticatedMockSupabaseClient,
+  createPostRequest,
+  createGetRequest,
+  parseJsonResponse,
+} from "./helpers";
+
+describe("test/helpers", () => {
+  describe("createMockQueryBuilder", () => {
+    it("チェイン可能なクエリビルダーを返す", () => {
+      const builder = createMockQueryBuilder();
+
+      // メソッドチェインが可能であること
+      const chain = builder.select("*");
+      expect(chain).toBe(builder);
+
+      const chain2 = builder.eq("id", "1");
+      expect(chain2).toBe(builder);
+    });
+
+    it("single() は指定したデータを返す", async () => {
+      const builder = createMockQueryBuilder({ id: "1", name: "test" });
+      const result = await builder.single();
+
+      expect(result.data).toEqual({ id: "1", name: "test" });
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("createMockSupabaseClient", () => {
+    it("認証済みのモッククライアントを返す", async () => {
+      const client = createMockSupabaseClient();
+      const { data } = await client.auth.getUser();
+
+      expect(data.user).toBeDefined();
+      expect(data.user.id).toBe("test-user-id");
+    });
+
+    it("カスタムユーザーを指定できる", async () => {
+      const client = createMockSupabaseClient({
+        user: { id: "custom-id", email: "custom@test.com" },
+      });
+      const { data } = await client.auth.getUser();
+
+      expect(data.user.id).toBe("custom-id");
+    });
+  });
+
+  describe("createUnauthenticatedMockSupabaseClient", () => {
+    it("未認証のモッククライアントを返す", async () => {
+      const client = createUnauthenticatedMockSupabaseClient();
+      const { data } = await client.auth.getUser();
+
+      expect(data.user).toBeNull();
+    });
+  });
+
+  describe("createPostRequest", () => {
+    it("JSON body 付きの POST リクエストを生成する", async () => {
+      const req = createPostRequest({ key: "value" });
+
+      expect(req.method).toBe("POST");
+      expect(req.headers.get("Content-Type")).toBe("application/json");
+
+      const body = await req.json();
+      expect(body.key).toBe("value");
+    });
+  });
+
+  describe("createGetRequest", () => {
+    it("GET リクエストを生成する", () => {
+      const req = createGetRequest("http://localhost:3000/api/test");
+      expect(req.method).toBe("GET");
+    });
+  });
+
+  describe("parseJsonResponse", () => {
+    it("Response からステータスとボディをパースする", async () => {
+      const response = new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+      });
+
+      const result = await parseJsonResponse(response);
+      expect(result.status).toBe(404);
+      expect(result.body.error).toBe("not found");
+    });
+  });
+});

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,0 +1,132 @@
+/**
+ * テストヘルパー
+ * Supabase / Claude API のモックユーティリティと
+ * テスト用のリクエスト生成関数を集約
+ */
+import { vi } from "vitest";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/** Supabase クエリビルダーのモック型 */
+export interface MockQueryBuilder {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  gte: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+}
+
+/** Supabase クライアントのモック型 */
+export interface MockSupabaseClient {
+  auth: {
+    getUser: ReturnType<typeof vi.fn>;
+  };
+  from: ReturnType<typeof vi.fn>;
+}
+
+// ============================================================
+// Supabase モック
+// ============================================================
+
+/**
+ * チェイン可能な Supabase クエリビルダーのモックを生成する。
+ * 各メソッドは自分自身を返すので .from("x").select("*").eq("id", 1).single() のようにチェインできる。
+ */
+export function createMockQueryBuilder(resolvedData: unknown = null, resolvedError: unknown = null): MockQueryBuilder {
+  const builder: MockQueryBuilder = {} as MockQueryBuilder;
+
+  const result = { data: resolvedData, error: resolvedError, count: null };
+
+  const chainable = vi.fn().mockReturnValue(builder);
+
+  builder.select = vi.fn().mockReturnValue(builder);
+  builder.insert = vi.fn().mockReturnValue(builder);
+  builder.update = vi.fn().mockReturnValue(builder);
+  builder.delete = vi.fn().mockReturnValue(builder);
+  builder.eq = vi.fn().mockReturnValue(builder);
+  builder.in = vi.fn().mockReturnValue(builder);
+  builder.gte = vi.fn().mockReturnValue(builder);
+  builder.order = vi.fn().mockReturnValue(builder);
+  builder.single = vi.fn().mockResolvedValue(result);
+
+  // select の終端（.single() なし）でも結果を返せるように
+  // Promise-like にする
+  Object.assign(builder.select, {
+    then: (resolve: (value: unknown) => void) => resolve(result),
+  });
+
+  return builder;
+}
+
+/**
+ * 認証済みの Supabase クライアントモックを生成する。
+ */
+export function createMockSupabaseClient(options?: {
+  user?: { id: string; email?: string } | null;
+}): MockSupabaseClient {
+  const user = options?.user === undefined
+    ? { id: "test-user-id", email: "test@example.com" }
+    : options.user;
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error: null,
+      }),
+    },
+    from: vi.fn().mockReturnValue(createMockQueryBuilder()),
+  };
+}
+
+/**
+ * 未認証の Supabase クライアントモックを生成する。
+ */
+export function createUnauthenticatedMockSupabaseClient(): MockSupabaseClient {
+  return createMockSupabaseClient({ user: null });
+}
+
+// ============================================================
+// リクエスト生成
+// ============================================================
+
+/**
+ * POST リクエストを生成する（JSON body 付き）。
+ */
+export function createPostRequest(body: unknown, url = "http://localhost:3000/api/test"): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * GET リクエストを生成する。
+ */
+export function createGetRequest(url = "http://localhost:3000/api/test"): Request {
+  return new Request(url, {
+    method: "GET",
+  });
+}
+
+// ============================================================
+// レスポンスヘルパー
+// ============================================================
+
+/**
+ * NextResponse の JSON ボディをパースして返す。
+ */
+export async function parseJsonResponse(response: Response): Promise<{ status: number; body: Record<string, unknown> }> {
+  const body = await response.json();
+  return {
+    status: response.status,
+    body,
+  };
+}


### PR DESCRIPTION
## Summary
- API ルート（interviews, analyze, subscription, mock-interview）のユニットテストを追加
- ユーティリティ関数（error-response, auth/error-messages, auth/redirect, subscription, questions/data）のテストを追加
- コンポーネントロジック（password-strength）のテストを追加
- テストヘルパー（Supabaseモック、リクエスト生成等）を `src/test/helpers.ts` に集約

## 詳細
| テストファイル | テスト数 | カバー範囲 |
|---|---|---|
| `error-response.test.ts` | 26 | 全ステータスコード別のデフォルトaction、各エラー関数、ログ出力 |
| `error-messages.test.ts` | 11 | エラーコードマッピング、XSS対策（未知コード→DEFAULT_ERROR） |
| `redirect.test.ts` | 6 | ヘッダー別パス取得、/loginの除外、例外時のフォールバック |
| `data.test.ts` | 20 | ID一意性、必須フィールド、値の妥当性、カテゴリ網羅性 |
| `subscription.test.ts` | 12 | getModelForPlan、checkUsageLimit、getRemainingUsage |
| `password-strength.test.ts` | 18 | 5条件判定、4段階強度算出 |
| `interviews/route.test.ts` | 11 | 認証、バリデーション（企業名/カテゴリ/ラウンド/日付/スクリプト）、正常系 |
| `subscription/route.test.ts` | 4 | 認証、正常系レスポンス、Cache-Control、500エラー |
| `mock-interview/route.test.ts` | 12 | バリデーション、認証、APIキー、利用制限、正常系、エラーハンドリング |
| `analyze/route.test.ts` | 7 | バリデーション、認証、APIキー、404、利用制限、正常系、エラー非漏洩 |
| `helpers.test.ts` | 8 | テストヘルパー自体のテスト |

**合計: 11ファイル、135テスト追加（既存3ファイル38テストと合わせて計173テスト）**

## Test plan
- [x] `npm run test` で全173テスト PASS
- [x] `npm run build` 成功
- [x] Supabase / Claude API は適切にモック
- [x] 内部エラー詳細がクライアントに漏れないことを検証

closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)