### PR TITLE
feat: #202 - 利用上限ナッジ — Free→Pro アップグレード導線強化

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,10 +6,12 @@ import { Button } from "@/components/ui/button";
 import { ExportButtons } from "@/components/export-buttons";
 import { createClient } from "@/lib/supabase/server";
 import { redirectToLogin } from "@/lib/auth/redirect";
+import { getRemainingUsage } from "@/lib/subscription";
 import type { InterviewCategory } from "@/types/database";
 import type { SortOption } from "@/components/interview-filter";
 import { InterviewListSection } from "@/components/dashboard/interview-list-section";
 import { InterviewListSkeleton } from "@/components/dashboard/interview-list-skeleton";
+import { UsageNudgeBanner } from "@/components/dashboard/usage-nudge-banner";
 import { WeeklySummarySection } from "@/components/dashboard/weekly-summary-section";
 import { WeeklySummarySkeleton } from "@/components/dashboard/weekly-summary-skeleton";
 
@@ -59,8 +61,19 @@ export default async function DashboardPage({
     ? (sortParam as SortOption)
     : "date_desc";
 
+  // 利用状況を取得（ナッジバナー用）
+  const usage = await getRemainingUsage(user.id);
+
   return (
     <div className="container mx-auto px-4 py-8">
+      {/* 利用上限ナッジバナー（Free プラン & 残り1回以下のみ表示） */}
+      <UsageNudgeBanner
+        plan={usage.plan}
+        remaining={usage.remaining}
+        limit={usage.limit}
+        used={usage.used}
+      />
+
       {/* ヘッダー（即座に表示） */}
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">面接履歴</h1>

--- a/src/app/interview/[id]/result/page.tsx
+++ b/src/app/interview/[id]/result/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { redirectToLogin } from "@/lib/auth/redirect";
 import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
+import { getUserSubscription } from "@/lib/subscription";
 import type { Database } from "@/types/supabase";
 import { ResultContent } from "./result-content";
 
@@ -87,6 +88,9 @@ export default async function ResultPage({
 
   const hasOtherInterviews = (otherCompletedCount ?? 0) > 0;
 
+  // ユーザーのサブスクリプション情報を取得（アップセルカード用）
+  const subscription = await getUserSubscription(user.id);
+
   // 原文テキストを取得（transcripts → interview.transcript の優先順）
   let rawTranscript: string | null = null;
   if (transcripts.length > 0) {
@@ -108,6 +112,7 @@ export default async function ResultPage({
       interviewTags={interviewTags}
       hasOtherInterviews={hasOtherInterviews}
       rawTranscript={rawTranscript}
+      currentPlan={subscription.plan}
     />
   );
 }

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -15,9 +15,10 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import type { Database } from "@/types/supabase";
 import type { Json } from "@/types/supabase";
-import type { CategoryScores } from "@/types/database";
+import type { CategoryScores, SubscriptionPlan } from "@/types/database";
 import { CATEGORY_LABELS } from "@/lib/constants";
 import { parseAnnotations } from "@/components/annotated-transcript";
+import { ProUpsellCard } from "@/components/pro-upsell-card";
 
 // 動的インポート: 初期表示に不要なインタラクティブコンポーネントを遅延ロード
 const AnnotatedTranscript = dynamic(
@@ -256,6 +257,7 @@ export function ResultContent({
   interviewTags = [],
   hasOtherInterviews = false,
   rawTranscript = null,
+  currentPlan = "free",
 }: {
   interview: Interview;
   transcripts: Transcript[];
@@ -263,6 +265,7 @@ export function ResultContent({
   interviewTags?: TagData[];
   hasOtherInterviews?: boolean;
   rawTranscript?: string | null;
+  currentPlan?: SubscriptionPlan;
 }) {
   const suggestions = feedback
     ? parseJsonArray<Suggestion>(feedback.suggestions)
@@ -685,6 +688,9 @@ export function ResultContent({
           </div>
         </TabsContent>
       </Tabs>
+
+      {/* Pro プランアップセルカード（Free プランのみ） */}
+      {feedback && <ProUpsellCard plan={currentPlan} />}
 
       {/* ダッシュボードへのリンク */}
       <div className="mt-8 text-center">

--- a/src/components/dashboard/usage-nudge-banner.tsx
+++ b/src/components/dashboard/usage-nudge-banner.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { ArrowRight, X, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { SubscriptionPlan } from "@/types/database";
+
+/** localStorage に保存する dismiss キー */
+const DISMISS_KEY = "usage_nudge_dismissed";
+
+/**
+ * 今月の dismiss キーを生成する。月が変わればリセットされる。
+ */
+function getMonthlyDismissKey(): string {
+  const now = new Date();
+  return `${DISMISS_KEY}_${now.getFullYear()}_${now.getMonth()}`;
+}
+
+interface UsageNudgeBannerProps {
+  plan: SubscriptionPlan;
+  remaining: number | null;
+  limit: number | null;
+  used: number;
+}
+
+/**
+ * 利用上限ナッジバナー
+ *
+ * - Free プランで残り1回: 黄色の注意バナー
+ * - Free プランで残り0回: 赤色の警告バナー
+ * - Pro/Premium/enterprise: 表示しない
+ * - 「今月は表示しない」で localStorage に保存
+ */
+export function UsageNudgeBanner({
+  plan,
+  remaining,
+  limit,
+  used,
+}: UsageNudgeBannerProps) {
+  const [dismissed, setDismissed] = useState(true); // 初期値は非表示（SSR対策）
+
+  useEffect(() => {
+    const key = getMonthlyDismissKey();
+    const stored = localStorage.getItem(key);
+    setDismissed(stored === "true");
+  }, []);
+
+  // Free プラン以外は表示しない
+  if (plan !== "free") return null;
+
+  // 上限なし or 残り2回以上は表示しない
+  if (remaining === null || limit === null) return null;
+  if (remaining > 1) return null;
+
+  // dismiss 済みなら表示しない
+  if (dismissed) return null;
+
+  const isExhausted = remaining === 0;
+
+  function handleDismiss() {
+    const key = getMonthlyDismissKey();
+    localStorage.setItem(key, "true");
+    setDismissed(true);
+  }
+
+  return (
+    <div
+      role="alert"
+      className={`relative mb-6 rounded-lg border p-4 ${
+        isExhausted
+          ? "border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/30"
+          : "border-yellow-200 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950/30"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <Sparkles
+          className={`mt-0.5 h-5 w-5 shrink-0 ${
+            isExhausted
+              ? "text-red-500 dark:text-red-400"
+              : "text-yellow-500 dark:text-yellow-400"
+          }`}
+        />
+
+        <div className="flex-1 min-w-0">
+          <p
+            className={`text-sm font-medium ${
+              isExhausted
+                ? "text-red-800 dark:text-red-200"
+                : "text-yellow-800 dark:text-yellow-200"
+            }`}
+          >
+            {isExhausted
+              ? "今月の無料枠を使い切りました"
+              : `今月の残り利用回数: ${remaining}回（${used}/${limit}回使用済み）`}
+          </p>
+          <p
+            className={`mt-1 text-sm ${
+              isExhausted
+                ? "text-red-700 dark:text-red-300"
+                : "text-yellow-700 dark:text-yellow-300"
+            }`}
+          >
+            {isExhausted
+              ? "Pro プランにアップグレードすると、月30回まで分析できます。"
+              : "Pro プランなら月30回まで。もっと面接対策を進めませんか？"}
+          </p>
+
+          <div className="mt-3 flex items-center gap-3">
+            <Button
+              size="sm"
+              asChild
+              className={
+                isExhausted
+                  ? "bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
+                  : "bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-600 dark:hover:bg-yellow-700"
+              }
+            >
+              <Link href="/pricing">
+                料金プランを見る
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Link>
+            </Button>
+            <button
+              type="button"
+              onClick={handleDismiss}
+              className={`text-xs underline-offset-2 hover:underline ${
+                isExhausted
+                  ? "text-red-600 dark:text-red-400"
+                  : "text-yellow-600 dark:text-yellow-400"
+              }`}
+            >
+              今月は表示しない
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="閉じる"
+          className={`shrink-0 rounded-md p-1 transition-colors ${
+            isExhausted
+              ? "text-red-400 hover:text-red-600 dark:text-red-500 dark:hover:text-red-300"
+              : "text-yellow-400 hover:text-yellow-600 dark:text-yellow-500 dark:hover:text-yellow-300"
+          }`}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pro-upsell-card.tsx
+++ b/src/components/pro-upsell-card.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, Zap, BarChart3, Brain, Infinity } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { SubscriptionPlan } from "@/types/database";
+
+interface ProUpsellCardProps {
+  plan: SubscriptionPlan;
+}
+
+/** Pro/Premium の特徴比較アイテム */
+const UPGRADE_FEATURES = [
+  {
+    icon: BarChart3,
+    label: "月30回まで分析",
+    description: "Free の10倍。毎日の面接練習に",
+  },
+  {
+    icon: Brain,
+    label: "高精度 AI モデル",
+    description: "Claude Sonnet によるより的確なフィードバック",
+  },
+  {
+    icon: Zap,
+    label: "成長トラッキング",
+    description: "スコア推移をグラフで可視化",
+  },
+  {
+    icon: Infinity,
+    label: "パーソナライズ分析",
+    description: "あなたの弱点に合わせたアドバイス",
+  },
+];
+
+/**
+ * 分析結果ページ下部に表示する Pro プランアップセルカード。
+ * Free プランユーザーにのみ表示する。
+ */
+export function ProUpsellCard({ plan }: ProUpsellCardProps) {
+  // Free プラン以外は表示しない
+  if (plan !== "free") return null;
+
+  return (
+    <Card className="mt-8 border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 dark:border-blue-900 dark:from-blue-950/30 dark:to-indigo-950/30">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-blue-700 dark:text-blue-300">
+          <Zap className="h-5 w-5" />
+          Pro プランでさらに詳細な分析を
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {UPGRADE_FEATURES.map((feature) => (
+            <div key={feature.label} className="flex items-start gap-2">
+              <feature.icon className="mt-0.5 h-4 w-4 shrink-0 text-blue-500 dark:text-blue-400" />
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  {feature.label}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {feature.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 flex items-center gap-3">
+          <Button size="sm" asChild>
+            <Link href="/pricing">
+              料金プランを見る
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Link>
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            月額 ¥980 から
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- ダッシュボードに利用上限ナッジバナーを追加（Free プラン残り1回: 黄色警告, 0回: 赤色警告）
- 分析結果ページ下部に Pro プランアップセルカード（機能比較付き）を追加
- 「今月は表示しない」ボタンで localStorage に dismiss 状態を保存（月替わりで自動リセット）
- Pro/Premium ユーザーには一切表示しない
- ダークモード完全対応

## 変更ファイル
- `src/components/dashboard/usage-nudge-banner.tsx` — 新規: ナッジバナー Client Component
- `src/components/pro-upsell-card.tsx` — 新規: Pro プランアップセルカード
- `src/app/dashboard/page.tsx` — ナッジバナーを統合
- `src/app/interview/[id]/result/page.tsx` — サブスクリプション情報取得を追加
- `src/app/interview/[id]/result/result-content.tsx` — アップセルカードを統合

## Test plan
- [ ] Free プランで残り2回以上の場合、バナーが表示されないこと
- [ ] Free プランで残り1回の場合、黄色バナーが表示されること
- [ ] Free プランで残り0回の場合、赤色バナーが表示されること
- [ ] 「今月は表示しない」クリックでバナーが非表示になること
- [ ] 月が変わると dismiss 状態がリセットされること
- [ ] Pro/Premium ユーザーにはバナー・アップセルカードが表示されないこと
- [ ] 「料金プランを見る」ボタンで /pricing に遷移すること
- [ ] ダークモードで適切な配色で表示されること
- [ ] `npm run build` が成功すること

closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)