### PR TITLE
feat: #188 面接練習リマインダー

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import type { SortOption } from "@/components/interview-filter";
 import { InterviewListSection } from "@/components/dashboard/interview-list-section";
 import { InterviewListSkeleton } from "@/components/dashboard/interview-list-skeleton";
 import { UsageNudgeBanner } from "@/components/dashboard/usage-nudge-banner";
+import { PracticeReminderBanner } from "@/components/dashboard/practice-reminder-banner";
 import { WeeklySummarySection } from "@/components/dashboard/weekly-summary-section";
 import { WeeklySummarySkeleton } from "@/components/dashboard/weekly-summary-skeleton";
 
@@ -66,6 +67,9 @@ export default async function DashboardPage({
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {/* 練習リマインダーバナー */}
+      <PracticeReminderBanner />
+
       {/* 利用上限ナッジバナー（Free プラン & 残り1回以下のみ表示） */}
       <UsageNudgeBanner
         plan={usage.plan}

--- a/src/app/interview/[id]/result/result-content.tsx
+++ b/src/app/interview/[id]/result/result-content.tsx
@@ -19,6 +19,7 @@ import type { CategoryScores, SubscriptionPlan } from "@/types/database";
 import { CATEGORY_LABELS } from "@/lib/constants";
 import { parseAnnotations } from "@/components/annotated-transcript";
 import { ProUpsellCard } from "@/components/pro-upsell-card";
+import { recordPracticeActivity } from "@/lib/reminder";
 
 // 動的インポート: 初期表示に不要なインタラクティブコンポーネントを遅延ロード
 const AnnotatedTranscript = dynamic(
@@ -267,6 +268,11 @@ export function ResultContent({
   rawTranscript?: string | null;
   currentPlan?: SubscriptionPlan;
 }) {
+  // 面接結果閲覧時に最終利用日を記録
+  if (typeof window !== "undefined") {
+    recordPracticeActivity();
+  }
+
   const suggestions = feedback
     ? parseJsonArray<Suggestion>(feedback.suggestions)
     : [];

--- a/src/app/mock-interview/[id]/chat/chat-interface.tsx
+++ b/src/app/mock-interview/[id]/chat/chat-interface.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import type { MockInterviewMessage } from "@/types/database";
+import { recordPracticeActivity } from "@/lib/reminder";
 
 // ============================================================
 // 定数
@@ -107,6 +108,14 @@ export function ChatInterface({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
+
+  // ============================================================
+  // 最終利用日の記録
+  // ============================================================
+
+  useEffect(() => {
+    recordPracticeActivity();
+  }, []);
 
   // ============================================================
   // 自動スクロール

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -15,7 +15,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, Save, X, CheckCircle, AlertCircle, Bell, BellOff } from "lucide-react";
+import { Loader2, Save, X, CheckCircle, AlertCircle, Bell, BellOff, Clock, CalendarDays } from "lucide-react";
 import {
   isNotificationSupported,
   getNotificationPermission,
@@ -23,6 +23,15 @@ import {
   isNotificationEnabled,
   setNotificationEnabled as setNotificationEnabledStorage,
 } from "@/lib/notifications";
+import {
+  getReminderSettings,
+  saveReminderSettings,
+  getDaysForFrequency,
+  FREQUENCY_LABELS,
+  DAY_LABELS,
+  type ReminderFrequency,
+  type ReminderSettings,
+} from "@/lib/reminder";
 import {
   PERSONALITY_TYPES,
   PERSONALITY_DATA,
@@ -130,7 +139,13 @@ export default function ProfilePage() {
     useState<NotificationPermission | null>(null);
   const [notificationEnabled, setNotificationEnabledState] = useState(true);
 
-  // 通知状態の初期化
+  // リマインダー設定
+  const [reminderEnabled, setReminderEnabled] = useState(false);
+  const [reminderFrequency, setReminderFrequency] = useState<ReminderFrequency>("three_per_week");
+  const [reminderTime, setReminderTime] = useState("20:00");
+  const [reminderDays, setReminderDays] = useState<boolean[]>([false, true, false, true, false, true, false]);
+
+  // 通知状態・リマインダーの初期化
   useEffect(() => {
     const supported = isNotificationSupported();
     setNotificationSupported(supported);
@@ -138,6 +153,13 @@ export default function ProfilePage() {
       setNotificationPermission(getNotificationPermission());
       setNotificationEnabledState(isNotificationEnabled());
     }
+
+    // リマインダー設定の読み込み
+    const reminderSettings = getReminderSettings();
+    setReminderEnabled(reminderSettings.enabled);
+    setReminderFrequency(reminderSettings.frequency);
+    setReminderTime(reminderSettings.time);
+    setReminderDays(reminderSettings.days);
   }, []);
 
   // トースト自動非表示
@@ -920,6 +942,191 @@ export default function ProfilePage() {
               <p className="text-sm text-muted-foreground">
                 お使いのブラウザはブラウザ通知に対応していません。分析完了時はアプリ内で通知されます。
               </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* 練習リマインダー設定 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CalendarDays className="h-5 w-5" />
+              練習リマインダー
+            </CardTitle>
+            <CardDescription>
+              定期的に面接練習を思い出せるようリマインダーを設定しましょう
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* ON/OFF トグル */}
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="flex items-center gap-3">
+                {reminderEnabled ? (
+                  <Bell className="h-5 w-5 text-primary" />
+                ) : (
+                  <BellOff className="h-5 w-5 text-muted-foreground" />
+                )}
+                <div>
+                  <p className="text-sm font-medium">リマインダー通知</p>
+                  <p className="text-xs text-muted-foreground">
+                    {reminderEnabled
+                      ? "設定した曜日・時刻にリマインドします"
+                      : "リマインダーは無効です"}
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  const next = !reminderEnabled;
+                  setReminderEnabled(next);
+                  if (next && notificationPermission !== "granted") {
+                    requestNotificationPermission().then((perm) => {
+                      setNotificationPermission(perm);
+                      if (perm === "granted") {
+                        setNotificationEnabledState(true);
+                        setNotificationEnabledStorage(true);
+                      }
+                    });
+                  }
+                  const newSettings: ReminderSettings = {
+                    enabled: next,
+                    frequency: reminderFrequency,
+                    time: reminderTime,
+                    days: reminderDays,
+                  };
+                  saveReminderSettings(newSettings);
+                }}
+                role="switch"
+                aria-checked={reminderEnabled}
+                aria-label="リマインダーの切り替え"
+                className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                  reminderEnabled ? "bg-primary" : "bg-muted"
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                    reminderEnabled ? "translate-x-5" : "translate-x-0"
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* 詳細設定（有効時のみ表示） */}
+            {reminderEnabled && (
+              <div className="space-y-4 rounded-lg border border-dashed p-4">
+                {/* 頻度選択 */}
+                <div className="space-y-2">
+                  <Label htmlFor="reminderFrequency" className="flex items-center gap-1.5">
+                    <Clock className="h-3.5 w-3.5" />
+                    頻度
+                  </Label>
+                  <select
+                    id="reminderFrequency"
+                    value={reminderFrequency}
+                    onChange={(e) => {
+                      const freq = e.target.value as ReminderFrequency;
+                      setReminderFrequency(freq);
+                      const newDays = getDaysForFrequency(freq);
+                      setReminderDays(newDays);
+                      saveReminderSettings({
+                        enabled: reminderEnabled,
+                        frequency: freq,
+                        time: reminderTime,
+                        days: newDays,
+                      });
+                    }}
+                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+                    aria-label="リマインダー頻度"
+                  >
+                    {(Object.entries(FREQUENCY_LABELS) as [ReminderFrequency, string][]).map(
+                      ([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      )
+                    )}
+                  </select>
+                </div>
+
+                {/* 曜日選択 */}
+                <div className="space-y-2">
+                  <Label className="flex items-center gap-1.5">
+                    <CalendarDays className="h-3.5 w-3.5" />
+                    リマインド曜日
+                  </Label>
+                  <div className="flex gap-1.5">
+                    {DAY_LABELS.map((label, index) => {
+                      const active = reminderDays[index];
+                      return (
+                        <button
+                          key={label}
+                          type="button"
+                          onClick={() => {
+                            const newDays = [...reminderDays];
+                            newDays[index] = !newDays[index];
+                            setReminderDays(newDays);
+                            saveReminderSettings({
+                              enabled: reminderEnabled,
+                              frequency: reminderFrequency,
+                              time: reminderTime,
+                              days: newDays,
+                            });
+                          }}
+                          aria-pressed={active}
+                          aria-label={`${label}曜日`}
+                          className={`flex h-9 w-9 items-center justify-center rounded-full text-sm font-medium transition-colors ${
+                            active
+                              ? "bg-primary text-primary-foreground"
+                              : "border border-border bg-background text-muted-foreground hover:bg-accent"
+                          }`}
+                        >
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* 時刻設定 */}
+                <div className="space-y-2">
+                  <Label htmlFor="reminderTime" className="flex items-center gap-1.5">
+                    <Clock className="h-3.5 w-3.5" />
+                    リマインド時刻
+                  </Label>
+                  <Input
+                    id="reminderTime"
+                    type="time"
+                    value={reminderTime}
+                    onChange={(e) => {
+                      const newTime = e.target.value;
+                      setReminderTime(newTime);
+                      saveReminderSettings({
+                        enabled: reminderEnabled,
+                        frequency: reminderFrequency,
+                        time: newTime,
+                        days: reminderDays,
+                      });
+                    }}
+                    className="w-36"
+                    aria-label="リマインド時刻"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    この時刻以降にダッシュボードを開くとリマインド通知が表示されます
+                  </p>
+                </div>
+
+                {/* ブラウザ通知の状態表示 */}
+                {notificationPermission !== "granted" && (
+                  <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-900 dark:bg-yellow-950/30">
+                    <p className="text-xs text-yellow-800 dark:text-yellow-200">
+                      {notificationPermission === "denied"
+                        ? "ブラウザ通知がブロックされています。ブラウザの設定から通知を許可すると、より効果的にリマインドできます。"
+                        : "ブラウザ通知を許可すると、ページを開いた際にデスクトップ通知でもリマインドされます。"}
+                    </p>
+                  </div>
+                )}
+              </div>
             )}
           </CardContent>
         </Card>

--- a/src/components/dashboard/practice-reminder-banner.tsx
+++ b/src/components/dashboard/practice-reminder-banner.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Bell, X, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  shouldShowInactivityBanner,
+  getDaysSinceLastPractice,
+  dismissReminderBanner,
+  getReminderSettings,
+  shouldShowReminder,
+  FREQUENCY_LABELS,
+} from "@/lib/reminder";
+import {
+  isNotificationSupported,
+  sendBrowserNotification,
+} from "@/lib/notifications";
+
+/**
+ * 練習リマインダーバナー
+ *
+ * ダッシュボード上部に表示。以下の条件で表示される:
+ * - リマインダーが有効
+ * - 設定日数以上練習していない場合 => 非アクティブバナー
+ * - またはリマインダー時刻を過ぎている場合 => 通知も送信
+ */
+export function PracticeReminderBanner() {
+  const [showBanner, setShowBanner] = useState(false);
+  const [daysSince, setDaysSince] = useState<number | null>(null);
+  const [notificationSent, setNotificationSent] = useState(false);
+
+  useEffect(() => {
+    // 非アクティブバナーの判定
+    const shouldShow = shouldShowInactivityBanner();
+    setShowBanner(shouldShow);
+
+    if (shouldShow) {
+      setDaysSince(getDaysSinceLastPractice());
+    }
+
+    // リマインダー時刻チェック + ブラウザ通知（ページ表示時のみ）
+    if (shouldShowReminder() && isNotificationSupported() && !notificationSent) {
+      const settings = getReminderSettings();
+      const notifKey = `reminder_notif_${new Date().toISOString().slice(0, 10)}`;
+      const alreadySent = localStorage.getItem(notifKey);
+
+      if (!alreadySent) {
+        sendBrowserNotification("面接練習の時間です", {
+          body: `今日の面接練習をしましょう！（${FREQUENCY_LABELS[settings.frequency]}リマインダー）`,
+          tag: "practice-reminder",
+          onClick: () => {
+            window.location.href = "/dashboard";
+          },
+        });
+        localStorage.setItem(notifKey, "true");
+        setNotificationSent(true);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!showBanner) return null;
+
+  const getMessage = () => {
+    if (daysSince === null) return "";
+    if (daysSince >= 14) {
+      return `${daysSince}日間練習していません。久しぶりに面接練習をしませんか？`;
+    }
+    if (daysSince >= 7) {
+      return `${daysSince}日ぶりですね！面接力を維持するために、今日も練習しましょう。`;
+    }
+    return `${daysSince}日間練習していません。今日こそ面接練習をしましょう！`;
+  };
+
+  function handleDismiss() {
+    dismissReminderBanner();
+    setShowBanner(false);
+  }
+
+  return (
+    <div
+      role="alert"
+      className="relative mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950/30"
+    >
+      <div className="flex items-start gap-3">
+        <Bell className="mt-0.5 h-5 w-5 shrink-0 text-blue-500 dark:text-blue-400" />
+
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+            {getMessage()}
+          </p>
+          <p className="mt-1 text-sm text-blue-700 dark:text-blue-300">
+            定期的な練習が面接成功のカギです。少しの時間でも効果があります。
+          </p>
+
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <Button
+              size="sm"
+              asChild
+              className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700"
+            >
+              <Link href="/interview/new">
+                面接を記録する
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Link>
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              asChild
+              className="border-blue-300 text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:text-blue-300 dark:hover:bg-blue-900"
+            >
+              <Link href="/mock-interview">AI模擬面接を試す</Link>
+            </Button>
+            <button
+              type="button"
+              onClick={handleDismiss}
+              className="text-xs text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+            >
+              今日は表示しない
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="閉じる"
+          className="shrink-0 rounded-md p-1 text-blue-400 transition-colors hover:text-blue-600 dark:text-blue-500 dark:hover:text-blue-300"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/reminder.test.ts
+++ b/src/lib/reminder.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  getReminderSettings,
+  saveReminderSettings,
+  getDaysForFrequency,
+  recordPracticeActivity,
+  getLastPracticeTimestamp,
+  getDaysSinceLastPractice,
+  dismissReminderBanner,
+  isReminderBannerDismissed,
+  shouldShowReminder,
+  shouldShowInactivityBanner,
+  FREQUENCY_LABELS,
+  DAY_LABELS,
+  type ReminderSettings,
+} from "./reminder";
+
+// localStorage のモック
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+describe("reminder", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getReminderSettings", () => {
+    it("デフォルト設定を返す", () => {
+      const settings = getReminderSettings();
+      expect(settings.enabled).toBe(false);
+      expect(settings.frequency).toBe("three_per_week");
+      expect(settings.time).toBe("20:00");
+      expect(settings.days).toEqual([false, true, false, true, false, true, false]);
+    });
+
+    it("保存済みの設定を正しく読み込む", () => {
+      const custom: ReminderSettings = {
+        enabled: true,
+        frequency: "daily",
+        time: "09:00",
+        days: [true, true, true, true, true, true, true],
+      };
+      saveReminderSettings(custom);
+      const settings = getReminderSettings();
+      expect(settings).toEqual(custom);
+    });
+
+    it("不正な JSON の場合デフォルトを返す", () => {
+      localStorageMock.setItem("practice_reminder_settings", "invalid-json");
+      const settings = getReminderSettings();
+      expect(settings.enabled).toBe(false);
+    });
+  });
+
+  describe("saveReminderSettings", () => {
+    it("設定を localStorage に保存する", () => {
+      const settings: ReminderSettings = {
+        enabled: true,
+        frequency: "weekly",
+        time: "18:30",
+        days: [false, true, false, false, false, false, false],
+      };
+      saveReminderSettings(settings);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "practice_reminder_settings",
+        JSON.stringify(settings)
+      );
+    });
+  });
+
+  describe("getDaysForFrequency", () => {
+    it("daily は全日 true", () => {
+      const days = getDaysForFrequency("daily");
+      expect(days).toEqual([true, true, true, true, true, true, true]);
+    });
+
+    it("three_per_week は月水金", () => {
+      const days = getDaysForFrequency("three_per_week");
+      expect(days).toEqual([false, true, false, true, false, true, false]);
+    });
+
+    it("weekly は月曜のみ", () => {
+      const days = getDaysForFrequency("weekly");
+      expect(days).toEqual([false, true, false, false, false, false, false]);
+    });
+  });
+
+  describe("recordPracticeActivity / getLastPracticeTimestamp", () => {
+    it("タイムスタンプを記録・取得できる", () => {
+      expect(getLastPracticeTimestamp()).toBeNull();
+      recordPracticeActivity();
+      expect(getLastPracticeTimestamp()).not.toBeNull();
+    });
+  });
+
+  describe("getDaysSinceLastPractice", () => {
+    it("記録がない場合 null を返す", () => {
+      expect(getDaysSinceLastPractice()).toBeNull();
+    });
+
+    it("今日の記録なら 0 日", () => {
+      recordPracticeActivity();
+      expect(getDaysSinceLastPractice()).toBe(0);
+    });
+
+    it("3日前の記録なら 3", () => {
+      const threeDaysAgo = new Date();
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+      localStorageMock.setItem("last_practice_timestamp", threeDaysAgo.toISOString());
+      expect(getDaysSinceLastPractice()).toBe(3);
+    });
+  });
+
+  describe("dismissReminderBanner / isReminderBannerDismissed", () => {
+    it("dismiss 前は false", () => {
+      expect(isReminderBannerDismissed()).toBe(false);
+    });
+
+    it("dismiss 後は true", () => {
+      dismissReminderBanner();
+      expect(isReminderBannerDismissed()).toBe(true);
+    });
+  });
+
+  describe("shouldShowReminder", () => {
+    it("無効の場合 false を返す", () => {
+      expect(shouldShowReminder()).toBe(false);
+    });
+
+    it("有効で曜日・時刻が一致すれば true", () => {
+      const now = new Date();
+      const todayDay = now.getDay();
+      const days = [false, false, false, false, false, false, false];
+      days[todayDay] = true;
+
+      saveReminderSettings({
+        enabled: true,
+        frequency: "daily",
+        time: "00:00", // 常に過ぎている
+        days,
+      });
+
+      expect(shouldShowReminder()).toBe(true);
+    });
+
+    it("曜日が一致しなければ false", () => {
+      const now = new Date();
+      const todayDay = now.getDay();
+      const days = [true, true, true, true, true, true, true];
+      days[todayDay] = false;
+
+      saveReminderSettings({
+        enabled: true,
+        frequency: "daily",
+        time: "00:00",
+        days,
+      });
+
+      expect(shouldShowReminder()).toBe(false);
+    });
+  });
+
+  describe("shouldShowInactivityBanner", () => {
+    it("無効の場合 false", () => {
+      expect(shouldShowInactivityBanner()).toBe(false);
+    });
+
+    it("一度も利用していない場合 false", () => {
+      saveReminderSettings({
+        enabled: true,
+        frequency: "daily",
+        time: "00:00",
+        days: [true, true, true, true, true, true, true],
+      });
+      expect(shouldShowInactivityBanner()).toBe(false);
+    });
+
+    it("daily で2日以上経過していれば true", () => {
+      saveReminderSettings({
+        enabled: true,
+        frequency: "daily",
+        time: "00:00",
+        days: [true, true, true, true, true, true, true],
+      });
+      const threeDaysAgo = new Date();
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+      localStorageMock.setItem("last_practice_timestamp", threeDaysAgo.toISOString());
+      expect(shouldShowInactivityBanner()).toBe(true);
+    });
+
+    it("weekly で10日以上経過していれば true", () => {
+      saveReminderSettings({
+        enabled: true,
+        frequency: "weekly",
+        time: "00:00",
+        days: [false, true, false, false, false, false, false],
+      });
+      const elevenDaysAgo = new Date();
+      elevenDaysAgo.setDate(elevenDaysAgo.getDate() - 11);
+      localStorageMock.setItem("last_practice_timestamp", elevenDaysAgo.toISOString());
+      expect(shouldShowInactivityBanner()).toBe(true);
+    });
+  });
+
+  describe("定数", () => {
+    it("FREQUENCY_LABELS が正しい", () => {
+      expect(FREQUENCY_LABELS.daily).toBe("毎日");
+      expect(FREQUENCY_LABELS.three_per_week).toBe("週3回");
+      expect(FREQUENCY_LABELS.weekly).toBe("週1回");
+    });
+
+    it("DAY_LABELS が7つ", () => {
+      expect(DAY_LABELS).toHaveLength(7);
+      expect(DAY_LABELS[0]).toBe("日");
+      expect(DAY_LABELS[6]).toBe("土");
+    });
+  });
+});

--- a/src/lib/reminder.ts
+++ b/src/lib/reminder.ts
@@ -1,0 +1,196 @@
+/**
+ * 面接練習リマインダー設定ユーティリティ
+ *
+ * localStorage ベースでリマインダーの頻度・時刻・曜日を管理する。
+ * DB 変更不要。ブラウザ通知 API と組み合わせて使用。
+ */
+
+// ============================================================
+// localStorage キー
+// ============================================================
+
+const REMINDER_SETTINGS_KEY = "practice_reminder_settings";
+const LAST_PRACTICE_KEY = "last_practice_timestamp";
+const REMINDER_DISMISSED_KEY = "reminder_banner_dismissed";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+export type ReminderFrequency = "daily" | "three_per_week" | "weekly";
+
+export interface ReminderSettings {
+  /** リマインダー有効/無効 */
+  enabled: boolean;
+  /** 頻度 */
+  frequency: ReminderFrequency;
+  /** リマインダー時刻（HH:mm 形式） */
+  time: string;
+  /** 曜日ごとの有効/無効（0=日, 1=月, ... 6=土） */
+  days: boolean[];
+}
+
+// ============================================================
+// デフォルト値
+// ============================================================
+
+const DEFAULT_SETTINGS: ReminderSettings = {
+  enabled: false,
+  frequency: "three_per_week",
+  time: "20:00",
+  // デフォルト: 月水金
+  days: [false, true, false, true, false, true, false],
+};
+
+/** 頻度のプリセット曜日 */
+const FREQUENCY_PRESETS: Record<ReminderFrequency, boolean[]> = {
+  daily: [true, true, true, true, true, true, true],
+  three_per_week: [false, true, false, true, false, true, false],
+  weekly: [false, true, false, false, false, false, false],
+};
+
+// ============================================================
+// 設定の読み書き
+// ============================================================
+
+/** リマインダー設定を取得 */
+export function getReminderSettings(): ReminderSettings {
+  if (typeof window === "undefined") return DEFAULT_SETTINGS;
+  try {
+    const stored = localStorage.getItem(REMINDER_SETTINGS_KEY);
+    if (!stored) return DEFAULT_SETTINGS;
+    const parsed = JSON.parse(stored) as Partial<ReminderSettings>;
+    return {
+      enabled: parsed.enabled ?? DEFAULT_SETTINGS.enabled,
+      frequency: parsed.frequency ?? DEFAULT_SETTINGS.frequency,
+      time: parsed.time ?? DEFAULT_SETTINGS.time,
+      days:
+        Array.isArray(parsed.days) && parsed.days.length === 7
+          ? parsed.days
+          : DEFAULT_SETTINGS.days,
+    };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+/** リマインダー設定を保存 */
+export function saveReminderSettings(settings: ReminderSettings): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(REMINDER_SETTINGS_KEY, JSON.stringify(settings));
+}
+
+/** 頻度プリセットから曜日配列を取得 */
+export function getDaysForFrequency(frequency: ReminderFrequency): boolean[] {
+  return [...FREQUENCY_PRESETS[frequency]];
+}
+
+// ============================================================
+// 最終利用日の管理
+// ============================================================
+
+/** 最終利用タイムスタンプを記録 */
+export function recordPracticeActivity(): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(LAST_PRACTICE_KEY, new Date().toISOString());
+}
+
+/** 最終利用タイムスタンプを取得 */
+export function getLastPracticeTimestamp(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(LAST_PRACTICE_KEY);
+}
+
+/** 最終利用からの経過日数を計算 */
+export function getDaysSinceLastPractice(): number | null {
+  const timestamp = getLastPracticeTimestamp();
+  if (!timestamp) return null;
+  const last = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - last.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}
+
+// ============================================================
+// バナー dismiss 管理
+// ============================================================
+
+/** バナーを非表示にする（当日分） */
+export function dismissReminderBanner(): void {
+  if (typeof window === "undefined") return;
+  const today = new Date().toISOString().slice(0, 10);
+  localStorage.setItem(REMINDER_DISMISSED_KEY, today);
+}
+
+/** バナーが当日 dismiss 済みか */
+export function isReminderBannerDismissed(): boolean {
+  if (typeof window === "undefined") return true;
+  const dismissed = localStorage.getItem(REMINDER_DISMISSED_KEY);
+  if (!dismissed) return false;
+  const today = new Date().toISOString().slice(0, 10);
+  return dismissed === today;
+}
+
+// ============================================================
+// リマインダー判定ロジック
+// ============================================================
+
+/**
+ * 今日リマインダーを表示すべきかどうか判定する
+ * - 設定が有効
+ * - 今日が設定曜日に含まれている
+ * - リマインダー時刻を過ぎている
+ */
+export function shouldShowReminder(): boolean {
+  const settings = getReminderSettings();
+  if (!settings.enabled) return false;
+
+  const now = new Date();
+  const todayDay = now.getDay(); // 0=日, 1=月, ...
+
+  // 曜日チェック
+  if (!settings.days[todayDay]) return false;
+
+  // 時刻チェック
+  const [hours, minutes] = settings.time.split(":").map(Number);
+  const reminderTime = new Date(now);
+  reminderTime.setHours(hours, minutes, 0, 0);
+
+  return now >= reminderTime;
+}
+
+/**
+ * ダッシュボードでリマインダーバナーを表示すべきか判定
+ * 設定日数以上利用がなければ true
+ */
+export function shouldShowInactivityBanner(): boolean {
+  const settings = getReminderSettings();
+  if (!settings.enabled) return false;
+  if (isReminderBannerDismissed()) return false;
+
+  const daysSince = getDaysSinceLastPractice();
+
+  // 一度も利用していない場合は表示しない（初回ユーザーはデータがない）
+  if (daysSince === null) return false;
+
+  // 頻度に応じた閾値
+  const thresholds: Record<ReminderFrequency, number> = {
+    daily: 2,
+    three_per_week: 4,
+    weekly: 10,
+  };
+
+  return daysSince >= thresholds[settings.frequency];
+}
+
+// ============================================================
+// 表示用ヘルパー
+// ============================================================
+
+export const FREQUENCY_LABELS: Record<ReminderFrequency, string> = {
+  daily: "毎日",
+  three_per_week: "週3回",
+  weekly: "週1回",
+};
+
+export const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;


### PR DESCRIPTION
## Summary
- プロフィールページに「練習リマインダー」設定セクションを追加（ON/OFF、頻度、曜日、時刻）
- ダッシュボードに非アクティブバナーを表示（設定日数以上未練習時）
- ブラウザ Notification API によるデスクトップ通知対応
- 面接結果閲覧時・AI模擬面接開始時に最終利用日を自動記録
- localStorage ベースのため DB 変更なし

closes #188

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `src/lib/reminder.ts` | リマインダー設定ユーティリティ（localStorage 管理） |
| `src/lib/reminder.test.ts` | Vitest テスト 22 件 |
| `src/components/dashboard/practice-reminder-banner.tsx` | ダッシュボード用リマインダーバナー |
| `src/app/dashboard/page.tsx` | バナーコンポーネントの組み込み |
| `src/app/profile/page.tsx` | リマインダー設定 UI セクション追加 |
| `src/app/interview/[id]/result/result-content.tsx` | 最終利用日の記録 |
| `src/app/mock-interview/[id]/chat/chat-interface.tsx` | 最終利用日の記録 |

## Test plan
- [ ] プロフィール → 練習リマインダーセクションの ON/OFF トグルが動作する
- [ ] 頻度変更で曜日プリセットが切り替わる
- [ ] 曜日ボタンの個別 ON/OFF が localStorage に保存される
- [ ] 時刻設定が保存される
- [ ] 面接結果ページ閲覧後に `last_practice_timestamp` が localStorage に記録される
- [ ] AI模擬面接開始後に `last_practice_timestamp` が記録される
- [ ] リマインダー有効 + 設定日数以上経過時、ダッシュボードにバナー表示
- [ ] バナーの「今日は表示しない」で当日非表示
- [ ] `npm run build` 成功
- [ ] `npx vitest run src/lib/reminder.test.ts` 22 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)