### PR TITLE
feat: #209 CSP・セキュリティヘッダー強化 + CSRF対策

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,23 +1,57 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
+import bundleAnalyzer from "@next/bundle-analyzer";
+
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
 
 const nextConfig: NextConfig = {
   // 画像最適化: WebP/AVIF フォーマットに対応
   images: {
     formats: ["image/avif", "image/webp"],
   },
+
+  // セキュリティヘッダー（middleware 非経由のリクエストにも適用）
+  headers: async () => [
+    {
+      source: "/:path*",
+      headers: [
+        // クリックジャッキング防止
+        { key: "X-Frame-Options", value: "DENY" },
+        // MIME タイプスニッフィング防止
+        { key: "X-Content-Type-Options", value: "nosniff" },
+        // リファラー制御
+        { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        // ブラウザ機能制限（マイクは面接録音で必要）
+        {
+          key: "Permissions-Policy",
+          value: "camera=(), microphone=(self), geolocation=()",
+        },
+        // DNS プリフェッチ有効化
+        { key: "X-DNS-Prefetch-Control", value: "on" },
+        // HTTPS 強制（2年間 + サブドメイン + preload）
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+      ],
+    },
+  ],
 };
 
-export default withSentryConfig(nextConfig, {
-  org: process.env.SENTRY_ORG,
-  project: process.env.SENTRY_PROJECT,
-  sourcemaps: {
-    disable: !process.env.SENTRY_AUTH_TOKEN,
-  },
-  silent: !process.env.CI,
-  bundleSizeOptimizations: {
-    excludeDebugStatements: true,
-  },
-  authToken: process.env.SENTRY_AUTH_TOKEN,
-  telemetry: false,
-});
+export default withBundleAnalyzer(
+  withSentryConfig(nextConfig, {
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    sourcemaps: {
+      disable: !process.env.SENTRY_AUTH_TOKEN,
+    },
+    silent: !process.env.CI,
+    bundleSizeOptimizations: {
+      excludeDebugStatements: true,
+    },
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    telemetry: false,
+  })
+);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,136 @@ import { type NextRequest, NextResponse } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
 // ============================================================
+// セキュリティヘッダー & CSP
+// ============================================================
+
+/**
+ * Content Security Policy を構築する。
+ * next-themes はインラインスクリプトでテーマ初期化を行うため 'unsafe-inline' が必要。
+ * Tailwind CSS / shadcn/ui はインラインスタイルを使用するため style-src に 'unsafe-inline' が必要。
+ */
+function buildCsp(): string {
+  const directives: string[] = [
+    // デフォルト: 自サイトのみ
+    "default-src 'self'",
+    // スクリプト: 自サイト + unsafe-inline（next-themes テーマ初期化）
+    "script-src 'self' 'unsafe-inline' https://js.stripe.com",
+    // スタイル: 自サイト + unsafe-inline（Tailwind/shadcn）
+    "style-src 'self' 'unsafe-inline'",
+    // 画像: 自サイト + data URI（SVG インライン等）+ blob（画像プレビュー）
+    "img-src 'self' data: blob:",
+    // フォント: 自サイトのみ（next/font でセルフホスティング）
+    "font-src 'self'",
+    // 接続先: 自サイト + Supabase + Sentry + AssemblyAI
+    "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://api.assemblyai.com",
+    // フレーム: Stripe Checkout 用
+    "frame-src 'self' https://js.stripe.com",
+    // メディア: 自サイト + blob（録音データ）
+    "media-src 'self' blob:",
+    // ワーカー: 自サイト + blob（AudioWorklet 等）
+    "worker-src 'self' blob:",
+    // フォーム送信先: 自サイトのみ
+    "form-action 'self'",
+    // ベース URI: 自サイトのみ
+    "base-uri 'self'",
+    // フレーム祖先: なし（クリックジャッキング防止）
+    "frame-ancestors 'none'",
+    // オブジェクト: なし（Flash 等のプラグイン無効化）
+    "object-src 'none'",
+  ];
+  return directives.join("; ");
+}
+
+/**
+ * レスポンスにセキュリティヘッダーを付与する。
+ */
+function setSecurityHeaders(response: NextResponse): void {
+  // CSP
+  response.headers.set("Content-Security-Policy", buildCsp());
+  // クリックジャッキング防止
+  response.headers.set("X-Frame-Options", "DENY");
+  // MIME タイプスニッフィング防止
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  // リファラー制御
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  // ブラウザ機能制限（マイクは面接録音で必要）
+  response.headers.set(
+    "Permissions-Policy",
+    "camera=(), microphone=(self), geolocation=()"
+  );
+  // DNS プリフェッチ有効化
+  response.headers.set("X-DNS-Prefetch-Control", "on");
+  // HTTPS 強制（2年間 + サブドメイン + preload）
+  response.headers.set(
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains; preload"
+  );
+}
+
+// ============================================================
+// CSRF 対策（Origin / Referer 検証）
+// ============================================================
+
+/** 許可するオリジンのリスト */
+function getAllowedOrigins(): string[] {
+  const origins = ["https://interviewcoach.jp"];
+  // 開発環境
+  if (process.env.NODE_ENV !== "production") {
+    origins.push("http://localhost:3000");
+    origins.push("http://127.0.0.1:3000");
+  }
+  // Vercel プレビュー環境
+  if (process.env.VERCEL_URL) {
+    origins.push(`https://${process.env.VERCEL_URL}`);
+  }
+  return origins;
+}
+
+/**
+ * 状態変更系リクエスト（POST/PUT/PATCH/DELETE）に対して
+ * Origin / Referer ヘッダーを検証する。
+ * Stripe Webhook は署名検証で保護されているため CSRF チェックをスキップする。
+ */
+function validateCsrf(request: NextRequest): boolean {
+  const method = request.method.toUpperCase();
+
+  // GET / HEAD / OPTIONS は状態変更しないためスキップ
+  if (["GET", "HEAD", "OPTIONS"].includes(method)) {
+    return true;
+  }
+
+  // Stripe Webhook は stripe-signature で検証されるためスキップ
+  if (request.nextUrl.pathname === "/api/stripe/webhook") {
+    return true;
+  }
+
+  // Supabase Auth Callback は外部リダイレクトからのため CSRF チェックをスキップ
+  if (
+    request.nextUrl.pathname.startsWith("/auth/callback") ||
+    request.nextUrl.pathname.startsWith("/api/auth/callback")
+  ) {
+    return true;
+  }
+
+  const origin = request.headers.get("origin");
+  const referer = request.headers.get("referer");
+  const allowedOrigins = getAllowedOrigins();
+
+  // Origin ヘッダーがある場合はそれで検証
+  if (origin) {
+    return allowedOrigins.some((allowed) => origin === allowed);
+  }
+
+  // Origin がない場合は Referer で検証
+  if (referer) {
+    return allowedOrigins.some((allowed) => referer.startsWith(allowed));
+  }
+
+  // Origin も Referer もない場合は拒否（ブラウザからの正常なリクエストには必ず付与される）
+  return false;
+}
+
+// ============================================================
 // インメモリレート制限（MVP用）
 // 本番環境では Redis ベースのレート制限に置き換えること
 // ============================================================
@@ -104,6 +234,16 @@ function shouldCheckOnboarding(pathname: string): boolean {
 }
 
 export async function middleware(request: NextRequest) {
+  // -------------------------------------------------------
+  // CSRF 検証（状態変更系 API に対して Origin/Referer を検証）
+  // -------------------------------------------------------
+  if (request.nextUrl.pathname.startsWith("/api/") && !validateCsrf(request)) {
+    return NextResponse.json(
+      { error: "不正なリクエストです。ページを再読み込みしてお試しください。" },
+      { status: 403 }
+    );
+  }
+
   // /api/* へのリクエストにレート制限を適用
   if (request.nextUrl.pathname.startsWith("/api/")) {
     const ip = getClientIp(request);
@@ -129,6 +269,7 @@ export async function middleware(request: NextRequest) {
     response.headers.set("X-RateLimit-Limit", String(RATE_LIMIT_MAX_REQUESTS));
     response.headers.set("X-RateLimit-Remaining", String(remaining));
     response.headers.set("X-RateLimit-Reset", String(Math.ceil(resetAt / 1000)));
+    setSecurityHeaders(response);
     return response;
   }
 
@@ -177,6 +318,9 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(url);
     }
   }
+
+  // 全レスポンスにセキュリティヘッダーを付与
+  setSecurityHeaders(response);
 
   return response;
 }


### PR DESCRIPTION
## Summary
- `next.config.ts` に `headers()` でセキュリティヘッダーを追加（middleware 非経由のリクエストにも対応）
- `src/middleware.ts` に CSP（Content Security Policy）を追加し、全レスポンスに適用
- `src/middleware.ts` に CSRF 対策（Origin/Referer 検証）を追加

## 変更内容

### セキュリティヘッダー（next.config.ts + middleware.ts）
- **X-Frame-Options**: `DENY`（クリックジャッキング防止）
- **X-Content-Type-Options**: `nosniff`（MIME スニッフィング防止）
- **Referrer-Policy**: `strict-origin-when-cross-origin`
- **Permissions-Policy**: `camera=(), microphone=(self), geolocation=()`（マイクは面接録音で必要）
- **X-DNS-Prefetch-Control**: `on`
- **Strict-Transport-Security**: `max-age=63072000; includeSubDomains; preload`（2年間）

### CSP（middleware.ts）
- `default-src 'self'`
- `script-src 'self' 'unsafe-inline' https://js.stripe.com`（next-themes テーマ初期化に unsafe-inline 必要）
- `style-src 'self' 'unsafe-inline'`（Tailwind/shadcn に必要）
- `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://api.assemblyai.com`
- `frame-src 'self' https://js.stripe.com`
- `media-src 'self' blob:`（録音データ）
- `worker-src 'self' blob:`（AudioWorklet）
- `frame-ancestors 'none'` / `object-src 'none'`

### CSRF 対策（middleware.ts）
- POST/PUT/PATCH/DELETE リクエストに対して Origin/Referer ヘッダーを検証
- 許可オリジン: `https://interviewcoach.jp` + 開発環境 + Vercel プレビュー
- Stripe Webhook（署名検証で保護済み）と Auth Callback は除外

## Test plan
- [x] `npm run build` 成功
- [x] 既存テスト 195/195 パス
- [ ] ブラウザで主要ページにアクセスし CSP 違反エラーがないことを確認
- [ ] DevTools の Network タブでセキュリティヘッダーが付与されていることを確認
- [ ] 面接録音（マイク使用）が動作することを確認

closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)