### PR TITLE
feat: #187 キーボードショートカット — コマンドパレット & グローバルショートカット

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/supabase-js": "^2.98.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^0.575.0",
         "next": "16.1.6",
         "next-themes": "^0.4.6",
@@ -25,6 +26,7 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.1.6",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
@@ -765,6 +767,16 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -2515,6 +2527,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.1.6.tgz",
+      "integrity": "sha512-ee2kagdTaeEWPlotgdTOqFHYcD3e2m2bbE3I9Rq2i6ABYi5OgopmtEUe8NM23viaYxLV2tDH/2nd5+qKoEr6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
@@ -3310,6 +3332,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.2.0",
@@ -7433,6 +7462,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -8216,6 +8258,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -8559,6 +8617,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8770,6 +8835,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eciesjs": {
       "version": "0.4.17",
@@ -10334,6 +10406,22 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -10474,6 +10562,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -11030,6 +11125,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -12131,6 +12236,16 @@
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12652,6 +12767,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -14333,6 +14458,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -14960,6 +15100,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -15751,6 +15901,66 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@supabase/supabase-js": "^2.98.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
     "next-themes": "^0.4.6",
@@ -30,6 +31,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.1.6",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { CookieConsent } from "@/components/cookie-consent";
 import { ThemeProvider } from "@/components/theme-provider";
 import { SessionMonitor } from "@/components/session-monitor";
 import { MobileCTA } from "@/components/mobile-cta";
+import { CommandPalette } from "@/components/command-palette";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -93,6 +94,7 @@ export default function RootLayout({
             <main className="flex-1">{children}</main>
             <Footer />
           </div>
+          <CommandPalette />
           <SessionMonitor />
           <MobileCTA />
           <CookieConsent />

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import {
+  BarChart3,
+  FileText,
+  HelpCircle,
+  LayoutDashboard,
+  Mic,
+  Monitor,
+  Moon,
+  MessageSquare,
+  Sun,
+  TrendingUp,
+  User,
+  CreditCard,
+  BookOpen,
+} from "lucide-react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command";
+import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { ShortcutHelpDialog } from "@/components/shortcut-help-dialog";
+
+/**
+ * コマンドパレット + グローバルキーボードショートカット。
+ * layout.tsx に配置してアプリ全体で使用する。
+ */
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const router = useRouter();
+  const { setTheme } = useTheme();
+
+  const handleNavigate = useCallback(
+    (path: string) => {
+      setOpen(false);
+      router.push(path);
+    },
+    [router]
+  );
+
+  const handleCommandPalette = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  const handleShortcutHelp = useCallback(() => {
+    setHelpOpen(true);
+  }, []);
+
+  useKeyboardShortcuts({
+    onCommandPalette: handleCommandPalette,
+    onShortcutHelp: handleShortcutHelp,
+    onNavigate: handleNavigate,
+  });
+
+  // Mac / Windows の修飾キー表示を切り替え
+  const [isMac, setIsMac] = useState(false);
+  useEffect(() => {
+    setIsMac(navigator.platform?.toLowerCase().includes("mac") ?? false);
+  }, []);
+  const modKey = isMac ? "\u2318" : "Ctrl";
+
+  return (
+    <>
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="コマンドパレット"
+        description="ページや操作をファジー検索..."
+      >
+        <CommandInput placeholder="ページや操作を検索..." />
+        <CommandList>
+          <CommandEmpty>結果が見つかりません</CommandEmpty>
+
+          {/* ナビゲーション */}
+          <CommandGroup heading="ナビゲーション">
+            <CommandItem onSelect={() => handleNavigate("/interview/new")}>
+              <Mic className="mr-2 h-4 w-4" />
+              面接を記録する
+              <CommandShortcut>N</CommandShortcut>
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/mock-interview")}>
+              <MessageSquare className="mr-2 h-4 w-4" />
+              AI模擬面接
+              <CommandShortcut>M</CommandShortcut>
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/es-review")}>
+              <FileText className="mr-2 h-4 w-4" />
+              ES添削
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/questions")}>
+              <BookOpen className="mr-2 h-4 w-4" />
+              質問集
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/dashboard")}>
+              <LayoutDashboard className="mr-2 h-4 w-4" />
+              ダッシュボード
+              <CommandShortcut>D</CommandShortcut>
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/dashboard/growth")}>
+              <TrendingUp className="mr-2 h-4 w-4" />
+              成長記録
+              <CommandShortcut>G</CommandShortcut>
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/personality")}>
+              <BarChart3 className="mr-2 h-4 w-4" />
+              16パーソナリティ診断
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/profile")}>
+              <User className="mr-2 h-4 w-4" />
+              プロフィール
+            </CommandItem>
+            <CommandItem onSelect={() => handleNavigate("/pricing")}>
+              <CreditCard className="mr-2 h-4 w-4" />
+              料金プラン
+            </CommandItem>
+          </CommandGroup>
+
+          <CommandSeparator />
+
+          {/* テーマ切替 */}
+          <CommandGroup heading="テーマ">
+            <CommandItem
+              onSelect={() => {
+                setTheme("light");
+                setOpen(false);
+              }}
+            >
+              <Sun className="mr-2 h-4 w-4" />
+              ライトモード
+            </CommandItem>
+            <CommandItem
+              onSelect={() => {
+                setTheme("dark");
+                setOpen(false);
+              }}
+            >
+              <Moon className="mr-2 h-4 w-4" />
+              ダークモード
+            </CommandItem>
+            <CommandItem
+              onSelect={() => {
+                setTheme("system");
+                setOpen(false);
+              }}
+            >
+              <Monitor className="mr-2 h-4 w-4" />
+              システムに合わせる
+            </CommandItem>
+          </CommandGroup>
+
+          <CommandSeparator />
+
+          {/* ヘルプ */}
+          <CommandGroup heading="ヘルプ">
+            <CommandItem
+              onSelect={() => {
+                setOpen(false);
+                // 少し遅延を入れてダイアログの切り替えを滑らかにする
+                setTimeout(() => setHelpOpen(true), 150);
+              }}
+            >
+              <HelpCircle className="mr-2 h-4 w-4" />
+              ショートカット一覧
+              <CommandShortcut>?</CommandShortcut>
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+
+        {/* フッター: ショートカットヒント */}
+        <div className="flex items-center justify-between border-t px-3 py-2 text-xs text-muted-foreground">
+          <span>
+            <kbd className="rounded border bg-muted px-1 py-0.5 text-[10px]">
+              {modKey}
+            </kbd>{" "}
+            +{" "}
+            <kbd className="rounded border bg-muted px-1 py-0.5 text-[10px]">
+              K
+            </kbd>{" "}
+            で開閉
+          </span>
+          <span>
+            <kbd className="rounded border bg-muted px-1 py-0.5 text-[10px]">
+              Esc
+            </kbd>{" "}
+            で閉じる
+          </span>
+        </div>
+      </CommandDialog>
+
+      <ShortcutHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
+    </>
+  );
+}

--- a/src/components/shortcut-help-dialog.tsx
+++ b/src/components/shortcut-help-dialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+interface ShortcutHelpDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface ShortcutEntry {
+  keys: string[];
+  description: string;
+}
+
+const shortcuts: { group: string; items: ShortcutEntry[] }[] = [
+  {
+    group: "一般",
+    items: [
+      { keys: ["Ctrl", "K"], description: "コマンドパレットを開く" },
+      { keys: ["?"], description: "ショートカット一覧を表示" },
+      { keys: ["Esc"], description: "モーダルを閉じる" },
+    ],
+  },
+  {
+    group: "ナビゲーション",
+    items: [
+      { keys: ["N"], description: "面接を記録する" },
+      { keys: ["M"], description: "AI模擬面接" },
+      { keys: ["D"], description: "ダッシュボード" },
+      { keys: ["G"], description: "成長記録" },
+    ],
+  },
+];
+
+/**
+ * ショートカット一覧ヘルプダイアログ。
+ * `?` キーまたはコマンドパレットから開く。
+ */
+export function ShortcutHelpDialog({
+  open,
+  onOpenChange,
+}: ShortcutHelpDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>キーボードショートカット</DialogTitle>
+          <DialogDescription>
+            テキスト入力中は単キーショートカットは無効になります
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-6">
+          {shortcuts.map((section) => (
+            <div key={section.group}>
+              <h3 className="mb-3 text-sm font-medium text-muted-foreground">
+                {section.group}
+              </h3>
+              <div className="space-y-2">
+                {section.items.map((item) => (
+                  <div
+                    key={item.description}
+                    className="flex items-center justify-between"
+                  >
+                    <span className="text-sm">{item.description}</span>
+                    <div className="flex items-center gap-1">
+                      {item.keys.map((key, i) => (
+                        <span key={i}>
+                          {i > 0 && (
+                            <span className="mx-0.5 text-xs text-muted-foreground">
+                              +
+                            </span>
+                          )}
+                          <kbd className="inline-flex h-6 min-w-[24px] items-center justify-center rounded border bg-muted px-1.5 text-xs font-medium">
+                            {key}
+                          </kbd>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+
+/**
+ * テキスト入力中かどうかを判定するヘルパー。
+ * input / textarea / contentEditable 要素にフォーカスがある場合は true。
+ */
+function isInputActive(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tagName = el.tagName.toLowerCase();
+  if (tagName === "input" || tagName === "textarea") return true;
+  if ((el as HTMLElement).isContentEditable) return true;
+  // cmdk の入力欄もテキスト入力とみなす
+  if (el.getAttribute("cmdk-input") !== null) return true;
+  return false;
+}
+
+interface KeyboardShortcutHandlers {
+  onCommandPalette: () => void;
+  onShortcutHelp: () => void;
+  onNavigate: (path: string) => void;
+}
+
+/**
+ * グローバルキーボードショートカットを登録するフック。
+ *
+ * - Ctrl/Cmd + K: コマンドパレット
+ * - ?: ショートカットヘルプ
+ * - N: 新規面接記録
+ * - M: 模擬面接
+ * - D: ダッシュボード
+ * - G: 成長記録
+ * - Escape: モーダル/ポップオーバーを閉じる（ブラウザデフォルト動作に委譲）
+ */
+export function useKeyboardShortcuts({
+  onCommandPalette,
+  onShortcutHelp,
+  onNavigate,
+}: KeyboardShortcutHandlers) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Ctrl/Cmd + K: コマンドパレット（入力中でも有効）
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        onCommandPalette();
+        return;
+      }
+
+      // テキスト入力中は以下のショートカットを無効化
+      if (isInputActive()) return;
+
+      // Shift は不要な単キーショートカット
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      switch (e.key) {
+        case "?":
+          e.preventDefault();
+          onShortcutHelp();
+          break;
+        case "n":
+        case "N":
+          e.preventDefault();
+          onNavigate("/interview/new");
+          break;
+        case "m":
+        case "M":
+          e.preventDefault();
+          onNavigate("/mock-interview");
+          break;
+        case "d":
+        case "D":
+          e.preventDefault();
+          onNavigate("/dashboard");
+          break;
+        case "g":
+        case "G":
+          e.preventDefault();
+          onNavigate("/dashboard/growth");
+          break;
+      }
+    },
+    [onCommandPalette, onShortcutHelp, onNavigate]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+}


### PR DESCRIPTION
## Summary
- `Ctrl/Cmd + K` でコマンドパレットを開閉。ファジー検索でページ・操作に素早くアクセス
- 単キーショートカット (`N`/`M`/`D`/`G`/`?`) でナビゲーション。テキスト入力中は自動無効化
- `?` キーでショートカット一覧ヘルプダイアログを表示
- コマンドパレットからテーマ切替 (ライト/ダーク/システム) が可能

## 変更ファイル
- `src/hooks/use-keyboard-shortcuts.ts` — グローバルキーボードショートカットフック
- `src/components/command-palette.tsx` — コマンドパレットコンポーネント
- `src/components/shortcut-help-dialog.tsx` — ショートカット一覧ダイアログ
- `src/components/ui/command.tsx` — shadcn/ui Command コンポーネント
- `src/components/ui/dialog.tsx` — shadcn/ui Dialog コンポーネント
- `src/app/layout.tsx` — CommandPalette をグローバル配置

## 受け入れ条件チェック
- [x] `Ctrl/Cmd + K` でコマンドパレットを開ける
- [x] `N` で新規面接記録ページに遷移
- [x] `M` で模擬面接ページに遷移
- [x] `D` でダッシュボードに遷移
- [x] `G` で成長記録ページに遷移
- [x] `Escape` でモーダルを閉じる
- [x] `?` でショートカット一覧ヘルプを表示
- [x] テキスト入力中はショートカットが無効
- [x] コマンドパレット内でファジー検索が可能

## Test plan
- [ ] `Ctrl+K` (Win) / `Cmd+K` (Mac) でコマンドパレットが開閉する
- [ ] パレット内で「面接」等を入力してファジー検索できる
- [ ] 各ナビゲーション項目を選択して正しいページに遷移する
- [ ] テーマ切替がコマンドパレットから動作する
- [ ] `N`/`M`/`D`/`G` キーで直接ナビゲーションできる
- [ ] `?` キーでヘルプダイアログが表示される
- [ ] テキスト入力中に `N` 等を押してもショートカットが発火しない
- [ ] `npm run build` が成功する

closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)