### PR TITLE
feat: #210 面接データの一括管理

### DIFF
--- a/src/app/api/interviews/bulk-action/route.ts
+++ b/src/app/api/interviews/bulk-action/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { unauthorized, badRequest, serverError } from "@/lib/api/error-response";
+
+/** 許可されるアクション種別 */
+const VALID_ACTIONS = ["archive", "unarchive", "soft_delete", "permanent_delete"] as const;
+type BulkAction = (typeof VALID_ACTIONS)[number];
+
+/** リクエストボディ型 */
+interface BulkActionRequest {
+  ids: string[];
+  action: BulkAction;
+}
+
+/** 一括操作の上限 */
+const MAX_BATCH_SIZE = 50;
+
+/**
+ * POST /api/interviews/bulk-action
+ *
+ * 面接データの一括アーカイブ / アーカイブ解除 / ソフトデリート / 完全削除
+ * RLS + user_id 検証で他ユーザーのデータは操作不可
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorized();
+    }
+
+    const body = (await request.json()) as BulkActionRequest;
+    const { ids, action } = body;
+
+    // --- バリデーション ---
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return badRequest("対象の面接を選択してください。");
+    }
+
+    if (ids.length > MAX_BATCH_SIZE) {
+      return badRequest(`一度に操作できるのは${MAX_BATCH_SIZE}件までです。`);
+    }
+
+    // UUID バリデーション
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!ids.every((id) => typeof id === "string" && uuidRegex.test(id))) {
+      return badRequest("無効なIDが含まれています。");
+    }
+
+    if (!VALID_ACTIONS.includes(action as BulkAction)) {
+      return badRequest("無効なアクションです。");
+    }
+
+    const now = new Date().toISOString();
+
+    switch (action) {
+      case "archive": {
+        const { error, count } = await supabase
+          .from("interviews")
+          .update({ archived_at: now } as never)
+          .in("id", ids)
+          .eq("user_id", user.id)
+          .is("deleted_at", null);
+
+        if (error) {
+          console.error("[bulk-action] archive error:", error.message);
+          return serverError("アーカイブに失敗しました。");
+        }
+
+        return NextResponse.json({ success: true, action, affected: count ?? ids.length });
+      }
+
+      case "unarchive": {
+        const { error, count } = await supabase
+          .from("interviews")
+          .update({ archived_at: null } as never)
+          .in("id", ids)
+          .eq("user_id", user.id)
+          .is("deleted_at", null);
+
+        if (error) {
+          console.error("[bulk-action] unarchive error:", error.message);
+          return serverError("アーカイブ解除に失敗しました。");
+        }
+
+        return NextResponse.json({ success: true, action, affected: count ?? ids.length });
+      }
+
+      case "soft_delete": {
+        const { error, count } = await supabase
+          .from("interviews")
+          .update({ deleted_at: now } as never)
+          .in("id", ids)
+          .eq("user_id", user.id)
+          .is("deleted_at", null);
+
+        if (error) {
+          console.error("[bulk-action] soft_delete error:", error.message);
+          return serverError("削除に失敗しました。");
+        }
+
+        return NextResponse.json({ success: true, action, affected: count ?? ids.length });
+      }
+
+      case "permanent_delete": {
+        // 完全削除: 関連テーブル(feedbacks, transcripts, interview_tags, shared_results)は CASCADE で削除される想定
+        // RLS で user_id 検証
+        const { error, count } = await supabase
+          .from("interviews")
+          .delete()
+          .in("id", ids)
+          .eq("user_id", user.id);
+
+        if (error) {
+          console.error("[bulk-action] permanent_delete error:", error.message);
+          return serverError("完全削除に失敗しました。");
+        }
+
+        return NextResponse.json({ success: true, action, affected: count ?? ids.length });
+      }
+
+      default:
+        return badRequest("無効なアクションです。");
+    }
+  } catch (error) {
+    console.error("[bulk-action] unexpected error:", error);
+    return serverError();
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -42,6 +42,7 @@ export default async function DashboardPage({
   const categoryParam = (params.category as string) || "all";
   const sortParam = (params.sort as string) || "date_desc";
   const tagParam = (params.tag as string) || "";
+  const tabParam = (params.tab as string) || "active";
 
   const currentCategory = [
     "arubaito",
@@ -61,6 +62,8 @@ export default async function DashboardPage({
   ].includes(sortParam)
     ? (sortParam as SortOption)
     : "date_desc";
+
+  const currentTab = tabParam === "archived" ? "archived" : "active" as const;
 
   // 利用状況を取得（ナッジバナー用）
   const usage = await getRemainingUsage(user.id);
@@ -116,6 +119,7 @@ export default async function DashboardPage({
           currentCategory={currentCategory}
           currentSort={currentSort}
           tagParam={tagParam}
+          currentTab={currentTab}
         />
       </Suspense>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,11 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
-import { CookieConsent } from "@/components/cookie-consent";
 import { ThemeProvider } from "@/components/theme-provider";
-import { SessionMonitor } from "@/components/session-monitor";
-import { MobileCTA } from "@/components/mobile-cta";
-import { CommandPalette } from "@/components/command-palette";
+import { ClientShell } from "@/components/client-shell";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -94,10 +91,7 @@ export default function RootLayout({
             <main className="flex-1">{children}</main>
             <Footer />
           </div>
-          <CommandPalette />
-          <SessionMonitor />
-          <MobileCTA />
-          <CookieConsent />
+          <ClientShell />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/client-shell.tsx
+++ b/src/components/client-shell.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const CookieConsent = dynamic(
+  () => import("@/components/cookie-consent").then((mod) => mod.CookieConsent),
+  { ssr: false }
+);
+const SessionMonitor = dynamic(
+  () =>
+    import("@/components/session-monitor").then((mod) => mod.SessionMonitor),
+  { ssr: false }
+);
+const MobileCTA = dynamic(
+  () => import("@/components/mobile-cta").then((mod) => mod.MobileCTA),
+  { ssr: false }
+);
+const CommandPalette = dynamic(
+  () =>
+    import("@/components/command-palette").then((mod) => mod.CommandPalette),
+  { ssr: false }
+);
+
+/**
+ * レイアウトで使用するクライアントコンポーネント群
+ * Next.js 16 では Server Component 内で dynamic({ ssr: false }) が禁止されたため、
+ * Client Component に分離して遅延ロードを実現する
+ */
+export function ClientShell() {
+  return (
+    <>
+      <CommandPalette />
+      <SessionMonitor />
+      <MobileCTA />
+      <CookieConsent />
+    </>
+  );
+}

--- a/src/components/dashboard/interview-list-client.tsx
+++ b/src/components/dashboard/interview-list-client.tsx
@@ -1,0 +1,562 @@
+"use client";
+
+import { useState, useCallback, useTransition, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Archive,
+  ArchiveRestore,
+  Trash2,
+  Search,
+  X,
+  CheckSquare,
+  Square,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { InterviewCard } from "@/components/interview-card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type {
+  InterviewCategory,
+  InterviewRound,
+  InterviewStatus,
+} from "@/types/database";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+interface TagData {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface InterviewItem {
+  id: string;
+  companyName: string;
+  category: InterviewCategory;
+  round: InterviewRound | null;
+  interviewDate: string | null;
+  overallScore: number | null;
+  status: InterviewStatus;
+  tags: TagData[];
+}
+
+type BulkAction = "archive" | "unarchive" | "soft_delete" | "permanent_delete";
+
+interface InterviewListClientProps {
+  interviews: InterviewItem[];
+  /** "active" | "archived" 現在のタブ */
+  currentTab: "active" | "archived";
+}
+
+// ============================================================
+// Component
+// ============================================================
+
+export function InterviewListClient({
+  interviews,
+  currentTab,
+}: InterviewListClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  // --- 検索 ---
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // --- 一括選択 ---
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectionMode, setSelectionMode] = useState(false);
+
+  // --- 確認ダイアログ ---
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState<BulkAction | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // --- 検索フィルタリング ---
+  const filteredInterviews = useMemo(() => {
+    if (!searchQuery.trim()) return interviews;
+    const query = searchQuery.trim().toLowerCase();
+    return interviews.filter(
+      (iv) =>
+        iv.companyName.toLowerCase().includes(query) ||
+        iv.tags.some((t) => t.name.toLowerCase().includes(query))
+    );
+  }, [interviews, searchQuery]);
+
+  // --- 選択ハンドラ ---
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedIds(new Set(filteredInterviews.map((iv) => iv.id)));
+  }, [filteredInterviews]);
+
+  const deselectAll = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const toggleSelectionMode = useCallback(() => {
+    setSelectionMode((prev) => {
+      if (prev) {
+        // 選択モード解除時にクリア
+        setSelectedIds(new Set());
+      }
+      return !prev;
+    });
+  }, []);
+
+  // --- 一括操作 ---
+  const requestBulkAction = useCallback((action: BulkAction) => {
+    setPendingAction(action);
+    setDialogOpen(true);
+  }, []);
+
+  const executeBulkAction = useCallback(async () => {
+    if (!pendingAction || selectedIds.size === 0) return;
+
+    setIsProcessing(true);
+    try {
+      const response = await fetch("/api/interviews/bulk-action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ids: Array.from(selectedIds),
+          action: pendingAction,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "操作に失敗しました");
+      }
+
+      // 成功: 選択解除 + ページ更新
+      setSelectedIds(new Set());
+      setSelectionMode(false);
+      setDialogOpen(false);
+      setPendingAction(null);
+
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (error) {
+      console.error("[bulk-action]", error);
+      alert(error instanceof Error ? error.message : "操作に失敗しました");
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [pendingAction, selectedIds, router]);
+
+  // --- 個別操作 ---
+  const handleSingleAction = useCallback(
+    async (id: string, action: BulkAction) => {
+      setSelectedIds(new Set([id]));
+      setPendingAction(action);
+      setDialogOpen(true);
+    },
+    []
+  );
+
+  // --- 検索クエリのURL反映（debounce不要: ローカルフィルタのみ） ---
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchQuery(value);
+      // 検索時に選択もクリア
+      setSelectedIds(new Set());
+    },
+    []
+  );
+
+  // --- タブ切替 ---
+  const handleTabChange = useCallback(
+    (tab: "active" | "archived") => {
+      const newParams = new URLSearchParams(searchParams.toString());
+      if (tab === "archived") {
+        newParams.set("tab", "archived");
+      } else {
+        newParams.delete("tab");
+      }
+      setSelectedIds(new Set());
+      setSelectionMode(false);
+      setSearchQuery("");
+      const qs = newParams.toString();
+      router.push(qs ? `/dashboard?${qs}` : "/dashboard");
+    },
+    [searchParams, router]
+  );
+
+  // --- ダイアログ用テキスト ---
+  const getDialogContent = useCallback(() => {
+    const count = selectedIds.size;
+    switch (pendingAction) {
+      case "archive":
+        return {
+          title: `${count}件の面接をアーカイブ`,
+          description:
+            "選択した面接をアーカイブします。アーカイブ済みタブからいつでも復元できます。",
+          actionLabel: "アーカイブする",
+          destructive: false,
+        };
+      case "unarchive":
+        return {
+          title: `${count}件の面接をアーカイブ解除`,
+          description: "選択した面接をアクティブに戻します。",
+          actionLabel: "アーカイブ解除する",
+          destructive: false,
+        };
+      case "soft_delete":
+        return {
+          title: `${count}件の面接を削除`,
+          description:
+            "選択した面接を削除します。削除後30日間は復元可能です。その後、完全に削除されます。",
+          actionLabel: "削除する",
+          destructive: true,
+        };
+      case "permanent_delete":
+        return {
+          title: `${count}件の面接を完全削除`,
+          description:
+            "選択した面接とすべての関連データ（フィードバック、文字起こし等）を完全に削除します。この操作は取り消せません。",
+          actionLabel: "完全に削除する",
+          destructive: true,
+        };
+      default:
+        return {
+          title: "",
+          description: "",
+          actionLabel: "",
+          destructive: false,
+        };
+    }
+  }, [pendingAction, selectedIds.size]);
+
+  const dialogContent = getDialogContent();
+
+  return (
+    <div className="space-y-4">
+      {/* タブ切替 + 検索バー */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {/* タブ */}
+        <div className="flex items-center gap-1 rounded-lg bg-muted p-1">
+          <button
+            type="button"
+            onClick={() => handleTabChange("active")}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              currentTab === "active"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            アクティブ
+          </button>
+          <button
+            type="button"
+            onClick={() => handleTabChange("archived")}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              currentTab === "archived"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            アーカイブ済み
+          </button>
+        </div>
+
+        {/* 検索バー */}
+        <div className="relative w-full sm:w-64">
+          <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="企業名・タグで検索..."
+            value={searchQuery}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="pl-9 pr-8"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => handleSearchChange("")}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 一括操作バー */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant={selectionMode ? "secondary" : "outline"}
+          size="sm"
+          onClick={toggleSelectionMode}
+        >
+          {selectionMode ? (
+            <>
+              <CheckSquare className="mr-1 h-4 w-4" />
+              選択モード: ON
+            </>
+          ) : (
+            <>
+              <Square className="mr-1 h-4 w-4" />
+              一括選択
+            </>
+          )}
+        </Button>
+
+        {selectionMode && (
+          <>
+            <Button variant="ghost" size="sm" onClick={selectAll}>
+              全選択 ({filteredInterviews.length})
+            </Button>
+            {selectedIds.size > 0 && (
+              <Button variant="ghost" size="sm" onClick={deselectAll}>
+                選択解除
+              </Button>
+            )}
+
+            <span className="text-sm text-muted-foreground">
+              {selectedIds.size}件選択中
+            </span>
+
+            {selectedIds.size > 0 && (
+              <div className="flex items-center gap-1 ml-auto">
+                {currentTab === "active" ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => requestBulkAction("archive")}
+                    >
+                      <Archive className="mr-1 h-4 w-4" />
+                      アーカイブ
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => requestBulkAction("soft_delete")}
+                    >
+                      <Trash2 className="mr-1 h-4 w-4" />
+                      削除
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => requestBulkAction("unarchive")}
+                    >
+                      <ArchiveRestore className="mr-1 h-4 w-4" />
+                      アーカイブ解除
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => requestBulkAction("permanent_delete")}
+                    >
+                      <Trash2 className="mr-1 h-4 w-4" />
+                      完全削除
+                    </Button>
+                  </>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* 面接カード一覧 */}
+      {filteredInterviews.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Search className="h-12 w-12 text-muted-foreground/50 mb-4" />
+          <p className="text-sm text-muted-foreground">
+            {searchQuery
+              ? `"${searchQuery}" に一致する面接が見つかりません`
+              : currentTab === "archived"
+              ? "アーカイブされた面接はありません"
+              : "面接データがありません"}
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredInterviews.map((interview) => (
+            <div key={interview.id} className="relative group">
+              {/* 選択モード時のチェックボックス */}
+              {selectionMode && (
+                <div className="absolute top-3 left-3 z-10">
+                  <Checkbox
+                    checked={selectedIds.has(interview.id)}
+                    onCheckedChange={() => toggleSelect(interview.id)}
+                    aria-label={`${interview.companyName} を選択`}
+                    className="bg-background"
+                  />
+                </div>
+              )}
+
+              {/* 個別アクションメニュー（非選択モード時） */}
+              {!selectionMode && (
+                <div className="absolute top-3 right-3 z-10 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  {currentTab === "active" ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleSingleAction(interview.id, "archive");
+                        }}
+                        className="rounded-md bg-background/80 backdrop-blur-sm p-1.5 text-muted-foreground hover:text-foreground hover:bg-background shadow-sm border"
+                        title="アーカイブ"
+                      >
+                        <Archive className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleSingleAction(interview.id, "soft_delete");
+                        }}
+                        className="rounded-md bg-background/80 backdrop-blur-sm p-1.5 text-muted-foreground hover:text-destructive hover:bg-background shadow-sm border"
+                        title="削除"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleSingleAction(interview.id, "unarchive");
+                        }}
+                        className="rounded-md bg-background/80 backdrop-blur-sm p-1.5 text-muted-foreground hover:text-foreground hover:bg-background shadow-sm border"
+                        title="アーカイブ解除"
+                      >
+                        <ArchiveRestore className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleSingleAction(interview.id, "permanent_delete");
+                        }}
+                        className="rounded-md bg-background/80 backdrop-blur-sm p-1.5 text-muted-foreground hover:text-destructive hover:bg-background shadow-sm border"
+                        title="完全削除"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* 選択モード時のクリックで選択切替 */}
+              {selectionMode ? (
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => toggleSelect(interview.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      toggleSelect(interview.id);
+                    }
+                  }}
+                  className={`cursor-pointer rounded-xl ring-2 transition-all ${
+                    selectedIds.has(interview.id)
+                      ? "ring-primary"
+                      : "ring-transparent"
+                  }`}
+                >
+                  <InterviewCard
+                    id={interview.id}
+                    companyName={interview.companyName}
+                    category={interview.category}
+                    round={interview.round}
+                    interviewDate={interview.interviewDate}
+                    overallScore={interview.overallScore}
+                    status={interview.status}
+                    tags={interview.tags}
+                  />
+                </div>
+              ) : (
+                <InterviewCard
+                  id={interview.id}
+                  companyName={interview.companyName}
+                  category={interview.category}
+                  round={interview.round}
+                  interviewDate={interview.interviewDate}
+                  overallScore={interview.overallScore}
+                  status={interview.status}
+                  tags={interview.tags}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 確認ダイアログ */}
+      <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dialogContent.title}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {dialogContent.description}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={isProcessing}
+              onClick={() => {
+                setPendingAction(null);
+                // 個別操作で設定されたselectedIdsもクリア
+                if (!selectionMode) {
+                  setSelectedIds(new Set());
+                }
+              }}
+            >
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={executeBulkAction}
+              disabled={isProcessing}
+              className={
+                dialogContent.destructive
+                  ? "bg-destructive text-white hover:bg-destructive/90"
+                  : ""
+              }
+            >
+              {isProcessing ? "処理中..." : dialogContent.actionLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/dashboard/interview-list-section.tsx
+++ b/src/components/dashboard/interview-list-section.tsx
@@ -1,7 +1,7 @@
 import { Plus, ClipboardList, MessageSquare, BookOpen } from "lucide-react";
 import { EmptyState } from "@/components/ui/empty-state";
-import { InterviewCard } from "@/components/interview-card";
 import { InterviewFilter, type SortOption } from "@/components/interview-filter";
+import { InterviewListClient, type InterviewItem } from "@/components/dashboard/interview-list-client";
 import { createClient } from "@/lib/supabase/server";
 import type { Database, InterviewCategory } from "@/types/database";
 
@@ -25,6 +25,8 @@ interface InterviewListSectionProps {
   currentCategory: InterviewCategory | "all";
   currentSort: SortOption;
   tagParam: string;
+  /** "active" | "archived" — デフォルト "active" */
+  currentTab?: "active" | "archived";
 }
 
 /**
@@ -36,6 +38,7 @@ export async function InterviewListSection({
   currentCategory,
   currentSort,
   tagParam,
+  currentTab = "active",
 }: InterviewListSectionProps) {
   const supabase = await createClient();
 
@@ -44,9 +47,18 @@ export async function InterviewListSection({
   let interviewQuery = supabase
     .from("interviews")
     .select(
-      "id, title, company_name_snapshot, interview_category, interview_round, interview_date, status"
+      "id, title, company_name_snapshot, interview_category, interview_round, interview_date, status, archived_at, deleted_at"
     )
-    .eq("user_id", userId);
+    .eq("user_id", userId)
+    // ソフトデリートされたレコードは除外
+    .is("deleted_at", null);
+
+  // タブに応じてアーカイブフィルタ
+  if (currentTab === "archived") {
+    interviewQuery = interviewQuery.not("archived_at", "is", null);
+  } else {
+    interviewQuery = interviewQuery.is("archived_at", null);
+  }
 
   if (currentCategory !== "all") {
     interviewQuery = interviewQuery.eq("interview_category", currentCategory);
@@ -151,6 +163,25 @@ export async function InterviewListSection({
     });
   }
 
+  // Client Component に渡すデータを整形
+  const interviewItems: InterviewItem[] = interviewsWithScore.map((iv) => ({
+    id: iv.id,
+    companyName: iv.company_name_snapshot,
+    category: iv.interview_category,
+    round: iv.interview_round,
+    interviewDate: iv.interview_date,
+    overallScore: iv.overallScore,
+    status: iv.status,
+    tags: iv.tags.map((t) => ({ id: t.id, name: t.name, color: t.color })),
+  }));
+
+  // 面接が一件もない場合（フィルタなし・アクティブタブの初回状態）
+  const isEmptyWithoutFilters =
+    currentTab === "active" &&
+    currentCategory === "all" &&
+    !tagParam &&
+    interviewsWithScore.length === 0;
+
   return (
     <>
       {/* フィルタ・ソート */}
@@ -166,60 +197,56 @@ export async function InterviewListSection({
 
       {/* 一覧 */}
       <div className="mt-6">
-        {interviewsWithScore.length === 0 ? (
-          currentCategory !== "all" || tagParam ? (
-            <EmptyState
-              icon={ClipboardList}
-              title="条件に一致する面接がありません"
-              description="フィルタ条件を変更するか、新しい面接を記録してください。"
-              primaryAction={{
-                label: "新規面接を記録",
-                href: "/interview/new",
-                icon: Plus,
-              }}
-              variant="no-results"
-            />
-          ) : (
-            <EmptyState
-              icon={ClipboardList}
-              title="さっそく面接練習を始めましょう！"
-              description="面接を記録してAIフィードバックを受けると、ここにスコアや改善点が表示されます。"
-              primaryAction={{
-                label: "面接を記録する",
-                href: "/interview/new",
-                icon: Plus,
-              }}
-              secondaryActions={[
-                {
-                  label: "AI模擬面接を試す",
-                  href: "/mock-interview",
-                  icon: MessageSquare,
-                },
-                {
-                  label: "質問集を見る",
-                  href: "/question-bank",
-                  icon: BookOpen,
-                },
-              ]}
-            />
-          )
-        ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {interviewsWithScore.map((interview) => (
-              <InterviewCard
-                key={interview.id}
-                id={interview.id}
-                companyName={interview.company_name_snapshot}
-                category={interview.interview_category}
-                round={interview.interview_round}
-                interviewDate={interview.interview_date}
-                overallScore={interview.overallScore}
-                status={interview.status}
-                tags={interview.tags}
+        {isEmptyWithoutFilters ? (
+          <EmptyState
+            icon={ClipboardList}
+            title="さっそく面接練習を始めましょう！"
+            description="面接を記録してAIフィードバックを受けると、ここにスコアや改善点が表示されます。"
+            primaryAction={{
+              label: "面接を記録する",
+              href: "/interview/new",
+              icon: Plus,
+            }}
+            secondaryActions={[
+              {
+                label: "AI模擬面接を試す",
+                href: "/mock-interview",
+                icon: MessageSquare,
+              },
+              {
+                label: "質問集を見る",
+                href: "/question-bank",
+                icon: BookOpen,
+              },
+            ]}
+          />
+        ) : currentCategory !== "all" || tagParam
+          ? interviewsWithScore.length === 0
+            ? (
+              <EmptyState
+                icon={ClipboardList}
+                title="条件に一致する面接がありません"
+                description="フィルタ条件を変更するか、新しい面接を記録してください。"
+                primaryAction={{
+                  label: "新規面接を記録",
+                  href: "/interview/new",
+                  icon: Plus,
+                }}
+                variant="no-results"
               />
-            ))}
-          </div>
-        )}
+            )
+            : (
+              <InterviewListClient
+                interviews={interviewItems}
+                currentTab={currentTab}
+              />
+            )
+          : (
+            <InterviewListClient
+              interviews={interviewItems}
+              currentTab={currentTab}
+            />
+          )}
       </div>
     </>
   );

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -218,6 +218,8 @@ export interface Database {
           transcript: string | null;
           transcript_char_count: number;
           notes: string | null;
+          archived_at: string | null;
+          deleted_at: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -236,6 +238,8 @@ export interface Database {
           transcript?: string | null;
           transcript_char_count?: number;
           notes?: string | null;
+          archived_at?: string | null;
+          deleted_at?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -254,6 +258,8 @@ export interface Database {
           transcript?: string | null;
           transcript_char_count?: number;
           notes?: string | null;
+          archived_at?: string | null;
+          deleted_at?: string | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/supabase/migrations/00011_interview_archive_delete.sql
+++ b/supabase/migrations/00011_interview_archive_delete.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- Issue #210: 面接データの一括管理 — アーカイブ・一括削除・検索機能
+-- ============================================================
+
+-- interviews テーブルに archived_at, deleted_at カラムを追加
+ALTER TABLE interviews
+  ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ DEFAULT NULL;
+
+-- インデックス追加（ソフトデリート・アーカイブフィルタ用）
+CREATE INDEX IF NOT EXISTS idx_interviews_deleted_at ON interviews (deleted_at);
+CREATE INDEX IF NOT EXISTS idx_interviews_archived_at ON interviews (archived_at);
+CREATE INDEX IF NOT EXISTS idx_interviews_user_deleted ON interviews (user_id, deleted_at);
+
+-- 検索用: company_name_snapshot の trigram インデックス（ilike 検索高速化）
+-- pg_trgm 拡張が利用可能な場合に有効
+-- CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- CREATE INDEX IF NOT EXISTS idx_interviews_company_trgm ON interviews USING gin (company_name_snapshot gin_trgm_ops);
+
+COMMENT ON COLUMN interviews.archived_at IS 'アーカイブ日時。NULLならアクティブ。';
+COMMENT ON COLUMN interviews.deleted_at IS 'ソフトデリート日時。NULLなら未削除。30日後に完全削除。';


### PR DESCRIPTION
## Summary
- 面接データのアーカイブ・一括削除・キーワード検索機能を追加
- アクティブ/アーカイブ済みタブで表示を切替
- チェックボックスによる一括選択 + 確認ダイアログ付き一括操作（アーカイブ・削除・完全削除）
- 企業名・タグによるローカルキーワード検索
- ソフトデリート（deleted_at）とアーカイブ（archived_at）のDB設計

## 変更内容
- `POST /api/interviews/bulk-action` — 一括操作API（archive/unarchive/soft_delete/permanent_delete）
- `InterviewListClient` — 検索・一括選択・タブ切替のClient Component
- `InterviewListSection` — archived_at / deleted_at フィルタ対応
- `AlertDialog` / `Checkbox` — shadcn/ui コンポーネント追加
- `00011_interview_archive_delete.sql` — マイグレーション（archived_at, deleted_at カラム + インデックス）
- `ClientShell` — Next.js 16 の dynamic ssr:false 制限対応

## Test plan
- [ ] ダッシュボードでアクティブ/アーカイブタブが切替できること
- [ ] 検索バーで企業名・タグ名による絞り込みができること
- [ ] 一括選択モードで複数面接を選択し、アーカイブ・削除できること
- [ ] 確認ダイアログが表示され、キャンセルで操作が中止されること
- [ ] アーカイブ済みタブからアーカイブ解除・完全削除ができること
- [ ] 個別カードのホバーアクションで個別操作ができること
- [ ] RLSにより他ユーザーのデータが操作されないこと
- [ ] `npm run build` が成功すること

closes #210