### PR TITLE
feat: #212 E2Eテスト拡充（Playwright）

### DIFF
--- a/e2e/auth-flow.spec.ts
+++ b/e2e/auth-flow.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from "@playwright/test";
+
+// ============================================================
+// 認証フロー — ページ UI 確認 & 未認証リダイレクト
+// ============================================================
+
+test.describe("ログインページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+  });
+
+  test("ページタイトルが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "ログイン" })
+    ).toBeVisible();
+  });
+
+  test("メールアドレスとパスワードの入力欄が表示される", async ({ page }) => {
+    await expect(page.getByLabel("メールアドレス")).toBeVisible();
+    await expect(page.getByLabel("パスワード")).toBeVisible();
+  });
+
+  test("ログインボタンが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "ログイン" })
+    ).toBeVisible();
+  });
+
+  test("サインアップへのリンクが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "サインアップ" })
+    ).toBeVisible();
+  });
+
+  test("パスワードを忘れた方リンクが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "パスワードを忘れた方" })
+    ).toBeVisible();
+  });
+
+  test("空フォームでは送信されない（HTML バリデーション）", async ({ page }) => {
+    const emailInput = page.getByLabel("メールアドレス");
+    // required 属性を確認
+    await expect(emailInput).toHaveAttribute("required", "");
+  });
+
+  test("サインアップリンクが /signup に遷移する", async ({ page }) => {
+    await page.getByRole("link", { name: "サインアップ" }).click();
+    await expect(page).toHaveURL(/\/signup/);
+  });
+
+  test("パスワードリセットリンクが /reset-password に遷移する", async ({
+    page,
+  }) => {
+    await page.getByRole("link", { name: "パスワードを忘れた方" }).click();
+    await expect(page).toHaveURL(/\/reset-password/);
+  });
+});
+
+test.describe("サインアップページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/signup");
+  });
+
+  test("ページタイトルが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "アカウント作成" })
+    ).toBeVisible();
+  });
+
+  test("メールアドレスとパスワードの入力欄が表示される", async ({ page }) => {
+    await expect(page.getByLabel("メールアドレス")).toBeVisible();
+    await expect(page.getByLabel("パスワード")).toBeVisible();
+  });
+
+  test("利用規約とプライバシーポリシーへの同意チェックボックスが表示される", async ({
+    page,
+  }) => {
+    await expect(page.getByText("利用規約")).toBeVisible();
+    await expect(page.getByText("プライバシーポリシー")).toBeVisible();
+  });
+
+  test("サインアップボタンは同意チェック前は無効", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "サインアップ" })
+    ).toBeDisabled();
+  });
+
+  test("同意チェック後にサインアップボタンが有効になる", async ({ page }) => {
+    await page.getByLabel(/利用規約/).check();
+    await expect(
+      page.getByRole("button", { name: "サインアップ" })
+    ).toBeEnabled();
+  });
+
+  test("ログインへのリンクが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "ログイン" })
+    ).toBeVisible();
+  });
+
+  test("ログインリンクが /login に遷移する", async ({ page }) => {
+    await page.getByRole("link", { name: "ログイン" }).click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+test.describe("パスワードリセットページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/reset-password");
+  });
+
+  test("ページタイトルが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "パスワードリセット" })
+    ).toBeVisible();
+  });
+
+  test("メールアドレス入力欄が表示される", async ({ page }) => {
+    await expect(page.getByLabel("メールアドレス")).toBeVisible();
+  });
+
+  test("リセットメール送信ボタンが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "リセットメールを送信" })
+    ).toBeVisible();
+  });
+
+  test("ログインページに戻るリンクが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "ログインページに戻る" })
+    ).toBeVisible();
+  });
+});
+
+test.describe("認証リダイレクト — 追加パス", () => {
+  test("ES添削ページは未認証でログインにリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/es-review");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("ES添削履歴ページは未認証でログインにリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/es-review/history");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("プロフィールページは未認証でログインにリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/profile");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("オンボーディングページは未認証でログインにリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/onboarding");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("プラン管理ページは未認証でログインにリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/settings/billing");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("面接記録作成ページは未認証でログインにリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/interview/new");
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "@playwright/test";
+
+// ============================================================
+// ダークモード切替 E2E テスト
+// ============================================================
+
+test.describe("ダークモード切替", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("テーマ切替ボタンが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "テーマを切り替え" })
+    ).toBeVisible();
+  });
+
+  test("ダークモードに切り替えるとhtml要素にdarkクラスが付与される", async ({
+    page,
+  }) => {
+    // テーマ切替ボタンをクリック
+    await page.getByRole("button", { name: "テーマを切り替え" }).click();
+
+    // ダークを選択
+    await page.getByRole("menuitem", { name: "ダーク" }).click();
+
+    // html 要素に dark クラスが付与されることを確認
+    await expect(page.locator("html")).toHaveClass(/dark/);
+  });
+
+  test("ライトモードに切り替えるとhtml要素にlightクラスが付与される", async ({
+    page,
+  }) => {
+    // テーマ切替ボタンをクリック
+    await page.getByRole("button", { name: "テーマを切り替え" }).click();
+
+    // ライトを選択
+    await page.getByRole("menuitem", { name: "ライト" }).click();
+
+    // html 要素に light クラスが付与されることを確認
+    await expect(page.locator("html")).toHaveClass(/light/);
+  });
+
+  test("システムモードに切り替えるとhtml要素のクラスが正しく設定される", async ({
+    page,
+  }) => {
+    // テーマ切替ボタンをクリック
+    await page.getByRole("button", { name: "テーマを切り替え" }).click();
+
+    // システムを選択
+    await page.getByRole("menuitem", { name: "システム" }).click();
+
+    // html 要素に light か dark のどちらかのクラスが付与されている
+    const htmlClass = await page.locator("html").getAttribute("class");
+    expect(htmlClass).toMatch(/light|dark/);
+  });
+
+  test("ダークモードでもランディングページの主要コンテンツが表示される", async ({
+    page,
+  }) => {
+    // ダークモードに切り替え
+    await page.getByRole("button", { name: "テーマを切り替え" }).click();
+    await page.getByRole("menuitem", { name: "ダーク" }).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+
+    // ヒーローセクションが引き続き表示されている
+    await expect(
+      page.getByRole("heading", { level: 1 })
+    ).toBeVisible();
+
+    // ヘッダーのロゴが表示されている
+    await expect(
+      page.getByRole("link", { name: /InterviewCoach/ }).first()
+    ).toBeVisible();
+
+    // フッターが表示されている
+    await expect(
+      page.locator("footer").getByText("InterviewCoach. All rights reserved.")
+    ).toBeVisible();
+  });
+
+  test("テーマ設定がページ遷移後も維持される", async ({ page }) => {
+    // ダークモードに切り替え
+    await page.getByRole("button", { name: "テーマを切り替え" }).click();
+    await page.getByRole("menuitem", { name: "ダーク" }).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+
+    // 別のページに遷移
+    await page.goto("/pricing");
+    await page.waitForLoadState("domcontentloaded");
+
+    // ダークモードが維持されている
+    await expect(page.locator("html")).toHaveClass(/dark/);
+  });
+
+  test("ダークモードでテーマ切替ドロップダウンの選択状態が正しい", async ({
+    page,
+  }) => {
+    // ダークモードに切り替え
+    await page.getByRole("button", { name: "テーマを切り替え" }).click();
+    await page.getByRole("menuitem", { name: "ダーク" }).click();
+
+    // もう一度開いて「ダーク」が強調されていることを確認
+    await page.getByRole("button", { name: "テーマを切り替え" }).click();
+    const darkItem = page.getByRole("menuitem", { name: "ダーク" });
+    await expect(darkItem).toHaveClass(/font-semibold/);
+  });
+});

--- a/e2e/dashboard-mock.spec.ts
+++ b/e2e/dashboard-mock.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect } from "@playwright/test";
+
+// ============================================================
+// ダッシュボード & 模擬面接 — API モックを使った認証済みテスト
+// ============================================================
+
+/**
+ * Supabase Auth API をモックして認証済みセッションを偽装するヘルパー。
+ * page.route() で Supabase のセッション取得をインターセプトする。
+ */
+async function mockAuthenticated(page: import("@playwright/test").Page) {
+  const fakeUser = {
+    id: "00000000-0000-0000-0000-000000000001",
+    email: "test@example.com",
+    aud: "authenticated",
+    role: "authenticated",
+    email_confirmed_at: "2025-01-01T00:00:00Z",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    app_metadata: { provider: "email" },
+    user_metadata: {},
+  };
+
+  const fakeSession = {
+    access_token: "fake-access-token",
+    token_type: "bearer",
+    expires_in: 3600,
+    refresh_token: "fake-refresh-token",
+    user: fakeUser,
+  };
+
+  // Supabase の getUser / getSession をモック
+  await page.route("**/auth/v1/user", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(fakeUser),
+    })
+  );
+
+  await page.route("**/auth/v1/token?grant_type=refresh_token", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(fakeSession),
+    })
+  );
+
+  // profiles テーブルクエリをモック（オンボーディング完了済み）
+  await page.route("**/rest/v1/profiles*", (route) => {
+    const url = route.request().url();
+    if (url.includes("select=onboarding_completed")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ onboarding_completed: true }),
+      });
+    }
+    // 他の profiles クエリ
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        onboarding_completed: true,
+        target_industry: ["IT"],
+        personality_type: "INTJ",
+      }),
+    });
+  });
+}
+
+test.describe("ダッシュボード — 面接一覧（モック認証）", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
+
+    // interviews テーブルクエリをモック
+    await page.route("**/rest/v1/interviews*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: { "content-range": "0-2/3" },
+        body: JSON.stringify([
+          {
+            id: "int-001",
+            title: "テスト面接1",
+            category: "new_grad",
+            overall_score: 75,
+            created_at: "2025-12-01T10:00:00Z",
+            is_archived: false,
+            tags: ["IT"],
+          },
+          {
+            id: "int-002",
+            title: "テスト面接2",
+            category: "intern",
+            overall_score: 85,
+            created_at: "2025-12-02T10:00:00Z",
+            is_archived: false,
+            tags: ["金融"],
+          },
+          {
+            id: "int-003",
+            title: "テスト面接3",
+            category: "arubaito",
+            overall_score: 60,
+            created_at: "2025-11-30T10:00:00Z",
+            is_archived: false,
+            tags: [],
+          },
+        ]),
+      })
+    );
+
+    // 利用状況 API をモック
+    await page.route("**/rest/v1/subscriptions*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          plan: "free",
+          status: "active",
+          current_period_end: "2026-12-31T00:00:00Z",
+        }),
+      })
+    );
+
+    // usage_logs をモック
+    await page.route("**/rest/v1/usage_logs*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      })
+    );
+
+    // weekly summary をモック
+    await page.route("**/rest/v1/weekly_summaries*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      })
+    );
+  });
+
+  test("ダッシュボードが表示される", async ({ page }) => {
+    await page.goto("/dashboard");
+    // ダッシュボードのヘッダー or タイトルが表示されることを確認
+    // リダイレクトされずにダッシュボードに留まる
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+});
+
+test.describe("模擬面接セットアップ — フォームバリデーション（モック認証）", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
+  });
+
+  test("模擬面接ページが表示される（認証モック）", async ({ page }) => {
+    await page.goto("/mock-interview");
+    // リダイレクトされずに模擬面接ページに留まる
+    await expect(page).toHaveURL(/\/mock-interview/);
+  });
+});
+
+test.describe("ES添削 — フォームバリデーション（モック認証）", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthenticated(page);
+  });
+
+  test("ES添削ページが表示される（認証モック）", async ({ page }) => {
+    await page.goto("/es-review");
+    // ES添削ページにリダイレクトされずに留まるか、ロード完了を確認
+    // クライアントサイド認証なので、Supabase の auth/v1/user を通して認証を偽装
+    await expect(page).toHaveURL(/\/es-review/);
+  });
+
+  test("ES添削フォームの質問例が表示される", async ({ page }) => {
+    await page.goto("/es-review");
+    // フォームが表示されるまで待つ
+    await expect(
+      page.getByText("学生時代に力を入れたことは何ですか？")
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("ES添削フォームに回答が短すぎるとエラーが出る", async ({ page }) => {
+    await page.goto("/es-review");
+
+    // フォームのロードを待つ
+    await page.waitForSelector('textarea', { timeout: 10_000 });
+
+    // 質問を入力
+    const questionInput = page.getByLabel(/質問/);
+    if (await questionInput.isVisible()) {
+      await questionInput.fill("テスト質問です");
+    }
+
+    // 短すぎる回答を入力
+    const answerTextarea = page.locator("textarea").first();
+    await answerTextarea.fill("短い回答");
+
+    // 送信ボタンをクリック
+    const submitButton = page.getByRole("button", { name: /添削/ });
+    if (await submitButton.isVisible()) {
+      await submitButton.click();
+      // バリデーションエラーが表示されることを確認
+      await expect(page.getByText(/50文字以上/)).toBeVisible({ timeout: 5_000 });
+    }
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from "@playwright/test";
+
+// ============================================================
+// ヘッダー・フッター ナビゲーション E2E テスト
+// ============================================================
+
+test.describe("ヘッダーナビゲーション（未ログイン）", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("ロゴが表示されトップページにリンクしている", async ({ page }) => {
+    const logo = page.getByRole("link", { name: /InterviewCoach/ }).first();
+    await expect(logo).toBeVisible();
+    await expect(logo).toHaveAttribute("href", "/");
+  });
+
+  test("質問集リンクが表示される", async ({ page }) => {
+    // Desktop nav（md 以上で表示）
+    await expect(
+      page.getByRole("link", { name: "質問集" }).first()
+    ).toBeVisible();
+  });
+
+  test("16パーソナリティリンクが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "16パーソナリティ" }).first()
+    ).toBeVisible();
+  });
+
+  test("ログインボタンが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: "ログイン" }).first()
+    ).toBeVisible();
+  });
+
+  test("無料体験ボタンが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("link", { name: /無料体験/ }).first()
+    ).toBeVisible();
+  });
+
+  test("質問集リンクが /questions に遷移する", async ({ page }) => {
+    await page.getByRole("link", { name: "質問集" }).first().click();
+    await expect(page).toHaveURL(/\/questions/);
+  });
+
+  test("16パーソナリティリンクが /personality に遷移する", async ({ page }) => {
+    await page
+      .getByRole("link", { name: "16パーソナリティ" })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/personality/);
+  });
+
+  test("ログインリンクが /login に遷移する", async ({ page }) => {
+    await page.getByRole("link", { name: "ログイン" }).first().click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("無料体験ボタンが /signup に遷移する", async ({ page }) => {
+    await page.getByRole("link", { name: /無料体験/ }).first().click();
+    await expect(page).toHaveURL(/\/signup/);
+  });
+
+  test("テーマ切り替えボタンが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "テーマを切り替え" })
+    ).toBeVisible();
+  });
+});
+
+test.describe("フッターナビゲーション", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("利用規約リンクが /legal/terms に遷移する", async ({ page }) => {
+    const footer = page.locator("footer");
+    await footer.getByRole("link", { name: "利用規約" }).click();
+    await expect(page).toHaveURL(/\/legal\/terms/);
+  });
+
+  test("プライバシーポリシーリンクが /legal/privacy に遷移する", async ({
+    page,
+  }) => {
+    const footer = page.locator("footer");
+    await footer.getByRole("link", { name: "プライバシーポリシー" }).click();
+    await expect(page).toHaveURL(/\/legal\/privacy/);
+  });
+
+  test("Cookie ポリシーリンクが /legal/cookies に遷移する", async ({
+    page,
+  }) => {
+    const footer = page.locator("footer");
+    await footer.getByRole("link", { name: "Cookie ポリシー" }).click();
+    await expect(page).toHaveURL(/\/legal\/cookies/);
+  });
+
+  test("特定商取引法リンクが /legal/tokushoho に遷移する", async ({
+    page,
+  }) => {
+    const footer = page.locator("footer");
+    await footer
+      .getByRole("link", { name: "特定商取引法に基づく表記" })
+      .click();
+    await expect(page).toHaveURL(/\/legal\/tokushoho/);
+  });
+});
+
+test.describe("クロスページナビゲーション", () => {
+  test("トップ → 質問集 → 質問詳細 → パンくずで戻る", async ({ page }) => {
+    // トップページから質問集へ
+    await page.goto("/");
+    await page.getByRole("link", { name: "質問集" }).first().click();
+    await expect(page).toHaveURL(/\/questions/);
+
+    // 最初の質問カードをクリック
+    const firstCard = page.locator('a[href^="/questions/q"]').first();
+    await firstCard.click();
+    await expect(page).toHaveURL(/\/questions\/q\d+/);
+
+    // パンくずで質問集に戻る
+    await page.getByRole("link", { name: "面接質問集に戻る" }).click();
+    await expect(page).toHaveURL(/\/questions$/);
+  });
+
+  test("トップ → パーソナリティ一覧 → タイプ詳細 → パンくずで戻る", async ({
+    page,
+  }) => {
+    // トップからパーソナリティへ
+    await page.goto("/");
+    await page
+      .getByRole("link", { name: "16パーソナリティ" })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/personality/);
+
+    // INTJ カードをクリック
+    await page.getByRole("link", { name: /INTJ/ }).first().click();
+    await expect(page).toHaveURL(/\/personality\/intj/);
+
+    // パンくずで一覧に戻る
+    await page
+      .getByRole("link", { name: /16パーソナリティ一覧/ })
+      .click();
+    await expect(page).toHaveURL(/\/personality$/);
+  });
+
+  test("料金ページから各プランのサインアップリンクが機能する", async ({
+    page,
+  }) => {
+    await page.goto("/pricing");
+
+    // 無料で始めるリンクをクリック
+    await page.getByRole("link", { name: "無料で始める" }).click();
+    await expect(page).toHaveURL(/\/signup/);
+  });
+
+  test("法的ページ間のリンク遷移", async ({ page }) => {
+    // 利用規約ページへ
+    await page.goto("/legal/terms");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "利用規約" })
+    ).toBeVisible();
+
+    // トップページに戻る
+    await page.getByRole("link", { name: "トップページに戻る" }).click();
+    await expect(page).toHaveURL("/");
+  });
+});
+
+test.describe("モバイルナビゲーション", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("ハンバーガーメニューが表示される", async ({ page }) => {
+    await page.goto("/");
+    // モバイルではハンバーガーメニューボタンが表示される
+    const menuButton = page.locator("button").filter({ has: page.locator('svg.lucide-menu') });
+    await expect(menuButton).toBeVisible();
+  });
+
+  test("ハンバーガーメニューを開くとナビリンクが表示される", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // ハンバーガーメニューをクリック
+    const menuButton = page.locator("button").filter({ has: page.locator('svg.lucide-menu') });
+    await menuButton.click();
+
+    // シートメニュー内にナビリンクが表示される
+    await expect(page.getByRole("link", { name: "質問集" }).last()).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "16パーソナリティ" }).last()
+    ).toBeVisible();
+  });
+});

--- a/e2e/questions-detail.spec.ts
+++ b/e2e/questions-detail.spec.ts
@@ -1,0 +1,259 @@
+import { test, expect } from "@playwright/test";
+
+// ============================================================
+// 質問集ページ — フィルタリング・質問詳細テスト
+// ============================================================
+
+test.describe("質問集ページ — フィルタリング", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/questions");
+  });
+
+  test("ページタイトルが表示される", async ({ page }) => {
+    await expect(page).toHaveTitle(/面接質問集/);
+  });
+
+  test("見出しが表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { level: 1, name: "面接質問集" })
+    ).toBeVisible();
+  });
+
+  test("全件数が表示される", async ({ page }) => {
+    // "全 N 問 収録" の表示を確認
+    await expect(page.getByText(/全 \d+ 問 収録/)).toBeVisible();
+  });
+
+  test("絞り込み検索カードが表示される", async ({ page }) => {
+    await expect(page.getByText("絞り込み検索")).toBeVisible();
+  });
+
+  test("業界フィルタボタンが表示される", async ({ page }) => {
+    const industries = ["IT", "金融", "コンサル", "メーカー", "商社"];
+    for (const industry of industries) {
+      await expect(
+        page.getByRole("button", { name: industry, exact: true })
+      ).toBeVisible();
+    }
+  });
+
+  test("面接ラウンドフィルタボタンが表示される", async ({ page }) => {
+    const rounds = ["1次", "2次", "最終", "GD", "ケース"];
+    for (const round of rounds) {
+      await expect(
+        page.getByRole("button", { name: round, exact: true })
+      ).toBeVisible();
+    }
+  });
+
+  test("質問タイプフィルタボタンが表示される", async ({ page }) => {
+    const types = ["自己PR", "志望動機", "ガクチカ", "逆質問"];
+    for (const type of types) {
+      await expect(
+        page.getByRole("button", { name: type, exact: true })
+      ).toBeVisible();
+    }
+  });
+
+  test("テキスト検索で質問を絞り込める", async ({ page }) => {
+    const searchInput = page.getByPlaceholder("質問を検索...");
+    await searchInput.fill("自己PR");
+
+    // 絞り込み結果が表示される
+    await expect(page.getByText(/\d+ 件の質問が見つかりました/)).toBeVisible();
+  });
+
+  test("業界フィルタで質問を絞り込める", async ({ page }) => {
+    // IT をクリック
+    await page.getByRole("button", { name: "IT", exact: true }).click();
+
+    // 絞り込み結果件数が表示される
+    await expect(page.getByText(/\d+ 件の質問が見つかりました/)).toBeVisible();
+
+    // フィルタをクリアボタンが表示される
+    await expect(
+      page.getByRole("button", { name: "フィルタをクリア" })
+    ).toBeVisible();
+  });
+
+  test("ラウンドフィルタで質問を絞り込める", async ({ page }) => {
+    // 最終 をクリック
+    await page.getByRole("button", { name: "最終", exact: true }).click();
+
+    // 件数表示の確認
+    await expect(page.getByText(/\d+ 件の質問が見つかりました/)).toBeVisible();
+  });
+
+  test("タイプフィルタで質問を絞り込める", async ({ page }) => {
+    // 志望動機 をクリック
+    await page
+      .getByRole("button", { name: "志望動機", exact: true })
+      .click();
+
+    // 件数表示の確認
+    await expect(page.getByText(/\d+ 件の質問が見つかりました/)).toBeVisible();
+  });
+
+  test("フィルタをクリアで全件に戻る", async ({ page }) => {
+    // 最初の全件数を取得
+    const allCountText = await page
+      .getByText(/\d+ 件の質問が見つかりました/)
+      .textContent();
+
+    // フィルタを適用
+    await page.getByRole("button", { name: "金融", exact: true }).click();
+
+    // フィルタをクリア
+    await page.getByRole("button", { name: "フィルタをクリア" }).click();
+
+    // 全件数に戻る
+    await expect(page.getByText(allCountText!)).toBeVisible();
+  });
+
+  test("フィルタのトグル動作 — 同じボタンを2回クリックでフィルタ解除", async ({
+    page,
+  }) => {
+    // 全件数を取得
+    const allCountText = await page
+      .getByText(/\d+ 件の質問が見つかりました/)
+      .textContent();
+
+    // IT をクリック → フィルタ適用
+    await page.getByRole("button", { name: "IT", exact: true }).click();
+
+    // もう一度 IT をクリック → フィルタ解除
+    await page.getByRole("button", { name: "IT", exact: true }).click();
+
+    // 全件数に戻る
+    await expect(page.getByText(allCountText!)).toBeVisible();
+  });
+
+  test("複数フィルタの組み合わせが動作する", async ({ page }) => {
+    // 業界: IT を選択
+    await page.getByRole("button", { name: "IT", exact: true }).click();
+
+    // タイプ: 自己PR を選択
+    await page
+      .getByRole("button", { name: "自己PR", exact: true })
+      .click();
+
+    // 件数が表示される（組み合わせ絞り込み）
+    await expect(page.getByText(/\d+ 件の質問が見つかりました/)).toBeVisible();
+  });
+
+  test("質問カードをクリックすると詳細ページに遷移する", async ({ page }) => {
+    // 最初の質問カードをクリック
+    const firstCard = page.locator('a[href^="/questions/q"]').first();
+    await expect(firstCard).toBeVisible();
+    await firstCard.click();
+
+    // URL が /questions/qXXX 形式に遷移
+    await expect(page).toHaveURL(/\/questions\/q\d+/);
+  });
+
+  test("絞り込み結果がゼロの場合にメッセージが表示される", async ({ page }) => {
+    // ありえない検索文字列
+    const searchInput = page.getByPlaceholder("質問を検索...");
+    await searchInput.fill("zzzzxxxxxyyyyy");
+
+    // ゼロ件メッセージの確認
+    await expect(
+      page.getByText("条件に一致する質問が見つかりませんでした")
+    ).toBeVisible();
+  });
+});
+
+test.describe("質問詳細ページ", () => {
+  test("質問詳細ページが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "自己PRをしてください。" })
+    ).toBeVisible();
+  });
+
+  test("パンくずナビゲーションが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(
+      page.getByRole("link", { name: "面接質問集に戻る" })
+    ).toBeVisible();
+  });
+
+  test("回答のポイントセクションが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(page.getByText("回答のポイント")).toBeVisible();
+  });
+
+  test("難易度バッジが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    // q001 は easy = "基本"
+    await expect(page.getByText("基本")).toBeVisible();
+  });
+
+  test("質問タイプバッジが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(page.getByText("自己PR").first()).toBeVisible();
+  });
+
+  test("関連する質問セクションが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(page.getByText("関連する質問")).toBeVisible();
+  });
+
+  test("カテゴリから探すセクションが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(page.getByText("カテゴリから探す")).toBeVisible();
+  });
+
+  test("対象業界セクションが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(page.getByText("対象業界")).toBeVisible();
+  });
+
+  test("模擬面接を始めるリンクが表示される", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await expect(
+      page.getByRole("link", { name: /模擬面接を始める/ })
+    ).toBeVisible();
+  });
+
+  test("パンくずから質問一覧に戻れる", async ({ page }) => {
+    await page.goto("/questions/q001");
+    await page.getByRole("link", { name: "面接質問集に戻る" }).click();
+    await expect(page).toHaveURL(/\/questions$/);
+  });
+
+  test("存在しない質問IDで 404 が表示される", async ({ page }) => {
+    await page.goto("/questions/q99999");
+    await expect(page.getByText("404")).toBeVisible();
+  });
+
+  test("JSON-LD 構造化データが埋め込まれている", async ({ page }) => {
+    await page.goto("/questions/q001");
+    const jsonLd = page.locator('script[type="application/ld+json"]');
+    await expect(jsonLd).toBeAttached();
+
+    const content = await jsonLd.textContent();
+    expect(content).toBeTruthy();
+    const parsed = JSON.parse(content!);
+    expect(parsed["@type"]).toBe("QAPage");
+  });
+});
+
+test.describe("質問集ページ — SEO", () => {
+  test("meta description が設定されている", async ({ page }) => {
+    await page.goto("/questions");
+    const description = page.locator('meta[name="description"]');
+    await expect(description).toHaveAttribute("content", /面接/);
+  });
+
+  test("JSON-LD FAQPage が埋め込まれている", async ({ page }) => {
+    await page.goto("/questions");
+    const jsonLd = page.locator('script[type="application/ld+json"]');
+    await expect(jsonLd).toBeAttached();
+
+    const content = await jsonLd.textContent();
+    expect(content).toBeTruthy();
+    const parsed = JSON.parse(content!);
+    expect(parsed["@type"]).toBe("FAQPage");
+  });
+});


### PR DESCRIPTION
## Summary
- 認証フロー（ログイン/サインアップ/パスワードリセット）のUI・バリデーションテスト追加
- ダッシュボード・模擬面接・ES添削のAPIモック認証済みテスト追加
- ダークモード切替の動作確認テスト追加
- 質問集ページのフィルタリング・詳細ページ・SEOテスト追加
- ヘッダー・フッター・モバイルナビゲーションの遷移テスト追加
- 未認証リダイレクトテストの対象パスを拡充（ES添削、プロフィール、オンボーディング、プラン管理、面接記録）

## 新規テストファイル
| ファイル | テスト数 | カバー範囲 |
|---|---|---|
| `e2e/auth-flow.spec.ts` | 19 | 認証UI・フォームバリデーション・リダイレクト |
| `e2e/dashboard-mock.spec.ts` | 5 | ダッシュボード・模擬面接・ES添削（モック認証） |
| `e2e/dark-mode.spec.ts` | 7 | ダークモード切替・テーマ永続性 |
| `e2e/questions-detail.spec.ts` | 24 | 質問フィルタリング・詳細ページ・SEO |
| `e2e/navigation.spec.ts` | 16 | ヘッダー・フッター・モバイルナビ・クロスページ遷移 |

## Test plan
- [ ] `npm run build` が成功すること（確認済み）
- [ ] `npx playwright test` が CI 上で 3分以内に完了すること
- [ ] 全テストがローカル dev サーバーで正常に動作すること

closes #212