### PR TITLE
feat: #220 i18n基盤構築 — ハードコード日本語テキストの定数化

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -15,9 +15,10 @@ import { UsageNudgeBanner } from "@/components/dashboard/usage-nudge-banner";
 import { PracticeReminderBanner } from "@/components/dashboard/practice-reminder-banner";
 import { WeeklySummarySection } from "@/components/dashboard/weekly-summary-section";
 import { WeeklySummarySkeleton } from "@/components/dashboard/weekly-summary-skeleton";
+import { t } from "@/lib/i18n";
 
 export const metadata: Metadata = {
-  title: "ダッシュボード",
+  title: t("metadata.dashboardTitle"),
   robots: { index: false, follow: false },
 };
 
@@ -83,7 +84,7 @@ export default async function DashboardPage({
 
       {/* ヘッダー（即座に表示） */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">面接履歴</h1>
+        <h1 className="text-2xl font-bold">{t("dashboard.title")}</h1>
         <div className="flex items-center gap-2">
           <Suspense
             fallback={
@@ -95,13 +96,13 @@ export default async function DashboardPage({
           <Button variant="outline" asChild>
             <Link href="/mock-interview">
               <MessageSquare className="mr-2 h-4 w-4" />
-              AI模擬面接
+              {t("dashboard.mockInterview")}
             </Link>
           </Button>
           <Button asChild>
             <Link href="/interview/new">
               <Plus className="mr-2 h-4 w-4" />
-              新規面接を記録
+              {t("dashboard.newInterview")}
             </Link>
           </Button>
         </div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, Home, RotateCcw, Mail, Copy, Check } from "lucide-react"
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { reportClientError } from "@/lib/error-reporting";
+import { t } from "@/lib/i18n";
 
 export default function Error({
   error,
@@ -43,25 +44,25 @@ export default function Error({
 
       <div className="text-center">
         <h1 className="text-4xl font-bold tracking-tight">
-          エラーが発生しました
+          {t("error.title")}
         </h1>
         <p className="mt-4 text-muted-foreground">
-          申し訳ございません。予期しないエラーが発生しました。
+          {t("error.description")}
         </p>
         <p className="mt-2 text-sm text-muted-foreground">
-          時間をおいて再度お試しいただくか、ホームに戻ってください。
+          {t("error.suggestion")}
         </p>
       </div>
 
       {/* エラーID表示 */}
       {errorId && (
         <div className="flex items-center gap-2 rounded-lg border bg-muted/50 px-4 py-2">
-          <span className="text-xs text-muted-foreground">エラーID:</span>
+          <span className="text-xs text-muted-foreground">{t("error.errorId")}</span>
           <code className="text-xs font-mono font-medium">{errorId}</code>
           <button
             onClick={handleCopyErrorId}
             className="ml-1 rounded p-1 hover:bg-muted transition-colors"
-            title="エラーIDをコピー"
+            title={t("error.copyErrorId")}
           >
             {copied ? (
               <Check className="h-3 w-3 text-green-600" />
@@ -76,12 +77,12 @@ export default function Error({
       <div className="flex flex-col items-center gap-4 sm:flex-row">
         <Button size="lg" onClick={reset}>
           <RotateCcw className="mr-2 h-4 w-4" />
-          もう一度試す
+          {t("error.retry")}
         </Button>
         <Button size="lg" variant="outline" asChild>
           <Link href="/">
             <Home className="mr-2 h-4 w-4" />
-            ホームに戻る
+            {t("error.goHome")}
           </Link>
         </Button>
       </div>
@@ -89,7 +90,7 @@ export default function Error({
       {/* サポート案内 */}
       <div className="mt-4 text-center">
         <p className="text-sm text-muted-foreground">
-          問題が解決しない場合は、エラーIDを添えてお問い合わせください。
+          {t("error.supportGuide")}
         </p>
         <a
           href="mailto:support@interviewcoach.jp"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -18,6 +18,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Loader2, Info } from "lucide-react";
+import { t } from "@/lib/i18n";
 
 /**
  * redirect パラメータのバリデーション。
@@ -108,9 +109,9 @@ function LoginForm() {
 
       if (error) {
         if (error.message.includes("Email not confirmed")) {
-          setError("メールアドレスの確認が完了していません。受信トレイの確認メールからアカウントを有効化してください。");
+          setError(t("auth.emailNotConfirmed"));
         } else {
-          setError("メールアドレスまたはパスワードが正しくありません。入力内容をご確認ください。");
+          setError(t("auth.invalidCredentials"));
         }
         return;
       }
@@ -120,7 +121,7 @@ function LoginForm() {
       router.push(safeRedirect ?? "/dashboard");
       router.refresh();
     } catch {
-      setError("サーバーとの通信に失敗しました。時間を置いて再度お試しください。");
+      setError(t("common.networkError"));
     } finally {
       setLoading(false);
     }
@@ -130,9 +131,9 @@ function LoginForm() {
     <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">ログイン</CardTitle>
+          <CardTitle className="text-2xl">{t("auth.login")}</CardTitle>
           <CardDescription>
-            メールアドレスとパスワードでログイン
+            {t("auth.loginDescription")}
           </CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
@@ -146,13 +147,13 @@ function LoginForm() {
               >
                 <Info className="mt-0.5 h-4 w-4 flex-shrink-0" />
                 <div>
-                  <p>セッションの有効期限が切れました。再度ログインしてください。</p>
+                  <p>{t("auth.sessionExpired")}</p>
                 </div>
                 <button
                   type="button"
                   onClick={() => setSessionExpiredBanner(false)}
                   className="ml-auto flex-shrink-0 text-blue-600 hover:text-blue-800 dark:text-blue-300 dark:hover:text-blue-100"
-                  aria-label="通知を閉じる"
+                  aria-label={t("auth.closeNotification")}
                 >
                   &times;
                 </button>
@@ -176,7 +177,7 @@ function LoginForm() {
               </div>
             )}
             <div className="space-y-2">
-              <Label htmlFor="email">メールアドレス</Label>
+              <Label htmlFor="email">{t("auth.email")}</Label>
               <Input
                 id="email"
                 type="email"
@@ -189,12 +190,12 @@ function LoginForm() {
             </div>
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <Label htmlFor="password">パスワード</Label>
+                <Label htmlFor="password">{t("auth.password")}</Label>
                 <Link
                   href="/reset-password"
                   className="text-xs text-muted-foreground hover:text-primary hover:underline"
                 >
-                  パスワードを忘れた方
+                  {t("auth.forgotPassword")}
                 </Link>
               </div>
               <Input
@@ -210,12 +211,12 @@ function LoginForm() {
           <CardFooter className="flex flex-col gap-4">
             <Button type="submit" className="w-full" disabled={loading}>
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {loading ? "ログイン中..." : "ログイン"}
+              {loading ? t("auth.loginLoading") : t("auth.login")}
             </Button>
             <p className="text-sm text-muted-foreground">
-              アカウントをお持ちでないですか？{" "}
+              {t("auth.noAccount")}{" "}
               <Link href="/signup" className="text-primary hover:underline">
-                サインアップ
+                {t("auth.signup")}
               </Link>
             </p>
           </CardFooter>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -8,6 +8,7 @@ import {
   MessageSquare,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { t } from "@/lib/i18n";
 
 export default function NotFound() {
   return (
@@ -17,12 +18,12 @@ export default function NotFound() {
       </div>
 
       <div className="text-center">
-        <h1 className="text-6xl font-bold tracking-tight">404</h1>
+        <h1 className="text-6xl font-bold tracking-tight">{t("notFound.title")}</h1>
         <p className="mt-4 text-xl text-muted-foreground">
-          ページが見つかりません
+          {t("notFound.description")}
         </p>
         <p className="mt-2 text-sm text-muted-foreground">
-          お探しのページは移動または削除された可能性があります。
+          {t("notFound.suggestion")}
         </p>
       </div>
 
@@ -30,13 +31,13 @@ export default function NotFound() {
         <Button size="lg" asChild>
           <Link href="/">
             <Home className="mr-2 h-4 w-4" />
-            ホームに戻る
+            {t("notFound.goHome")}
           </Link>
         </Button>
         <Button size="lg" variant="outline" asChild>
           <Link href="/dashboard">
             <LayoutDashboard className="mr-2 h-4 w-4" />
-            ダッシュボード
+            {t("notFound.dashboard")}
           </Link>
         </Button>
       </div>
@@ -44,7 +45,7 @@ export default function NotFound() {
       {/* サジェストリンク */}
       <div className="mt-4 w-full max-w-md">
         <p className="mb-3 text-center text-sm font-medium text-muted-foreground">
-          お探しの内容はこちらかもしれません
+          {t("notFound.suggestTitle")}
         </p>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
           <Link
@@ -52,21 +53,21 @@ export default function NotFound() {
             className="flex items-center gap-2 rounded-lg border px-4 py-3 text-sm transition-colors hover:bg-muted"
           >
             <Mic className="h-4 w-4 text-muted-foreground" />
-            面接分析
+            {t("notFound.interviewAnalysis")}
           </Link>
           <Link
             href="/es-review"
             className="flex items-center gap-2 rounded-lg border px-4 py-3 text-sm transition-colors hover:bg-muted"
           >
             <FileText className="h-4 w-4 text-muted-foreground" />
-            ES添削
+            {t("notFound.esReview")}
           </Link>
           <Link
             href="/mock-interview"
             className="flex items-center gap-2 rounded-lg border px-4 py-3 text-sm transition-colors hover:bg-muted"
           >
             <MessageSquare className="h-4 w-4 text-muted-foreground" />
-            模擬面接
+            {t("notFound.mockInterview")}
           </Link>
         </div>
       </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -17,6 +17,7 @@ import {
 import { Loader2, Mail } from "lucide-react";
 import { PasswordStrength } from "@/components/ui/password-strength";
 import { PasswordInput } from "@/components/ui/password-input";
+import { t } from "@/lib/i18n";
 
 export default function SignUpPage() {
   const [email, setEmail] = useState("");
@@ -31,12 +32,12 @@ export default function SignUpPage() {
     setError("");
 
     if (!agreed) {
-      setError("利用規約とプライバシーポリシーへの同意が必要です");
+      setError(t("auth.termsRequired"));
       return;
     }
 
     if (password.length < 8) {
-      setError("パスワードは8文字以上で入力してください");
+      setError(t("auth.passwordMinLength"));
       return;
     }
 
@@ -54,16 +55,16 @@ export default function SignUpPage() {
 
       if (error) {
         if (error.message.includes("already registered")) {
-          setError("このメールアドレスは既に登録されています。ログインページからお試しください。");
+          setError(t("auth.alreadyRegistered"));
         } else {
-          setError("アカウント作成に失敗しました。入力内容を確認して再度お試しください。");
+          setError(t("auth.signupFailed"));
         }
         return;
       }
 
       setEmailSent(true);
     } catch {
-      setError("サーバーとの通信に失敗しました。時間を置いて再度お試しください。");
+      setError(t("common.networkError"));
     } finally {
       setLoading(false);
     }
@@ -78,16 +79,16 @@ export default function SignUpPage() {
             <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
               <Mail className="h-8 w-8 text-primary" />
             </div>
-            <CardTitle className="text-2xl">メールを確認してください</CardTitle>
+            <CardTitle className="text-2xl">{t("auth.confirmEmail")}</CardTitle>
             <CardDescription className="mt-2 text-base">
               <span className="font-medium text-foreground">{email}</span>
-              {" "}に確認メールを送信しました。
+              {" "}{t("auth.confirmEmailSent")}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="rounded-md bg-muted p-4 text-sm text-muted-foreground">
-              <p className="mb-2">メール内のリンクをクリックして、アカウントの登録を完了してください。</p>
-              <p>メールが届かない場合は、迷惑メールフォルダもご確認ください。</p>
+              <p className="mb-2">{t("auth.confirmEmailInstruction")}</p>
+              <p>{t("auth.confirmEmailSpam")}</p>
             </div>
           </CardContent>
           <CardFooter className="flex flex-col gap-4">
@@ -96,12 +97,12 @@ export default function SignUpPage() {
               className="w-full"
               onClick={() => setEmailSent(false)}
             >
-              別のメールアドレスで登録する
+              {t("auth.useAnotherEmail")}
             </Button>
             <p className="text-sm text-muted-foreground">
-              すでにアカウントをお持ちですか？{" "}
+              {t("auth.hasAccount")}{" "}
               <Link href="/login" className="text-primary hover:underline">
-                ログイン
+                {t("auth.login")}
               </Link>
             </p>
           </CardFooter>
@@ -114,9 +115,9 @@ export default function SignUpPage() {
     <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl">アカウント作成</CardTitle>
+          <CardTitle className="text-2xl">{t("auth.signupTitle")}</CardTitle>
           <CardDescription>
-            メールアドレスとパスワードで登録
+            {t("auth.signupDescription")}
           </CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
@@ -131,7 +132,7 @@ export default function SignUpPage() {
               </div>
             )}
             <div className="space-y-2">
-              <Label htmlFor="email">メールアドレス</Label>
+              <Label htmlFor="email">{t("auth.email")}</Label>
               <Input
                 id="email"
                 type="email"
@@ -143,11 +144,11 @@ export default function SignUpPage() {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password">パスワード</Label>
+              <Label htmlFor="password">{t("auth.password")}</Label>
               <PasswordInput
                 id="password"
                 autoComplete="new-password"
-                placeholder="8文字以上"
+                placeholder={t("auth.passwordPlaceholder")}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
@@ -172,7 +173,7 @@ export default function SignUpPage() {
                   target="_blank"
                   className="text-primary underline underline-offset-4 hover:text-primary/80"
                 >
-                  利用規約
+                  {t("auth.termsOfService")}
                 </Link>
                 と
                 <Link
@@ -180,9 +181,9 @@ export default function SignUpPage() {
                   target="_blank"
                   className="text-primary underline underline-offset-4 hover:text-primary/80"
                 >
-                  プライバシーポリシー
+                  {t("auth.privacyPolicy")}
                 </Link>
-                に同意します
+                {t("auth.agreeTerms")}
               </Label>
             </div>
           </CardContent>
@@ -193,12 +194,12 @@ export default function SignUpPage() {
               disabled={loading || !agreed}
             >
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {loading ? "登録中..." : "サインアップ"}
+              {loading ? t("auth.signupLoading") : t("auth.signup")}
             </Button>
             <p className="text-sm text-muted-foreground">
-              すでにアカウントをお持ちですか？{" "}
+              {t("auth.hasAccount")}{" "}
               <Link href="/login" className="text-primary hover:underline">
-                ログイン
+                {t("auth.login")}
               </Link>
             </p>
           </CardFooter>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { t } from "@/lib/i18n";
 
 export function Footer() {
   return (
@@ -10,25 +11,25 @@ export function Footer() {
             href="/legal/terms"
             className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
           >
-            利用規約
+            {t("footer.termsOfService")}
           </Link>
           <Link
             href="/legal/privacy"
             className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
           >
-            プライバシーポリシー
+            {t("footer.privacyPolicy")}
           </Link>
           <Link
             href="/legal/cookies"
             className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
           >
-            Cookie ポリシー
+            {t("footer.cookiePolicy")}
           </Link>
           <Link
             href="/legal/tokushoho"
             className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
           >
-            特定商取引法に基づく表記
+            {t("footer.tokushoho")}
           </Link>
         </nav>
       </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import type { User } from "@supabase/supabase-js";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { t } from "@/lib/i18n";
 
 export function Header() {
   const [user, setUser] = useState<User | null>(null);
@@ -76,18 +77,18 @@ export function Header() {
   };
 
   const publicNavItems = [
-    { href: "/questions", label: "質問集" },
-    { href: "/personality", label: "16パーソナリティ" },
+    { href: "/questions", label: t("nav.questions") },
+    { href: "/personality", label: t("nav.personality") },
   ];
 
   // オンボーディング完了後のみ表示する保護対象ナビ
   const authNavItems = user && onboardingCompleted
     ? [
-        { href: "/dashboard", label: "ダッシュボード" },
-        { href: "/mock-interview", label: "模擬面接" },
-        { href: "/es-review", label: "ES添削" },
-        { href: "/dashboard/growth", label: "成長記録" },
-        { href: "/profile", label: "プロフィール" },
+        { href: "/dashboard", label: t("nav.dashboard") },
+        { href: "/mock-interview", label: t("nav.mockInterview") },
+        { href: "/es-review", label: t("nav.esReview") },
+        { href: "/dashboard/growth", label: t("nav.growthRecord") },
+        { href: "/profile", label: t("nav.profile") },
       ]
     : [];
 
@@ -127,28 +128,28 @@ export function Header() {
                 <DropdownMenuItem asChild>
                   <Link href="/profile">
                     <UserCircle className="mr-2 h-4 w-4" />
-                    プロフィール
+                    {t("nav.profile")}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link href="/settings/billing">
                     <CreditCard className="mr-2 h-4 w-4" />
-                    プラン管理
+                    {t("nav.planManagement")}
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={handleLogout}>
                   <LogOut className="mr-2 h-4 w-4" />
-                  ログアウト
+                  {t("auth.logout")}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <>
               <Button variant="ghost" size="sm" asChild>
-                <Link href="/login">ログイン</Link>
+                <Link href="/login">{t("auth.login")}</Link>
               </Button>
               <Button size="sm" asChild>
-                <Link href="/signup">3分で無料体験</Link>
+                <Link href="/signup">{t("auth.freeTrialCta")}</Link>
               </Button>
             </>
           )}
@@ -185,16 +186,16 @@ export function Header() {
                       onClick={handleLogout}
                     >
                       <LogOut className="mr-2 h-4 w-4" />
-                      ログアウト
+                      {t("auth.logout")}
                     </Button>
                   </>
                 ) : (
                   <>
                     <Button variant="ghost" size="sm" asChild>
-                      <Link href="/login">ログイン</Link>
+                      <Link href="/login">{t("auth.login")}</Link>
                     </Button>
                     <Button size="sm" asChild>
-                      <Link href="/signup">3分で無料体験</Link>
+                      <Link href="/signup">{t("auth.freeTrialCta")}</Link>
                     </Button>
                   </>
                 )}

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,0 +1,64 @@
+/**
+ * i18n ヘルパー
+ *
+ * 型安全なメッセージ参照関数を提供する。
+ * 現在は日本語のみだが、将来的に言語切り替え機構を追加可能な設計。
+ */
+
+import { ja } from "./ja";
+import type { MessageKey, Messages } from "./types";
+
+/** 現在のメッセージオブジェクト（将来的にロケール切替対応可能） */
+const messages: Messages = ja;
+
+/**
+ * ドットキーで指定されたメッセージ文字列を取得する。
+ *
+ * @param key - "namespace.key" 形式のメッセージキー（例: "common.loading"）
+ * @param params - テンプレート変数の置換マップ（例: { count: 3 }）
+ * @returns 解決されたメッセージ文字列。キーが見つからない場合はキー自体を返す。
+ *
+ * @example
+ * t("common.loading")          // => "読み込み中..."
+ * t("interview.companyNameMaxLength", { max: 100 }) // => "企業名は100文字以内で入力してください"
+ */
+export function t(
+  key: MessageKey,
+  params?: Record<string, string | number>
+): string {
+  const parts = key.split(".");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let value: any = messages;
+
+  for (const part of parts) {
+    if (value == null || typeof value !== "object") {
+      return key;
+    }
+    value = value[part];
+  }
+
+  if (typeof value !== "string") {
+    return key;
+  }
+
+  // テンプレート変数の置換: {variable} -> params[variable]
+  if (params) {
+    return value.replace(/\{(\w+)\}/g, (_, name: string) => {
+      const replacement = params[name];
+      return replacement != null ? String(replacement) : `{${name}}`;
+    });
+  }
+
+  return value;
+}
+
+// 名前空間単位でオブジェクトを取得するヘルパー
+export function getMessages<NS extends keyof Messages>(
+  namespace: NS
+): Messages[NS] {
+  return messages[namespace];
+}
+
+// 型と定数をre-export
+export { ja } from "./ja";
+export type { MessageKey, Messages, Namespace } from "./types";

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -1,0 +1,269 @@
+/**
+ * 日本語メッセージ定数
+ *
+ * 名前空間ごとにUI テキストを定義する。
+ * テンプレート変数は {variable} 形式で埋め込み、t() ヘルパーで置換する。
+ */
+export const ja = {
+  // ============================================================
+  // 共通
+  // ============================================================
+  common: {
+    loading: "読み込み中...",
+    error: "エラーが発生しました",
+    save: "保存",
+    cancel: "キャンセル",
+    delete: "削除",
+    back: "戻る",
+    next: "次へ",
+    submit: "送信",
+    close: "閉じる",
+    search: "検索",
+    noData: "データがありません",
+    retry: "もう一度試す",
+    home: "ホームに戻る",
+    networkError: "サーバーとの通信に失敗しました。時間を置いて再度お試しください。",
+    perMonth: "/月",
+  },
+
+  // ============================================================
+  // メタデータ
+  // ============================================================
+  metadata: {
+    siteTitle: "InterviewCoach",
+    siteDescription:
+      "面接練習の録音をAIが分析し、回答内容・話し方の両面からフィードバックを自動生成。新卒就活を成功に導くAI面接コーチ。",
+    ogAlt: "InterviewCoach - AI面接フィードバック",
+    lpTitle:
+      "InterviewCoach - 面接練習を録音するだけ。AIが即座に分析・フィードバック",
+    lpDescription:
+      "面接練習を録音するだけで、回答内容・話し方をAIが即座に分析。スコア表示と成長トラッキングで、確実に面接力を伸ばせる就活支援アプリ。無料プランあり。",
+    dashboardTitle: "ダッシュボード",
+    pricingTitle: "料金プラン | InterviewCoach",
+  },
+
+  // ============================================================
+  // 認証
+  // ============================================================
+  auth: {
+    login: "ログイン",
+    loginLoading: "ログイン中...",
+    signup: "サインアップ",
+    signupLoading: "登録中...",
+    logout: "ログアウト",
+    email: "メールアドレス",
+    password: "パスワード",
+    passwordPlaceholder: "8文字以上",
+    loginDescription: "メールアドレスとパスワードでログイン",
+    signupTitle: "アカウント作成",
+    signupDescription: "メールアドレスとパスワードで登録",
+    forgotPassword: "パスワードを忘れた方",
+    noAccount: "アカウントをお持ちでないですか？",
+    hasAccount: "すでにアカウントをお持ちですか？",
+    agreeTerms: "に同意します",
+    termsOfService: "利用規約",
+    privacyPolicy: "プライバシーポリシー",
+    emailNotConfirmed:
+      "メールアドレスの確認が完了していません。受信トレイの確認メールからアカウントを有効化してください。",
+    invalidCredentials:
+      "メールアドレスまたはパスワードが正しくありません。入力内容をご確認ください。",
+    alreadyRegistered:
+      "このメールアドレスは既に登録されています。ログインページからお試しください。",
+    signupFailed:
+      "アカウント作成に失敗しました。入力内容を確認して再度お試しください。",
+    termsRequired: "利用規約とプライバシーポリシーへの同意が必要です",
+    passwordMinLength: "パスワードは8文字以上で入力してください",
+    confirmEmail: "メールを確認してください",
+    confirmEmailSent: "に確認メールを送信しました。",
+    confirmEmailInstruction:
+      "メール内のリンクをクリックして、アカウントの登録を完了してください。",
+    confirmEmailSpam:
+      "メールが届かない場合は、迷惑メールフォルダもご確認ください。",
+    useAnotherEmail: "別のメールアドレスで登録する",
+    sessionExpired:
+      "セッションの有効期限が切れました。再度ログインしてください。",
+    closeNotification: "通知を閉じる",
+    freeTrialCta: "3分で無料体験",
+    noCreditCard: "クレジットカード不要・30秒で登録完了",
+  },
+
+  // ============================================================
+  // ダッシュボード
+  // ============================================================
+  dashboard: {
+    title: "面接履歴",
+    newInterview: "新規面接を記録",
+    mockInterview: "AI模擬面接",
+    backToDashboard: "ダッシュボードに戻る",
+  },
+
+  // ============================================================
+  // 面接
+  // ============================================================
+  interview: {
+    scriptRegistration: "面接スクリプト登録",
+    companyName: "企業名",
+    companyNamePlaceholder: "例: 株式会社サンプル",
+    companyNameRequired: "企業名を入力してください",
+    companyNameMaxLength:
+      "企業名は{max}文字以内で入力してください",
+    category: "面接カテゴリ",
+    categoryRequired: "面接カテゴリを選択してください",
+    categoryPlaceholder: "カテゴリを選択",
+    round: "面接ラウンド",
+    roundRequired: "面接ラウンドを選択してください",
+    roundPlaceholder: "ラウンドを選択",
+    interviewDate: "面接日",
+    interviewDateFuture: "面接日は今日以前の日付を指定してください",
+    transcript: "音声スクリプト",
+    transcriptRequired: "音声スクリプトを入力してください",
+    transcriptMinLength:
+      "音声スクリプトは{min}文字以上入力してください（現在: {current}文字）",
+    transcriptMaxLength:
+      "音声スクリプトは{max}文字以内で入力してください（現在: {current}文字）",
+    transcriptMinNote: "（最低{min}文字）",
+    transcriptPastePlaceholder:
+      "テキストを直接貼り付けることもできます",
+    transcriptTextareaPlaceholder:
+      "音声文字起こし結果をここに貼り付けてください...",
+    chars: "文字",
+    register: "登録する",
+    saving: "保存中...",
+    saveFailed: "保存に失敗しました",
+    networkError:
+      "ネットワークエラーが発生しました。接続を確認してもう一度お試しください。",
+    fileUploadLabel: "テキストファイルをアップロード",
+    fileDragDrop: ".txt ファイルをドラッグ&ドロップ、または",
+    fileSelect: "ファイルを選択",
+    fileMaxSize: "最大 1MB / UTF-8 テキストファイル",
+    fileClear: "ファイルをクリア",
+    fileTxtOnly: ".txt ファイルのみアップロードできます",
+    fileSizeLimit: "ファイルサイズは1MB以内にしてください",
+    fileEncodingError:
+      "ファイルのエンコーディングが正しくない可能性があります。UTF-8 のテキストファイルを使用してください。",
+    fileReadError: "ファイルの読み込みに失敗しました",
+    // カテゴリラベル
+    categoryArubaito: "アルバイト",
+    categoryIntern: "インターン",
+    categoryNewGrad: "新卒",
+    categoryOther: "その他",
+    // ラウンドラベル
+    roundFirst: "一次面接",
+    roundSecond: "二次面接",
+    roundThird: "三次面接",
+    roundFinal: "最終面接",
+    roundGD: "GD（グループディスカッション）",
+    roundCase: "ケース面接",
+    roundOther: "その他",
+  },
+
+  // ============================================================
+  // 面接結果
+  // ============================================================
+  result: {
+    overallScore: "総合スコア",
+    categoryScore: "カテゴリ別スコア",
+    noCategoryScore: "カテゴリ別スコアはありません",
+    goodPoints: "良い点",
+    improvementPoints: "改善点",
+    detailedFeedback: "詳細フィードバック",
+    advice: "次回へのアドバイス",
+    summary: "要約",
+    interviewSummary: "面接の要約",
+    transcription: "文字起こし",
+    suggestions: "改善提案",
+    filler: "フィラー",
+    noSuggestions: "改善提案はありません",
+    noTranscript: "文字起こしデータがありません",
+    noFeedbackYet: "フィードバックはまだ生成されていません",
+    waitForProcessing: "処理が完了するまでお待ちください",
+    checkProcessing: "処理状況を確認する",
+    compareWithPrevious: "前回と比較",
+    original: "元の回答",
+    improved: "改善案",
+    reason: "理由",
+    interviewer: "面接官",
+    candidate: "候補者",
+    // フィラー分析
+    totalFillers: "総フィラー数",
+    fillerRate: "フィラー率",
+    fillerTypes: "種類数",
+    fillerBreakdown: "フィラー表現の内訳",
+    noFillers: "フィラー表現は検出されませんでした",
+    times: "回",
+    types: "種類",
+    points: "点",
+  },
+
+  // ============================================================
+  // エラーページ
+  // ============================================================
+  error: {
+    title: "エラーが発生しました",
+    description: "申し訳ございません。予期しないエラーが発生しました。",
+    suggestion: "時間をおいて再度お試しいただくか、ホームに戻ってください。",
+    errorId: "エラーID:",
+    copyErrorId: "エラーIDをコピー",
+    retry: "もう一度試す",
+    goHome: "ホームに戻る",
+    supportGuide: "問題が解決しない場合は、エラーIDを添えてお問い合わせください。",
+  },
+
+  // ============================================================
+  // 404 ページ
+  // ============================================================
+  notFound: {
+    title: "404",
+    description: "ページが見つかりません",
+    suggestion: "お探しのページは移動または削除された可能性があります。",
+    goHome: "ホームに戻る",
+    dashboard: "ダッシュボード",
+    suggestTitle: "お探しの内容はこちらかもしれません",
+    interviewAnalysis: "面接分析",
+    esReview: "ES添削",
+    mockInterview: "模擬面接",
+  },
+
+  // ============================================================
+  // ナビゲーション
+  // ============================================================
+  nav: {
+    questions: "質問集",
+    personality: "16パーソナリティ",
+    dashboard: "ダッシュボード",
+    mockInterview: "模擬面接",
+    esReview: "ES添削",
+    growthRecord: "成長記録",
+    profile: "プロフィール",
+    planManagement: "プラン管理",
+  },
+
+  // ============================================================
+  // フッター
+  // ============================================================
+  footer: {
+    termsOfService: "利用規約",
+    privacyPolicy: "プライバシーポリシー",
+    cookiePolicy: "Cookie ポリシー",
+    tokushoho: "特定商取引法に基づく表記",
+  },
+
+  // ============================================================
+  // 料金
+  // ============================================================
+  pricing: {
+    title: "料金プラン",
+    subtitle: "まずは無料プランでお試しください",
+    currentPlan: "現在のプラン",
+    startFree: "無料で始める",
+    upgradeToProLabel: "Pro にアップグレード",
+    upgradeToPremiumLabel: "Premium にアップグレード",
+    startWithPro: "Pro で始める",
+    startWithPremium: "Premium で始める",
+    recommended: "おすすめ",
+    freeTrialCta: "無料ではじめる",
+    compareAll: "Premium プランなど、すべてのプランを比較する",
+    freePlanAlso: "無料プランだけでも、面接力は変わります。",
+    choosePlan: "あなたに合ったプランを",
+  },
+} as const;

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -1,0 +1,35 @@
+/**
+ * i18n メッセージ型定義
+ *
+ * 各名前空間のキーをドット区切りで参照するためのユーティリティ型。
+ * 例: "common.loading" | "auth.login" | "dashboard.title" ...
+ */
+
+import type { ja } from "./ja";
+
+/** メッセージオブジェクト全体の型 */
+export type Messages = typeof ja;
+
+/** 名前空間のキー */
+export type Namespace = keyof Messages;
+
+/**
+ * ネストされたオブジェクトのリーフキーをドット区切りで取得するユーティリティ型。
+ * 最大2階層まで対応。
+ */
+type DotPrefix<T extends string, U extends string> = `${T}.${U}`;
+
+type NestedKeys<T> = T extends object
+  ? {
+      [K in keyof T & string]: T[K] extends string
+        ? K
+        : T[K] extends object
+          ? DotPrefix<K, keyof T[K] & string>
+          : never;
+    }[keyof T & string]
+  : never;
+
+/** メッセージキーの完全修飾型（名前空間.キー） */
+export type MessageKey = {
+  [NS in Namespace]: DotPrefix<NS, NestedKeys<Messages[NS]>>;
+}[Namespace];


### PR DESCRIPTION
## Summary
- `src/lib/i18n/` ディレクトリに i18n 基盤を構築（メッセージ定数 `ja.ts`、型定義 `types.ts`、ヘルパー関数 `index.ts`）
- 型安全な `t()` ヘルパー関数を実装（ドットキー参照 + テンプレート変数 `{variable}` 置換対応）
- 主要7ファイルのハードコード日本語テキストを `t()` 関数経由に置換
  - ログインページ (`login/page.tsx`)
  - サインアップページ (`signup/page.tsx`)
  - ダッシュボード (`dashboard/page.tsx`)
  - エラーページ (`error.tsx`)
  - 404ページ (`not-found.tsx`)
  - ヘッダー (`header.tsx`)
  - フッター (`footer.tsx`)

## 技術詳細
- 外部ライブラリ不使用（シンプルな定数ファイル + ヘルパー関数）
- `MessageKey` 型により、存在しないキーの参照をコンパイル時に検出
- 名前空間: `common`, `metadata`, `auth`, `dashboard`, `interview`, `result`, `error`, `notFound`, `nav`, `footer`, `pricing`
- 将来的に `en.ts` 等を追加するだけで多言語対応可能な設計

## Test plan
- [x] `npm run build` 成功確認
- [x] TypeScript 型チェック（i18n 関連エラーなし）
- [ ] ログイン・サインアップ画面の表示確認
- [ ] ダッシュボード・エラー・404ページの表示確認
- [ ] ヘッダー・フッターのナビゲーションテキスト確認

closes #220