### PR TITLE
feat: 録音機能・アカウント削除・ヘルプページ

### DIFF
--- a/src/app/api/interviews/route.ts
+++ b/src/app/api/interviews/route.ts
@@ -48,13 +48,17 @@ export async function POST(request: Request) {
       interview_round,
       interview_date,
       transcript,
+      audio_url,
     } = body as {
       company_name: string;
       interview_category: InterviewCategory;
       interview_round: InterviewRound | null;
       interview_date: string | null;
-      transcript: string;
+      transcript: string | null;
+      audio_url: string | null;
     };
+
+    const isAudioMode = !!audio_url;
 
     // --- バリデーション ---
 
@@ -113,29 +117,36 @@ export async function POST(request: Request) {
       }
     }
 
-    // 音声スクリプト
-    if (!transcript || typeof transcript !== "string") {
-      return NextResponse.json(
-        { error: "音声スクリプトは必須です" },
-        { status: 400 }
-      );
-    }
-    const trimmedTranscript = transcript.trim();
-    if (trimmedTranscript.length < MIN_TRANSCRIPT_LENGTH) {
-      return NextResponse.json(
-        {
-          error: `音声スクリプトは${MIN_TRANSCRIPT_LENGTH}文字以上入力してください（現在: ${trimmedTranscript.length}文字）`,
-        },
-        { status: 400 }
-      );
-    }
-    if (trimmedTranscript.length > MAX_TRANSCRIPT_LENGTH) {
-      return NextResponse.json(
-        {
-          error: `音声スクリプトは${MAX_TRANSCRIPT_LENGTH.toLocaleString()}文字以内で入力してください（現在: ${trimmedTranscript.length.toLocaleString()}文字）`,
-        },
-        { status: 400 }
-      );
+    // 音声モード: audio_url が必須、テキストモード: transcript が必須
+    let trimmedTranscript: string | null = null;
+    if (isAudioMode) {
+      if (typeof audio_url !== "string" || !audio_url.startsWith("http")) {
+        return badRequest("無効な音声URLです");
+      }
+    } else {
+      if (!transcript || typeof transcript !== "string") {
+        return NextResponse.json(
+          { error: "音声スクリプトは必須です" },
+          { status: 400 }
+        );
+      }
+      trimmedTranscript = transcript.trim();
+      if (trimmedTranscript.length < MIN_TRANSCRIPT_LENGTH) {
+        return NextResponse.json(
+          {
+            error: `音声スクリプトは${MIN_TRANSCRIPT_LENGTH}文字以上入力してください（現在: ${trimmedTranscript.length}文字）`,
+          },
+          { status: 400 }
+        );
+      }
+      if (trimmedTranscript.length > MAX_TRANSCRIPT_LENGTH) {
+        return NextResponse.json(
+          {
+            error: `音声スクリプトは${MAX_TRANSCRIPT_LENGTH.toLocaleString()}文字以内で入力してください（現在: ${trimmedTranscript.length.toLocaleString()}文字）`,
+          },
+          { status: 400 }
+        );
+      }
     }
 
     // --- 企業の upsert ---
@@ -197,7 +208,8 @@ export async function POST(request: Request) {
           interview_category === "new_grad" ? interview_round : null,
         interview_date: interview_date || null,
         transcript: trimmedTranscript,
-        transcript_char_count: trimmedTranscript.length,
+        transcript_char_count: trimmedTranscript?.length ?? 0,
+        audio_url: isAudioMode ? audio_url : null,
         status: "uploaded",
       } as never);
 

--- a/src/app/api/interviews/upload-audio/route.ts
+++ b/src/app/api/interviews/upload-audio/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { unauthorized, badRequest, serverError } from "@/lib/api/error-response";
+import { reportApiError } from "@/lib/error-reporting";
+
+const ASSEMBLYAI_BASE = "https://api.assemblyai.com/v2";
+const MAX_AUDIO_SIZE = 50 * 1024 * 1024; // 50MB
+const ALLOWED_MIME_TYPES = [
+  "audio/webm",
+  "audio/mp4",
+  "audio/mpeg",
+  "audio/ogg",
+  "audio/wav",
+  "audio/x-wav",
+];
+
+export async function POST(request: Request) {
+  try {
+    // 認証チェック
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorized();
+    }
+
+    const assemblyKey = process.env.ASSEMBLYAI_API_KEY;
+    if (!assemblyKey) {
+      return serverError(
+        "音声処理サービスの設定に問題があります。しばらくしてから再度お試しください。"
+      );
+    }
+
+    // FormData から音声ファイルを取得
+    const formData = await request.formData();
+    const audioFile = formData.get("audio") as File | null;
+
+    if (!audioFile) {
+      return badRequest("音声ファイルが必要です");
+    }
+
+    if (audioFile.size > MAX_AUDIO_SIZE) {
+      return badRequest("音声ファイルは50MB以内にしてください");
+    }
+
+    // MIME タイプチェック（WebM は codecs パラメータ付きの場合もある）
+    const baseMime = audioFile.type.split(";")[0].trim();
+    if (!ALLOWED_MIME_TYPES.includes(baseMime)) {
+      return badRequest(
+        `対応していない音声形式です: ${audioFile.type}。WebM, MP4, MP3, WAV 形式に対応しています。`
+      );
+    }
+
+    // 音声データを取得
+    const audioBuffer = await audioFile.arrayBuffer();
+
+    // AssemblyAI にアップロード
+    const uploadRes = await fetch(`${ASSEMBLYAI_BASE}/upload`, {
+      method: "POST",
+      headers: {
+        authorization: assemblyKey,
+        "content-type": "application/octet-stream",
+      },
+      body: audioBuffer,
+    });
+
+    if (!uploadRes.ok) {
+      throw new Error(
+        `AssemblyAI upload failed: ${uploadRes.status} ${uploadRes.statusText}`
+      );
+    }
+
+    const uploadData = (await uploadRes.json()) as { upload_url: string };
+
+    if (!uploadData.upload_url) {
+      throw new Error("AssemblyAI upload did not return upload_url");
+    }
+
+    // Supabase Storage にもバックアップ保存
+    const ext = baseMime === "audio/webm" ? "webm" : baseMime.split("/")[1];
+    const storagePath = `${user.id}/${Date.now()}.${ext}`;
+
+    await supabase.storage
+      .from("interviews")
+      .upload(storagePath, audioBuffer, {
+        contentType: audioFile.type,
+        upsert: false,
+      });
+
+    return NextResponse.json({
+      audio_url: uploadData.upload_url,
+      storage_path: storagePath,
+    });
+  } catch (error) {
+    reportApiError(error, {
+      apiRoute: "/api/interviews/upload-audio",
+      featureArea: "interview",
+    });
+    return serverError(
+      "音声ファイルのアップロードに失敗しました。しばらくしてから再度お試しください。"
+    );
+  }
+}

--- a/src/app/api/profile/delete/route.ts
+++ b/src/app/api/profile/delete/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { unauthorized, badRequest, serverError } from "@/lib/api/error-response";
+import { reportApiError } from "@/lib/error-reporting";
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorized();
+    }
+
+    // パスワード確認（セキュリティ対策）
+    const body = await request.json();
+    const { password } = body as { password: string };
+
+    if (!password || typeof password !== "string") {
+      return badRequest("パスワードを入力してください");
+    }
+
+    // パスワード検証: 現在のメールアドレスで再ログインを試みる
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: user.email!,
+      password,
+    });
+
+    if (signInError) {
+      return NextResponse.json(
+        { error: "パスワードが正しくありません" },
+        { status: 400 }
+      );
+    }
+
+    // Admin クライアントでユーザーを削除
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !serviceRoleKey) {
+      return serverError(
+        "サーバー設定にエラーがあります。管理者にお問い合わせください。"
+      );
+    }
+
+    const adminClient = createAdminClient(supabaseUrl, serviceRoleKey);
+
+    // ユーザー削除（CASCADE で関連データも削除）
+    const { error: deleteError } = await adminClient.auth.admin.deleteUser(
+      user.id
+    );
+
+    if (deleteError) {
+      throw new Error(`User deletion failed: ${deleteError.message}`);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    reportApiError(error, {
+      apiRoute: "/api/profile/delete",
+      featureArea: "profile",
+    });
+    return serverError(
+      "アカウントの削除に失敗しました。しばらくしてから再度お試しください。"
+    );
+  }
+}

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -81,10 +81,23 @@ export async function POST(request: Request) {
 
     // utterances を transcripts テーブルに一括保存（N+1 回避）
     if (result.utterances && result.utterances.length > 0) {
+      // AssemblyAI の話者ラベル（"A", "B" 等）を interviewer/interviewee にマッピング
+      // 最初に発言した話者を面接官とみなす（面接では面接官が最初に挨拶する）
+      const speakerMap = new Map<string, "interviewer" | "interviewee">();
+      for (const u of result.utterances as { speaker: string }[]) {
+        if (!speakerMap.has(u.speaker)) {
+          speakerMap.set(
+            u.speaker,
+            speakerMap.size === 0 ? "interviewer" : "interviewee"
+          );
+        }
+        if (speakerMap.size >= 2) break;
+      }
+
       const transcripts = result.utterances.map(
-        (u: { speaker: string; text: string; start: number; end: number }, index: number) => ({
+        (u: { speaker: string; text: string; start: number; end: number }) => ({
           interview_id,
-          speaker: index % 2 === 0 ? "interviewer" : "interviewee",
+          speaker: speakerMap.get(u.speaker) ?? "interviewee",
           content: u.text,
           start_time: u.start / 1000,
           end_time: u.end / 1000,

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,0 +1,282 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Mic,
+  FileText,
+  Brain,
+  CreditCard,
+  Shield,
+  HelpCircle,
+  ChevronDown,
+} from "lucide-react";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: "ヘルプ・FAQ",
+  description:
+    "InterviewCoach の使い方やよくある質問をまとめたヘルプページです。",
+  openGraph: {
+    title: "ヘルプ・FAQ | InterviewCoach",
+    description:
+      "InterviewCoach の使い方やよくある質問をまとめたヘルプページです。",
+    url: "https://interviewcoach.jp/help",
+  },
+};
+
+// ============================================================
+// FAQ データ
+// ============================================================
+
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+interface FaqCategory {
+  id: string;
+  title: string;
+  icon: React.ReactNode;
+  items: FaqItem[];
+}
+
+const FAQ_CATEGORIES: FaqCategory[] = [
+  {
+    id: "getting-started",
+    title: "はじめに",
+    icon: <HelpCircle className="h-5 w-5" />,
+    items: [
+      {
+        question: "InterviewCoach とは何ですか？",
+        answer:
+          "InterviewCoach は、AI を活用した面接練習・フィードバックサービスです。面接の録音やテキスト入力から、話し方・内容・構成などを AI が分析し、改善点を具体的にフィードバックします。",
+      },
+      {
+        question: "無料で使えますか？",
+        answer:
+          "はい。Free プランでは月3回まで面接分析をご利用いただけます。より多くの分析が必要な場合は Pro プラン（月額¥980）や Premium プラン（月額¥1,980）をご検討ください。",
+      },
+      {
+        question: "アカウント登録は必要ですか？",
+        answer:
+          "はい。面接の分析結果を保存・管理するためにアカウント登録が必要です。メールアドレスとパスワードで簡単に登録できます。",
+      },
+    ],
+  },
+  {
+    id: "recording",
+    title: "面接の録音・登録",
+    icon: <Mic className="h-5 w-5" />,
+    items: [
+      {
+        question: "面接を録音するにはどうすればいいですか？",
+        answer:
+          "ダッシュボードの「新しい面接を記録」から、マイクボタンをクリックして録音を開始できます。ブラウザのマイク許可が必要です。録音が完了したら「送信」ボタンで分析を開始します。",
+      },
+      {
+        question: "テキストで面接内容を入力することもできますか？",
+        answer:
+          "はい。録音の他に、面接の書き起こしテキストを直接入力して分析することもできます。「テキスト入力」タブに切り替えて、面接内容を貼り付けてください。",
+      },
+      {
+        question: "対応している音声フォーマットは何ですか？",
+        answer:
+          "ブラウザで録音した WebM 形式のほか、MP3、MP4、WAV、OGG に対応しています。ファイルサイズは最大 50MB までです。",
+      },
+      {
+        question: "話者分離（誰が話しているか）は自動で判別されますか？",
+        answer:
+          "はい。音声から AI が自動的に面接官と受験者の発言を分離します。最初に話し始めた方が面接官として認識されます。",
+      },
+    ],
+  },
+  {
+    id: "analysis",
+    title: "AI 分析・フィードバック",
+    icon: <Brain className="h-5 w-5" />,
+    items: [
+      {
+        question: "分析にはどのくらい時間がかかりますか？",
+        answer:
+          "音声の場合は文字起こしに約1〜3分、AI 分析に約1〜2分かかります。テキスト入力の場合は AI 分析のみのため、約1〜2分で完了します。処理中はページを閉じても問題ありません。",
+      },
+      {
+        question: "どのような項目が分析されますか？",
+        answer:
+          "回答の論理性・具体性・簡潔さ、STAR法の活用度、フィラー（えーと、あの等）の頻度、話の構成力など多角的に分析します。総合スコアと各項目の改善アドバイスが提供されます。",
+      },
+      {
+        question: "フィラー分析とは何ですか？",
+        answer:
+          "「えーと」「あの」「まあ」などの言い淀み（フィラー）の出現回数と割合を分析する機能です。面接ではフィラーが多いと自信がなく聞こえることがあるため、改善の参考にしてください。",
+      },
+      {
+        question: "過去の分析結果を比較できますか？",
+        answer:
+          "はい。ダッシュボードから2つの面接結果を選んで比較できます。スコアの変化や改善ポイントを視覚的に確認できます。",
+      },
+    ],
+  },
+  {
+    id: "mock-interview",
+    title: "AI 模擬面接",
+    icon: <FileText className="h-5 w-5" />,
+    items: [
+      {
+        question: "AI 模擬面接とはどんな機能ですか？",
+        answer:
+          "AI が面接官役となり、リアルタイムで模擬面接を行います。業界・職種に合わせた質問が出題され、回答後に即座にフィードバックが得られます。",
+      },
+      {
+        question: "模擬面接の質問は業界ごとに異なりますか？",
+        answer:
+          "はい。面接開始前に業界・職種・面接ラウンド・面接官のスタイル（穏やか・厳しい等）を選択でき、それに合わせた質問が生成されます。",
+      },
+    ],
+  },
+  {
+    id: "billing",
+    title: "料金・プラン",
+    icon: <CreditCard className="h-5 w-5" />,
+    items: [
+      {
+        question: "プランの違いは何ですか？",
+        answer:
+          "Free プラン: 月3回の分析（AI Haiku モデル）。Pro プラン（¥980/月）: 月30回の分析（AI Sonnet モデル）。Premium プラン（¥1,980/月）: 無制限の分析（AI Sonnet モデル）。上位プランほど高精度な AI モデルを使用します。",
+      },
+      {
+        question: "プランの変更やキャンセルはできますか？",
+        answer:
+          "はい。「プラン管理」ページからいつでもプランの変更やキャンセルが可能です。キャンセルしても現在の請求期間中はサービスをご利用いただけます。",
+      },
+      {
+        question: "支払い方法は何ですか？",
+        answer:
+          "クレジットカード（Visa、Mastercard、American Express、JCB）でお支払いいただけます。決済は Stripe を利用しており、カード情報は当社サーバーには保存されません。",
+      },
+    ],
+  },
+  {
+    id: "account",
+    title: "アカウント・セキュリティ",
+    icon: <Shield className="h-5 w-5" />,
+    items: [
+      {
+        question: "パスワードを忘れた場合はどうすればいいですか？",
+        answer:
+          "ログイン画面の「パスワードをお忘れですか？」リンクからパスワードリセットが可能です。登録メールアドレスにリセット用のリンクが送信されます。",
+      },
+      {
+        question: "アカウントを削除（退会）するにはどうすればいいですか？",
+        answer:
+          "プロフィールページの最下部にある「アカウント削除」セクションから退会できます。パスワードの確認が必要です。削除すると、すべての面接記録・分析結果・プロフィール情報が完全に削除され、復元できません。",
+      },
+      {
+        question: "データのエクスポートはできますか？",
+        answer:
+          "はい。ダッシュボードの設定からデータのエクスポートが可能です。面接記録と分析結果を JSON 形式でダウンロードできます。",
+      },
+      {
+        question: "面接データのプライバシーは保護されていますか？",
+        answer:
+          "はい。すべてのデータは暗号化されて保存され、ご本人のみアクセス可能です（RLS ポリシーによるアクセス制御）。詳しくはプライバシーポリシーをご覧ください。",
+      },
+    ],
+  },
+];
+
+// ============================================================
+// コンポーネント
+// ============================================================
+
+export default function HelpPage() {
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-8">
+      {/* ヘッダー */}
+      <div className="mb-8 text-center">
+        <h1 className="text-3xl font-bold">ヘルプ・FAQ</h1>
+        <p className="mt-2 text-muted-foreground">
+          InterviewCoach の使い方やよくある質問をまとめています
+        </p>
+      </div>
+
+      {/* カテゴリナビゲーション */}
+      <nav className="mb-8 flex flex-wrap justify-center gap-2">
+        {FAQ_CATEGORIES.map((category) => (
+          <a
+            key={category.id}
+            href={`#${category.id}`}
+            className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            {category.icon}
+            {category.title}
+          </a>
+        ))}
+      </nav>
+
+      {/* FAQ セクション */}
+      <div className="space-y-8">
+        {FAQ_CATEGORIES.map((category) => (
+          <section key={category.id} id={category.id}>
+            <h2 className="mb-4 flex items-center gap-2 text-xl font-semibold">
+              {category.icon}
+              {category.title}
+            </h2>
+            <div className="space-y-3">
+              {category.items.map((item, index) => (
+                <details
+                  key={index}
+                  className="group rounded-lg border bg-card"
+                >
+                  <summary className="flex cursor-pointer items-center justify-between gap-2 p-4 text-sm font-medium [&::-webkit-details-marker]:hidden">
+                    {item.question}
+                    <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+                  </summary>
+                  <div className="border-t px-4 py-3 text-sm leading-relaxed text-muted-foreground">
+                    {item.answer}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      {/* お問い合わせ */}
+      <div className="mt-12 rounded-lg border bg-muted/50 p-6 text-center">
+        <h2 className="text-lg font-semibold">解決しない場合</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          上記で解決しない場合は、お気軽にお問い合わせください。
+        </p>
+        <a
+          href="mailto:support@interviewcoach.jp"
+          className="mt-3 inline-block text-sm font-medium text-primary underline-offset-4 hover:underline"
+        >
+          support@interviewcoach.jp
+        </a>
+      </div>
+
+      {/* フッターリンク */}
+      <div className="mt-8 flex flex-wrap justify-center gap-4 text-sm text-muted-foreground">
+        <Link
+          href="/legal/terms"
+          className="underline-offset-4 hover:text-foreground hover:underline"
+        >
+          利用規約
+        </Link>
+        <Link
+          href="/legal/privacy"
+          className="underline-offset-4 hover:text-foreground hover:underline"
+        >
+          プライバシーポリシー
+        </Link>
+        <Link
+          href="/pricing"
+          className="underline-offset-4 hover:text-foreground hover:underline"
+        >
+          料金プラン
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/interview/[id]/processing/page.tsx
+++ b/src/app/interview/[id]/processing/page.tsx
@@ -95,8 +95,32 @@ export default function ProcessingPage({
   const [isLoading, setIsLoading] = useState(true);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [hasAudio, setHasAudio] = useState<boolean | null>(null);
   const analyzeCalledRef = useRef(false);
+  const transcribeCalledRef = useRef(false);
   const notifiedRef = useRef(false);
+
+  // 文字起こし API を呼び出す関数（音声モード時）
+  const triggerTranscription = useCallback(async () => {
+    if (transcribeCalledRef.current) return;
+    transcribeCalledRef.current = true;
+
+    try {
+      const res = await fetch("/api/transcribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ interview_id: id }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "文字起こしに失敗しました");
+      }
+    } catch (error) {
+      console.error("[processing] transcribe error:", error);
+      transcribeCalledRef.current = false;
+    }
+  }, [id]);
 
   // AI分析 API を呼び出す関数
   const triggerAnalysis = useCallback(async () => {
@@ -142,7 +166,7 @@ export default function ProcessingPage({
         // Supabase RLS ポリシーにより、認証ユーザーは自分の interviews のみ取得可能。
         const { data, error } = await supabase
           .from("interviews")
-          .select("status")
+          .select("status, audio_url")
           .eq("id", id)
           .single();
 
@@ -160,8 +184,15 @@ export default function ProcessingPage({
           return;
         }
 
-        const status = (data as Record<string, unknown>)
-          .status as InterviewStatus;
+        const row = data as Record<string, unknown>;
+        const status = row.status as InterviewStatus;
+        const audioUrl = row.audio_url as string | null;
+
+        // 音声モードかどうかを初回のみ判定
+        if (hasAudio === null) {
+          setHasAudio(!!audioUrl);
+        }
+
         setCurrentStatus(status);
         setIsLoading(false);
 
@@ -191,8 +222,17 @@ export default function ProcessingPage({
           return;
         }
 
-        // uploaded 状態の場合、AI分析を自動開始
-        if (status === "uploaded" && !analyzeCalledRef.current) {
+        // uploaded 状態: 音声モードなら文字起こしから、テキストモードなら直接分析
+        if (status === "uploaded") {
+          if (audioUrl && !transcribeCalledRef.current) {
+            triggerTranscription();
+          } else if (!audioUrl && !analyzeCalledRef.current) {
+            triggerAnalysis();
+          }
+        }
+
+        // analyzing 状態: 文字起こし完了後、分析を開始（音声モードのフロー）
+        if (status === "analyzing" && !analyzeCalledRef.current) {
           triggerAnalysis();
         }
 
@@ -212,13 +252,14 @@ export default function ProcessingPage({
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [id, router, triggerAnalysis]);
+  }, [id, router, triggerAnalysis, triggerTranscription, hasAudio]);
 
   const handleRetry = async () => {
     setIsError(false);
     setErrorMessage(null);
     setIsLoading(true);
     analyzeCalledRef.current = false;
+    transcribeCalledRef.current = false;
 
     try {
       const res = await fetch("/api/interviews/retry", {

--- a/src/app/interview/new/page.tsx
+++ b/src/app/interview/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Upload, FileText, Loader2, X } from "lucide-react";
+import { Upload, FileText, Loader2, X, Mic, Square, Pause, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -17,6 +17,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { createClient } from "@/lib/supabase/client";
 import type { InterviewCategory, InterviewRound } from "@/types/database";
+import { useAudioRecorder } from "@/hooks/use-audio-recorder";
 
 // --- 定数 ---
 const MIN_TRANSCRIPT_LENGTH = 100;
@@ -51,7 +52,19 @@ interface DraftData {
   transcript: string;
 }
 
+/** 録音時間をフォーマット */
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+}
+
+type InputMode = "record" | "text";
+
 export default function NewInterviewPage() {
+  // 入力モード
+  const [inputMode, setInputMode] = useState<InputMode>("record");
+
   // フォーム状態
   const [companyName, setCompanyName] = useState("");
   const [category, setCategory] = useState<InterviewCategory | "">("");
@@ -60,6 +73,10 @@ export default function NewInterviewPage() {
     new Date().toISOString().split("T")[0]
   );
   const [transcript, setTranscript] = useState("");
+
+  // 録音
+  const recorder = useAudioRecorder();
+  const [uploadingAudio, setUploadingAudio] = useState(false);
 
   // 企業名サジェスト
   const [companySuggestions, setCompanySuggestions] = useState<string[]>([]);
@@ -287,14 +304,21 @@ export default function NewInterviewPage() {
       }
     }
 
-    // 音声スクリプト
-    const trimmedTranscript = transcript.trim();
-    if (!trimmedTranscript) {
-      newErrors.transcript = "音声スクリプトを入力してください";
-    } else if (trimmedTranscript.length < MIN_TRANSCRIPT_LENGTH) {
-      newErrors.transcript = `音声スクリプトは${MIN_TRANSCRIPT_LENGTH}文字以上入力してください（現在: ${trimmedTranscript.length}文字）`;
-    } else if (trimmedTranscript.length > MAX_TRANSCRIPT_LENGTH) {
-      newErrors.transcript = `音声スクリプトは${MAX_TRANSCRIPT_LENGTH.toLocaleString()}文字以内で入力してください（現在: ${trimmedTranscript.length.toLocaleString()}文字）`;
+    // 録音モード: 録音データが必要
+    if (inputMode === "record") {
+      if (!recorder.audioBlob) {
+        newErrors.audio = "面接を録音してください";
+      }
+    } else {
+      // テキストモード: 音声スクリプト
+      const trimmedTranscript = transcript.trim();
+      if (!trimmedTranscript) {
+        newErrors.transcript = "音声スクリプトを入力してください";
+      } else if (trimmedTranscript.length < MIN_TRANSCRIPT_LENGTH) {
+        newErrors.transcript = `音声スクリプトは${MIN_TRANSCRIPT_LENGTH}文字以上入力してください（現在: ${trimmedTranscript.length}文字）`;
+      } else if (trimmedTranscript.length > MAX_TRANSCRIPT_LENGTH) {
+        newErrors.transcript = `音声スクリプトは${MAX_TRANSCRIPT_LENGTH.toLocaleString()}文字以内で入力してください（現在: ${trimmedTranscript.length.toLocaleString()}文字）`;
+      }
     }
 
     setErrors(newErrors);
@@ -311,6 +335,31 @@ export default function NewInterviewPage() {
     setErrors({});
 
     try {
+      let audioUrl: string | null = null;
+
+      // 録音モード: 音声をアップロード
+      if (inputMode === "record" && recorder.audioBlob) {
+        setUploadingAudio(true);
+        const formData = new FormData();
+        formData.append("audio", recorder.audioBlob, "recording.webm");
+
+        const uploadRes = await fetch("/api/interviews/upload-audio", {
+          method: "POST",
+          body: formData,
+        });
+
+        const uploadData = await uploadRes.json();
+        setUploadingAudio(false);
+
+        if (!uploadRes.ok) {
+          setErrors({ submit: uploadData.error || "音声のアップロードに失敗しました" });
+          return;
+        }
+
+        audioUrl = uploadData.audio_url;
+      }
+
+      // 面接レコード作成
       const res = await fetch("/api/interviews", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -319,7 +368,8 @@ export default function NewInterviewPage() {
           interview_category: category,
           interview_round: category === "new_grad" ? round || null : null,
           interview_date: interviewDate || null,
-          transcript: transcript.trim(),
+          transcript: inputMode === "text" ? transcript.trim() : null,
+          audio_url: audioUrl,
         }),
       });
 
@@ -333,8 +383,8 @@ export default function NewInterviewPage() {
       // 下書きをクリア
       sessionStorage.removeItem(DRAFT_STORAGE_KEY);
 
-      router.push("/dashboard");
-      router.refresh();
+      // 処理ページへ遷移
+      router.push(`/interview/${data.interview_id}/processing`);
     } catch {
       setErrors({
         submit:
@@ -342,6 +392,7 @@ export default function NewInterviewPage() {
       });
     } finally {
       setSubmitting(false);
+      setUploadingAudio(false);
     }
   };
 
@@ -349,7 +400,7 @@ export default function NewInterviewPage() {
 
   return (
     <div className="container mx-auto max-w-2xl px-4 py-8">
-      <h1 className="mb-6 text-2xl font-bold">面接スクリプト登録</h1>
+      <h1 className="mb-6 text-2xl font-bold">面接を記録する</h1>
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* 送信エラー */}
@@ -506,125 +557,262 @@ export default function NewInterviewPage() {
           )}
         </div>
 
-        {/* 音声スクリプト */}
+        {/* 入力方法選択 */}
         <Card>
           <CardHeader>
             <CardTitle className="text-lg">
-              音声スクリプト <span className="text-destructive">*</span>
+              面接データ <span className="text-destructive">*</span>
             </CardTitle>
+            {/* タブ切替 */}
+            <div className="flex gap-1 rounded-lg bg-muted p-1">
+              <button
+                type="button"
+                onClick={() => setInputMode("record")}
+                className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  inputMode === "record"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <Mic className="h-4 w-4" />
+                録音する
+              </button>
+              <button
+                type="button"
+                onClick={() => setInputMode("text")}
+                className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  inputMode === "text"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <FileText className="h-4 w-4" />
+                テキスト入力
+              </button>
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
-            {/* ファイルアップロードエリア */}
-            <div
-              className={`relative rounded-md border-2 border-dashed p-6 text-center transition-colors ${
-                isDragging
-                  ? "border-primary bg-primary/5"
-                  : "border-muted-foreground/25 hover:border-muted-foreground/50"
-              }`}
-              onDragEnter={handleDragEnter}
-              onDragLeave={handleDragLeave}
-              onDragOver={handleDragOver}
-              onDrop={handleDrop}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".txt"
-                onChange={handleFileChange}
-                className="hidden"
-                aria-label="テキストファイルをアップロード"
-              />
-              <div className="flex flex-col items-center gap-2">
-                <Upload className="h-8 w-8 text-muted-foreground" />
+            {inputMode === "record" ? (
+              /* === 録音モード === */
+              <div className="space-y-4">
                 <p className="text-sm text-muted-foreground">
-                  .txt ファイルをドラッグ&ドロップ、または
+                  面接中にマイクで録音してください。録音後、AIが自動で文字起こし・話者分離を行います。
                 </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <FileText className="mr-2 h-4 w-4" />
-                  ファイルを選択
-                </Button>
-                <p className="text-xs text-muted-foreground">
-                  最大 1MB / UTF-8 テキストファイル
-                </p>
+
+                {/* 録音コントロール */}
+                <div className="flex flex-col items-center gap-4 rounded-lg border bg-muted/30 p-6">
+                  {/* タイマー */}
+                  <div className="text-3xl font-mono font-bold tabular-nums">
+                    {formatTime(recorder.elapsedTime)}
+                  </div>
+
+                  {/* 録音インジケーター */}
+                  {recorder.state === "recording" && (
+                    <div className="flex items-center gap-2 text-sm text-destructive">
+                      <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-destructive" />
+                      録音中...
+                    </div>
+                  )}
+                  {recorder.state === "paused" && (
+                    <div className="text-sm text-amber-600">一時停止中</div>
+                  )}
+
+                  {/* ボタン群 */}
+                  <div className="flex items-center gap-3">
+                    {recorder.state === "idle" || recorder.state === "stopped" ? (
+                      <Button
+                        type="button"
+                        size="lg"
+                        onClick={recorder.start}
+                        className="gap-2"
+                      >
+                        <Mic className="h-5 w-5" />
+                        {recorder.audioBlob ? "録り直す" : "録音開始"}
+                      </Button>
+                    ) : (
+                      <>
+                        {recorder.state === "recording" ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="lg"
+                            onClick={recorder.pause}
+                            className="gap-2"
+                          >
+                            <Pause className="h-5 w-5" />
+                            一時停止
+                          </Button>
+                        ) : (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="lg"
+                            onClick={recorder.resume}
+                            className="gap-2"
+                          >
+                            <Play className="h-5 w-5" />
+                            再開
+                          </Button>
+                        )}
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="lg"
+                          onClick={recorder.stop}
+                          className="gap-2"
+                        >
+                          <Square className="h-4 w-4" />
+                          録音停止
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                {/* 録音完了後のプレビュー */}
+                {recorder.audioBlob && recorder.state === "stopped" && (
+                  <div className="rounded-lg border bg-muted/30 p-4">
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="text-sm font-medium">録音データ</span>
+                      <span className="text-xs text-muted-foreground">
+                        {formatTime(recorder.elapsedTime)} / {(recorder.audioBlob.size / 1024 / 1024).toFixed(1)}MB
+                      </span>
+                    </div>
+                    <audio
+                      controls
+                      src={URL.createObjectURL(recorder.audioBlob)}
+                      className="w-full"
+                    />
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      送信後、AIが自動で文字起こしと話者分離を行います。面接官とあなたの発言を自動で識別し、あなたの発言のみフィラー分析を実施します。
+                    </p>
+                  </div>
+                )}
+
+                {/* 録音エラー */}
+                {recorder.error && (
+                  <p className="text-sm text-destructive">{recorder.error}</p>
+                )}
+                {errors.audio && (
+                  <p className="text-sm text-destructive">{errors.audio}</p>
+                )}
               </div>
-            </div>
-
-            {/* アップロードされたファイル名表示 */}
-            {fileName && (
-              <div className="flex items-center gap-2 rounded-md bg-secondary p-2 text-sm">
-                <FileText className="h-4 w-4" />
-                <span className="flex-1 truncate">{fileName}</span>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setFileName(null);
-                    setTranscript("");
-                  }}
-                  className="rounded-full p-1 hover:bg-accent"
-                  aria-label="ファイルをクリア"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </div>
-            )}
-
-            {/* ファイルエラー */}
-            {errors.file && (
-              <p className="text-sm text-destructive">{errors.file}</p>
-            )}
-
-            {/* テキストエリア */}
-            <div className="space-y-2">
-              <Label htmlFor="transcript">
-                テキストを直接貼り付けることもできます
-              </Label>
-              <Textarea
-                id="transcript"
-                placeholder="音声文字起こし結果をここに貼り付けてください..."
-                value={transcript}
-                onChange={(e) => {
-                  setTranscript(e.target.value);
-                  setFileName(null);
-                  clearError("transcript");
-                }}
-                rows={10}
-                className="min-h-[200px] resize-y"
-                aria-invalid={!!errors.transcript}
-                aria-describedby="transcript-count transcript-error"
-              />
-              <div className="flex items-center justify-between">
-                <p
-                  id="transcript-count"
-                  className={`text-xs ${
-                    transcriptCharCount > MAX_TRANSCRIPT_LENGTH
-                      ? "text-destructive"
-                      : transcriptCharCount > 0 &&
-                          transcriptCharCount < MIN_TRANSCRIPT_LENGTH
-                        ? "text-amber-600"
-                        : "text-muted-foreground"
+            ) : (
+              /* === テキストモード === */
+              <div className="space-y-4">
+                {/* ファイルアップロードエリア */}
+                <div
+                  className={`relative rounded-md border-2 border-dashed p-6 text-center transition-colors ${
+                    isDragging
+                      ? "border-primary bg-primary/5"
+                      : "border-muted-foreground/25 hover:border-muted-foreground/50"
                   }`}
+                  onDragEnter={handleDragEnter}
+                  onDragLeave={handleDragLeave}
+                  onDragOver={handleDragOver}
+                  onDrop={handleDrop}
                 >
-                  {transcriptCharCount.toLocaleString()} /{" "}
-                  {MAX_TRANSCRIPT_LENGTH.toLocaleString()} 文字
-                  {transcriptCharCount > 0 &&
-                    transcriptCharCount < MIN_TRANSCRIPT_LENGTH &&
-                    `（最低${MIN_TRANSCRIPT_LENGTH}文字）`}
-                </p>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".txt"
+                    onChange={handleFileChange}
+                    className="hidden"
+                    aria-label="テキストファイルをアップロード"
+                  />
+                  <div className="flex flex-col items-center gap-2">
+                    <Upload className="h-8 w-8 text-muted-foreground" />
+                    <p className="text-sm text-muted-foreground">
+                      .txt ファイルをドラッグ&ドロップ、または
+                    </p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      <FileText className="mr-2 h-4 w-4" />
+                      ファイルを選択
+                    </Button>
+                    <p className="text-xs text-muted-foreground">
+                      最大 1MB / UTF-8 テキストファイル
+                    </p>
+                  </div>
+                </div>
+
+                {/* アップロードされたファイル名表示 */}
+                {fileName && (
+                  <div className="flex items-center gap-2 rounded-md bg-secondary p-2 text-sm">
+                    <FileText className="h-4 w-4" />
+                    <span className="flex-1 truncate">{fileName}</span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setFileName(null);
+                        setTranscript("");
+                      }}
+                      className="rounded-full p-1 hover:bg-accent"
+                      aria-label="ファイルをクリア"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                )}
+
+                {/* ファイルエラー */}
+                {errors.file && (
+                  <p className="text-sm text-destructive">{errors.file}</p>
+                )}
+
+                {/* テキストエリア */}
+                <div className="space-y-2">
+                  <Label htmlFor="transcript">
+                    テキストを直接貼り付けることもできます
+                  </Label>
+                  <Textarea
+                    id="transcript"
+                    placeholder="音声文字起こし結果をここに貼り付けてください..."
+                    value={transcript}
+                    onChange={(e) => {
+                      setTranscript(e.target.value);
+                      setFileName(null);
+                      clearError("transcript");
+                    }}
+                    rows={10}
+                    className="min-h-[200px] resize-y"
+                    aria-invalid={!!errors.transcript}
+                    aria-describedby="transcript-count transcript-error"
+                  />
+                  <div className="flex items-center justify-between">
+                    <p
+                      id="transcript-count"
+                      className={`text-xs ${
+                        transcriptCharCount > MAX_TRANSCRIPT_LENGTH
+                          ? "text-destructive"
+                          : transcriptCharCount > 0 &&
+                              transcriptCharCount < MIN_TRANSCRIPT_LENGTH
+                            ? "text-amber-600"
+                            : "text-muted-foreground"
+                      }`}
+                    >
+                      {transcriptCharCount.toLocaleString()} /{" "}
+                      {MAX_TRANSCRIPT_LENGTH.toLocaleString()} 文字
+                      {transcriptCharCount > 0 &&
+                        transcriptCharCount < MIN_TRANSCRIPT_LENGTH &&
+                        `（最低${MIN_TRANSCRIPT_LENGTH}文字）`}
+                    </p>
+                  </div>
+                  {errors.transcript && (
+                    <p
+                      id="transcript-error"
+                      className="text-sm text-destructive"
+                    >
+                      {errors.transcript}
+                    </p>
+                  )}
+                </div>
               </div>
-              {errors.transcript && (
-                <p
-                  id="transcript-error"
-                  className="text-sm text-destructive"
-                >
-                  {errors.transcript}
-                </p>
-              )}
-            </div>
+            )}
           </CardContent>
         </Card>
 
@@ -633,13 +821,15 @@ export default function NewInterviewPage() {
           type="submit"
           size="lg"
           className="w-full"
-          disabled={submitting}
+          disabled={submitting || recorder.state === "recording" || recorder.state === "paused"}
         >
           {submitting ? (
             <>
               <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-              保存中...
+              {uploadingAudio ? "音声をアップロード中..." : "保存中..."}
             </>
+          ) : inputMode === "record" ? (
+            "録音データを送信して分析する"
           ) : (
             "登録する"
           )}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -15,7 +15,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, Save, X, CheckCircle, AlertCircle, Bell, BellOff, Clock, CalendarDays } from "lucide-react";
+import { Loader2, Save, X, CheckCircle, AlertCircle, Bell, BellOff, Clock, CalendarDays, Trash2 } from "lucide-react";
 import {
   isNotificationSupported,
   getNotificationPermission,
@@ -144,6 +144,12 @@ export default function ProfilePage() {
   const [reminderFrequency, setReminderFrequency] = useState<ReminderFrequency>("three_per_week");
   const [reminderTime, setReminderTime] = useState("20:00");
   const [reminderDays, setReminderDays] = useState<boolean[]>([false, true, false, true, false, true, false]);
+
+  // アカウント削除
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deletePassword, setDeletePassword] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   // 通知状態・リマインダーの初期化
   useEffect(() => {
@@ -310,6 +316,40 @@ export default function ProfilePage() {
     } finally {
       setSaving(false);
       savingRef.current = false;
+    }
+  };
+
+  // アカウント削除ハンドラー
+  const handleDeleteAccount = async () => {
+    if (!deletePassword.trim()) {
+      setDeleteError("パスワードを入力してください");
+      return;
+    }
+
+    setDeleting(true);
+    setDeleteError(null);
+
+    try {
+      const res = await fetch("/api/profile/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: deletePassword }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setDeleteError(data.error || "アカウントの削除に失敗しました");
+        setDeleting(false);
+        return;
+      }
+
+      // サインアウトしてトップページへリダイレクト
+      const supabase = createClient();
+      await supabase.auth.signOut();
+      router.push("/?deleted=true");
+    } catch {
+      setDeleteError("通信エラーが発生しました。もう一度お試しください。");
+      setDeleting(false);
     }
   };
 
@@ -1143,6 +1183,92 @@ export default function ProfilePage() {
           </Button>
         </div>
       </form>
+
+      {/* ============================================================ */}
+      {/* デンジャーゾーン — アカウント削除 */}
+      {/* ============================================================ */}
+      <Card className="mt-8 border-destructive/50">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive">
+            <Trash2 className="h-5 w-5" />
+            アカウント削除
+          </CardTitle>
+          <CardDescription>
+            アカウントを削除すると、すべてのデータ（面接記録・分析結果・プロフィール）が完全に削除されます。この操作は取り消せません。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!showDeleteConfirm ? (
+            <Button
+              variant="destructive"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              退会する
+            </Button>
+          ) : (
+            <div className="space-y-4">
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+                <p className="text-sm font-medium text-destructive">
+                  本当にアカウントを削除しますか？
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  確認のため、パスワードを入力してください。
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="deletePassword">パスワード</Label>
+                <Input
+                  id="deletePassword"
+                  type="password"
+                  autoComplete="current-password"
+                  value={deletePassword}
+                  onChange={(e) => {
+                    setDeletePassword(e.target.value);
+                    setDeleteError(null);
+                  }}
+                  placeholder="パスワードを入力"
+                  disabled={deleting}
+                />
+              </div>
+
+              {deleteError && (
+                <div className="flex items-center gap-2 text-sm text-destructive">
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  {deleteError}
+                </div>
+              )}
+
+              <div className="flex gap-3">
+                <Button
+                  variant="destructive"
+                  onClick={handleDeleteAccount}
+                  disabled={deleting || !deletePassword.trim()}
+                >
+                  {deleting ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="mr-2 h-4 w-4" />
+                  )}
+                  {deleting ? "削除中..." : "完全に削除する"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setShowDeleteConfirm(false);
+                    setDeletePassword("");
+                    setDeleteError(null);
+                  }}
+                  disabled={deleting}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -31,6 +31,12 @@ export function Footer() {
           >
             {t("footer.tokushoho")}
           </Link>
+          <Link
+            href="/help"
+            className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
+          >
+            {t("footer.help")}
+          </Link>
         </nav>
       </div>
     </footer>

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -246,6 +246,7 @@ export const ja = {
     privacyPolicy: "プライバシーポリシー",
     cookiePolicy: "Cookie ポリシー",
     tokushoho: "特定商取引法に基づく表記",
+    help: "ヘルプ",
   },
 
   // ============================================================

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -216,6 +216,7 @@ const ONBOARDING_BYPASS_PREFIXES = [
   "/update-password",
   "/personality",
   "/questions",
+  "/help",
 ];
 
 const ONBOARDING_REQUIRED_PREFIXES = [


### PR DESCRIPTION
## Summary

- **録音機能**: マイクから直接録音してAI分析できるようになりました。話者分離のバグ修正も含みます
- **アカウント削除**: プロフィールページからパスワード確認付きで退会可能に
- **ヘルプ/FAQ**: 6カテゴリ・20+件のFAQページを `/help` に追加、フッターにリンク追加

## Changes

### 録音機能 (commit 1)
- `interview/new` ページに録音UIを追加（開始/一時停止/再開/停止、タイマー表示、プレビュー再生）
- `/api/interviews/upload-audio` エンドポイント新規作成（AssemblyAI アップロード + Supabase Storage バックアップ）
- 話者分離を `index % 2` から AssemblyAI の実際の話者ラベルに修正
- `/api/interviews` に `audio_url` パラメータ対応追加
- `processing` ページで音声モード（文字起こし→分析）とテキストモード（直接分析）を分岐

### アカウント削除 (commit 2)
- `/api/profile/delete` エンドポイント新規作成（パスワード再検証 + Admin client で CASCADE 削除）
- プロフィールページにデンジャーゾーンUI追加（確認ダイアログ、パスワード入力、エラー表示）

### ヘルプ/FAQ (commit 3)
- `/help` ページ新規作成（はじめに、録音、AI分析、模擬面接、料金、アカウント・セキュリティの6カテゴリ）
- `details/summary` によるアコーディオンUI
- フッターにヘルプリンク追加、middleware にバイパスパス追加

## Test plan
- [ ] 録音ボタンを押してマイクから録音→送信→文字起こし→分析完了まで確認
- [ ] テキスト入力モードでも従来通り分析できること
- [ ] プロフィールページ最下部の「退会する」ボタンでアカウント削除確認ダイアログ表示
- [ ] 正しいパスワードで削除→サインアウト→トップページリダイレクト
- [ ] 間違ったパスワードでエラーメッセージ表示
- [ ] `/help` ページがログインなしでアクセスでき、FAQ アコーディオンが動作すること
- [ ] フッターの「ヘルプ」リンクが正しく機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)